### PR TITLE
feat: https lb backend services dashboard

### DIFF
--- a/dashboards/networking/README.md
+++ b/dashboards/networking/README.md
@@ -1,6 +1,5 @@
 ### Dashboards for Networking
 
-
 |Cloud DNS Monitoring|
 |:-------------------|
 |Filename: [clouddns-monitoring.json](clouddns-monitoring.json)|
@@ -34,6 +33,16 @@
 |Filename: [https-loadbalancer-monitoring.json](https-loadbalancer-monitoring.json)|
 |This dashboard has 9 charts for the related [HTTP/s load balancer metrics](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-loadbalancing), including `Request Count`, `Total Latency`, `Request Bytes`, `Response Bytes`, `Frontend RTT`, `Backend Request Count`, `Backend Request Bytes`, and `Backend Response Bytes`.|
 
+&nbsp;
+
+|HTTP/S Load Balancer Backend Services Monitoring|
+|:-----------------------------------------------|
+|Filename: [https-lb-backend-services-monitoring.json](https-lb-backend-services-monitoring.json)|
+|This dashboard has 10 charts for the related [HTTP/s load balancer metrics](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-loadbalancing),
+including `Backend Request Count by Code Class`, `Backend Request Count by Path`, `Error Rate`, `Error Count by Path and Code`, `Backend Latency`, `Backend P50 Latency by Path`, `Backend Request Bytes`, `Backend Request Bytes by Path`,
+`Backend Response Bytes` and `Backend Response Bytes by Path` all grouped by
+`backend_target_name`. It is intended to be used with a dashboard-wide filter on
+`backend_target_name`.
 
 &nbsp;
 
@@ -48,7 +57,6 @@
 |:-----------------------------------|
 |Filename: [network-udp-loadbalancer-monitoring.json](network-udp-loadbalancer-monitoring.json)|
 |This dashboard has 4 charts for the related [network UDP load balancer metrics](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-loadbalancing), including `Ingress UDP packets`, `Ingress UDP bytes`, `Egress UDP packets`, and `Egress UDP bytes`.|
-
 
 &nbsp;
 

--- a/dashboards/networking/https-lb-backend-services-monitoring.json
+++ b/dashboards/networking/https-lb-backend-services-monitoring.json
@@ -1,0 +1,353 @@
+{
+  "displayName": "HTTP/S LB Backend Services",
+  "gridLayout": {
+    "columns": "2",
+    "widgets": [
+      {
+        "title": "Backend Request Count by Code Class",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "groupByFields": [
+                      "resource.label.\"url_map_name\"",
+                      "resource.label.\"backend_target_name\"",
+                      "metric.label.\"response_code_class\""
+                    ],
+                    "perSeriesAligner": "ALIGN_RATE"
+                  },
+                  "filter": "metric.type=\"loadbalancing.googleapis.com/https/backend_request_count\" resource.type=\"https_lb_rule\"",
+                  "secondaryAggregation": {}
+                }
+              }
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "Backend Request Count by Path",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "groupByFields": [
+                      "resource.label.\"url_map_name\"",
+                      "resource.label.\"backend_target_name\"",
+                      "resource.label.\"matched_url_path_rule\""
+                    ],
+                    "perSeriesAligner": "ALIGN_RATE"
+                  },
+                  "filter": "metric.type=\"loadbalancing.googleapis.com/https/backend_request_count\" resource.type=\"https_lb_rule\"",
+                  "secondaryAggregation": {}
+                },
+                "unitOverride": "1"
+              }
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "Error Rate",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesQueryLanguage": "fetch https_lb_rule::loadbalancing.googleapis.com/https/backend_request_count\n| { t_0:\n      filter metric.response_code_class = 500\n      | align delta()\n      | group_by [resource.backend_target_name],\n          [value_backend_request_count_aggregate:\n             aggregate(value.backend_request_count)]\n  ; t_1:\n      ident\n      | align delta()\n      | group_by [resource.backend_target_name],\n          [value_backend_request_count_aggregate:\n             aggregate(value.backend_request_count)] }\n| outer_join [0]\n| value\n    [t_0_value_backend_request_count_aggregate_div:\n       div(t_0.value_backend_request_count_aggregate,\n         t_1.value_backend_request_count_aggregate)]"
+              }
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "Error Count by Path and Code",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesQueryLanguage": "fetch https_lb_rule::loadbalancing.googleapis.com/https/backend_request_count\n| filter metric.response_code_class = 500\n| align delta()\n| group_by\n    [resource.matched_url_path_rule, resource.backend_target_name,\n     metric.response_code],\n    [value_backend_request_count_aggregate:\n       aggregate(value.backend_request_count)]"
+              }
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "Backend Latency",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "crossSeriesReducer": "REDUCE_PERCENTILE_95",
+                    "groupByFields": [
+                      "resource.label.\"url_map_name\"",
+                      "resource.label.\"backend_target_name\""
+                    ],
+                    "perSeriesAligner": "ALIGN_DELTA"
+                  },
+                  "filter": "metric.type=\"loadbalancing.googleapis.com/https/backend_latencies\" resource.type=\"https_lb_rule\"",
+                  "secondaryAggregation": {}
+                },
+                "unitOverride": "ms"
+              }
+            },
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "crossSeriesReducer": "REDUCE_PERCENTILE_05",
+                    "perSeriesAligner": "ALIGN_DELTA"
+                  },
+                  "filter": "metric.type=\"loadbalancing.googleapis.com/https/backend_latencies\" resource.type=\"https_lb_rule\"",
+                  "secondaryAggregation": {}
+                },
+                "unitOverride": "ms"
+              }
+            },
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "crossSeriesReducer": "REDUCE_PERCENTILE_50",
+                    "perSeriesAligner": "ALIGN_DELTA"
+                  },
+                  "filter": "metric.type=\"loadbalancing.googleapis.com/https/backend_latencies\" resource.type=\"https_lb_rule\"",
+                  "secondaryAggregation": {}
+                },
+                "unitOverride": "ms"
+              }
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "Backend P50 Latency by Path",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "crossSeriesReducer": "REDUCE_PERCENTILE_50",
+                    "groupByFields": [
+                      "resource.label.\"url_map_name\"",
+                      "resource.label.\"backend_target_name\"",
+                      "resource.label.\"matched_url_path_rule\""
+                    ],
+                    "perSeriesAligner": "ALIGN_DELTA"
+                  },
+                  "filter": "metric.type=\"loadbalancing.googleapis.com/https/backend_latencies\" resource.type=\"https_lb_rule\"",
+                  "secondaryAggregation": {}
+                }
+              }
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "Backend Request Bytes",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "groupByFields": [
+                      "resource.label.\"url_map_name\"",
+                      "resource.label.\"backend_target_name\""
+                    ],
+                    "perSeriesAligner": "ALIGN_RATE"
+                  },
+                  "filter": "metric.type=\"loadbalancing.googleapis.com/https/backend_request_bytes_count\" resource.type=\"https_lb_rule\"",
+                  "secondaryAggregation": {}
+                },
+                "unitOverride": "By"
+              }
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "Backend Request Bytes by Path",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "groupByFields": [
+                      "resource.label.\"url_map_name\"",
+                      "resource.label.\"backend_target_name\"",
+                      "resource.label.\"matched_url_path_rule\""
+                    ],
+                    "perSeriesAligner": "ALIGN_RATE"
+                  },
+                  "filter": "metric.type=\"loadbalancing.googleapis.com/https/backend_request_bytes_count\" resource.type=\"https_lb_rule\"",
+                  "secondaryAggregation": {}
+                }
+              }
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "Backend Response Bytes",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "groupByFields": [
+                      "resource.label.\"url_map_name\"",
+                      "resource.label.\"backend_target_name\""
+                    ],
+                    "perSeriesAligner": "ALIGN_RATE"
+                  },
+                  "filter": "metric.type=\"loadbalancing.googleapis.com/https/backend_response_bytes_count\" resource.type=\"https_lb_rule\"",
+                  "secondaryAggregation": {}
+                },
+                "unitOverride": "By"
+              }
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "Backend Response Bytes by Path",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "groupByFields": [
+                      "resource.label.\"url_map_name\"",
+                      "resource.label.\"backend_target_name\"",
+                      "resource.label.\"matched_url_path_rule\""
+                    ],
+                    "perSeriesAligner": "ALIGN_RATE"
+                  },
+                  "filter": "metric.type=\"loadbalancing.googleapis.com/https/backend_response_bytes_count\" resource.type=\"https_lb_rule\"",
+                  "secondaryAggregation": {}
+                }
+              }
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Firstly, thanks for this great repo.

This is looking to fill in a gap in sample dashboards, namely for HTTPS LB backend services in particular. It provides many similar charts to the ones from the HTTPS LB dashboard, but tailored for per-service viewing, in general by grouping all charts by `backend_target_name` and then duplicating charts to have a `by path` counterpart.

Please import this dashboard, give it a try and provide feedback. Thanks!