### PR TITLE
Export / Import script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,28 @@ This repository contains samples that may be used with the [Cloud Monitoring Das
 ## How to use the samples
 
 1. Check it out from GitHub. For example, you can do it in Cloud Shell by clicking the button below:
-    
+
     [![Open this project in Cloud
 Shell](http://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples.git)
 
-1. Use the [gcloud monitoring dashboards create](https://cloud.google.com/sdk/gcloud/reference/monitoring/dashboards/create) command to create a dashboard.  Make sure you replace the __[file-name.json]__ in the command:
+1. Use these commands to import the dashboard.
+
+    First, set your environment variables, replacing the following values with your values:
+
+    *  PROJECT_ID you wish to import the dashboard to
+    *  FILE_NAME with the input filename for the dashboard JSON config
 
 ```bash
-gcloud monitoring dashboards create --config-from-file=[file_name.json]
+export PROJECT_ID=<PROJECT_ID>
+
+export FILE_NAME=<DASH_FILE_NAME>
+```
+
+1. Use the provided [script](scripts/dashboard/dashboard.sh) to create a dashboard.
+
+```bash
+scripts/dashboard/dashboard.sh import \
+    $PROJECT_ID $FILE_NAME
 ```
 
 Alternatively, you can run the following command via curl. Use the [projects.dashboards.create](https://cloud.google.com/monitoring/api/ref_v3/rest/v1/projects.dashboards/create) to call the Dashboards API with the sample JSON and create a new dashboard.
@@ -30,7 +44,7 @@ https://monitoring.googleapis.com/v1/projects/[project-id]/dashboards -d @[file-
 If you want to export a dashboard to a JSON file and share it, you can use the following steps.
 
 1. Create the dashboard in the Monitoring UI (or even better, share one that you’ve already developed and used).
- 
+
 1. Open the dashboard and copy the dashboard ID from the URL (the string is in the URL after the /monitoring/dashboards/custom/ ˆprefix). For example, __10768789961894600977__ is the dashboard ID in the URL below:
 
     https://console.cloud.google.com/monitoring/dashboards/custom/10768789961894600977?project=sd-uxr-001&timeDomain=1h
@@ -41,14 +55,13 @@ If you want to export a dashboard to a JSON file and share it, you can use the f
     First, set your environment variables, replacing the following values with your values:
 
     *  DASH_ID with the dashboard ID copied from step #2
-    *  YOUR_PROJECT_ID with your project id that contains the dashboard
-    *  FILE_NAME with the output filename for the dashboard JSON config 
+    *  PROJECT_ID with your project id that contains the dashboard
+    *  FILE_NAME with the output filename for the dashboard JSON config
 
     ```bash
     export DASH_ID=<YOUR_DASH_ID>
 
-    export PROJECT_NUMBER=$(gcloud projects describe <YOUR_PROJECT_ID> 
-        --format="value(projectNumber)")
+    export PROJECT_ID=<PROJECT_ID>
 
     export FILE_NAME=<DASH_FILE_NAME>
     ```
@@ -56,20 +69,6 @@ If you want to export a dashboard to a JSON file and share it, you can use the f
 1. Use the gcloud command line to export the dashboard to a JSON file.
 
     ```bash
-    gcloud monitoring dashboards describe \
-    projects/$PROJECT_NUMBER/dashboards/$DASH_ID --format=json > $FILE_NAME   
-    ```
-
-1. Open the exported JSON file in an editor and remove the etag / name fields. Alternatively, you can use the `sed` command on a Linux or MAC terminal, for example:
-
-    ```bash
-    sed -i '/"name":/d' $FILE_NAME
-    sed -i '/"etag":/d' $FILE_NAME
-    ```
-
-    MAC version of the sed commands. Note the '' addition.
-
-    ```bash
-    sed -i '' '/"etag":/d' $FILE_NAME
-    sed -i '' '/"name":/d' $FILE_NAME
+    scripts/dashboard/dashboard.sh export \
+        $DASH_ID $PROJECT_ID $FILE_NAME
     ```

--- a/scripts/dashboard/Makefile
+++ b/scripts/dashboard/Makefile
@@ -1,0 +1,3 @@
+.PHONY: shellcheck
+shellcheck:
+	shellcheck dashboard.sh

--- a/scripts/dashboard/README.md
+++ b/scripts/dashboard/README.md
@@ -1,0 +1,47 @@
+# Dashboard Export / Import
+
+The script `dashbaord.sh` is a bash utility for exporting and
+importing Google Cloud Monitoring dashboard.
+
+## Required utilities
+
+- [Gcloud SKD](https://cloud.google.com/sdk/docs/install)
+- [jq](https://stedolan.github.io/jq/)
+
+## Usage
+
+### Export Dashboard
+
+Export a dashboard to a json file
+
+Args:
+- action: export
+- dashboard_id
+- project
+- output file
+
+```
+./dashboard.sh export 11449921252968550000 test-project kpi.json
+```
+
+### Import Dashboard
+
+Import a dashboard from a json file
+
+Args:
+- action: import
+- project_id
+- input_file
+
+```
+./dashboard.sh import agent-analysis kpa.json
+```
+
+## Developing
+
+Required utilities
+- [shellcheck](https://www.shellcheck.net/)
+- [make](https://www.gnu.org/software/make/)
+
+A Makefile is provided. After making changes, run `make` to
+perform sanity checks.

--- a/scripts/dashboard/dashboard.sh
+++ b/scripts/dashboard/dashboard.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -eE
+
+ACTION=${1:?"action [import | export ] is required as argument \$1"}
+
+dashboard_export () {
+    # action is $1
+    dashboard_id=${2:?"dashboard id is required as argument \$2"}
+    project_id=${3:?"project id is required as argument \$3"}
+    output_file=${4:?"output file name is requred as argument \$4"}
+
+    project_number=$(gcloud projects describe "${project_id}" --format="value(projectNumber)")
+
+    echo "Exporting dashboard \"$dashboard_id\" from project \"$project_id\" to file \"${output_file}\""
+
+    gcloud monitoring dashboards describe \
+        "projects/${project_number}/dashboards/${dashboard_id}" \
+        --format=json | jq  'del(.name, .etag)' \
+        > "${output_file}"
+
+    echo "Export finished"
+}
+
+dashboard_import () {
+    # action is $1
+    project_id=${2:?"project id is required as argument \$2"}
+    input_file=${3:?"input file is requred as argument \$3"}
+
+    gcloud --project "${project_id}" \
+        monitoring dashboards create \
+        --config-from-file "${input_file}"
+}
+
+if [ "$ACTION" = "export" ]; then
+    dashboard_export "$@"
+elif [ "$ACTION" = "import" ]; then
+    dashboard_import "$@"
+else
+    echo "unknown action: ${ACTION}"
+    exit 1
+fi


### PR DESCRIPTION
Instead of using gcloud and sed to handle exporting and importing dashboard, I have written a script that will handle
1. exporting the dashboard
2. preparing the dashboard json configuration to be importable (removing fields `name` and `etag`
3. importing previously exported dashboards

- Added export / import script `scripts/dashboard/dashboard.sh`
- Added readme for export / import script `scripts/dashboard/README.md`
- Updated primary README.md to leverage the new script