### PR TITLE
Add Initial Azure Virtual Machine Dashboards

### DIFF
--- a/dashboards/azure-virtual-machine/README.md
+++ b/dashboards/azure-virtual-machine/README.md
@@ -1,0 +1,17 @@
+### Dashboards for Azure Virtual Machines
+
+Note: These dashboards are built using [BindPlane](https://docs.bindplane.bluemedora.com/docs/getting-started)
+
+|Azure Virtual Machines - OS Metrics|
+|:------------------|
+|Filename: [os.json](os.json)|
+|This dashboard has 13 charts for the related [BindPlate metrics for Azure Virtual Machines](https://docs.bindplane.bluemedora.com/docs/microsoft-azure-virtualmachines) that focus on , including `Disk Queue Depth`, `Disk Read/Write Data`, `Disk Read/Write Operations`, `CPU Utilization`, and `Network In/Out`.|
+
+&nbsp;
+
+|Azure Virtual Machines Overview|
+|:-----------------------|
+|Filename: [overview.json](overview.json)|
+|This dashboard has 7 widgets for the related [BindPlate metrics for Azure Virtual Machines](https://docs.bindplane.bluemedora.com/docs/microsoft-azure-virtualmachines), including `CPU Credits Consumed`, `CPU Credits Remaining`, `Network Received`, `Disk Read/Writes`, `CPU Utilization`, and `Network Sent`.|
+
+&nbsp;

--- a/dashboards/azure-virtual-machine/README.md
+++ b/dashboards/azure-virtual-machine/README.md
@@ -13,5 +13,3 @@ Note: These dashboards are built using [BindPlane](https://docs.bindplane.blueme
 |:-----------------------|
 |Filename: [overview.json](overview.json)|
 |This dashboard has 7 widgets for the related [BindPlate metrics for Azure Virtual Machines](https://docs.bindplane.bluemedora.com/docs/microsoft-azure-virtualmachines), including `CPU Credits Consumed`, `CPU Credits Remaining`, `Network Received`, `Disk Read/Writes`, `CPU Utilization`, and `Network Sent`.|
-
-&nbsp;

--- a/dashboards/azure-virtual-machine/os.json
+++ b/dashboards/azure-virtual-machine/os.json
@@ -1,0 +1,280 @@
+{
+    "displayName": "Azure Virtual Machines - OS Metrics",
+    "mosaicLayout": {
+        "columns": 12,
+        "tiles": [
+            {
+                "height": 3,
+                "widget": {
+                    "title": "OS Disk Queue Depth",
+                    "xyChart": {
+                        "chartOptions": {
+                            "mode": "COLOR"
+                        },
+                        "dataSets": [
+                            {
+                                "minAlignmentPeriod": "60s",
+                                "plotType": "LINE",
+                                "timeSeriesQuery": {
+                                    "timeSeriesFilter": {
+                                        "aggregation": {
+                                            "perSeriesAligner": "ALIGN_MEAN"
+                                        },
+                                        "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_virtualmachines/virtual_machine/disk/os_queue_depth\" resource.type=\"generic_node\""
+                                    }
+                                }
+                            }
+                        ],
+                        "timeshiftDuration": "0s",
+                        "yAxis": {
+                            "label": "y1Axis",
+                            "scale": "LINEAR"
+                        }
+                    }
+                },
+                "width": 12,
+                "yPos": 8
+            },
+            {
+                "height": 3,
+                "widget": {
+                    "title": "OS Disk Read Data",
+                    "xyChart": {
+                        "chartOptions": {
+                            "mode": "COLOR"
+                        },
+                        "dataSets": [
+                            {
+                                "minAlignmentPeriod": "60s",
+                                "plotType": "LINE",
+                                "timeSeriesQuery": {
+                                    "timeSeriesFilter": {
+                                        "aggregation": {
+                                            "perSeriesAligner": "ALIGN_RATE"
+                                        },
+                                        "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_virtualmachines/virtual_machine/disk/os_read_data\" resource.type=\"generic_node\"",
+                                        "secondaryAggregation": {
+                                            "perSeriesAligner": "ALIGN_MEAN"
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "timeshiftDuration": "0s",
+                        "yAxis": {
+                            "label": "y1Axis",
+                            "scale": "LINEAR"
+                        }
+                    }
+                },
+                "width": 6,
+                "yPos": 11
+            },
+            {
+                "height": 3,
+                "widget": {
+                    "title": "OS Disk Read Operations",
+                    "xyChart": {
+                        "chartOptions": {
+                            "mode": "COLOR"
+                        },
+                        "dataSets": [
+                            {
+                                "minAlignmentPeriod": "60s",
+                                "plotType": "STACKED_AREA",
+                                "timeSeriesQuery": {
+                                    "timeSeriesFilter": {
+                                        "aggregation": {
+                                            "perSeriesAligner": "ALIGN_RATE"
+                                        },
+                                        "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_virtualmachines/virtual_machine/disk/os_read_operations\" resource.type=\"generic_node\"",
+                                        "secondaryAggregation": {
+                                            "perSeriesAligner": "ALIGN_MEAN"
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "timeshiftDuration": "0s",
+                        "yAxis": {
+                            "label": "y1Axis",
+                            "scale": "LINEAR"
+                        }
+                    }
+                },
+                "width": 6,
+                "xPos": 6,
+                "yPos": 11
+            },
+            {
+                "height": 3,
+                "widget": {
+                    "title": "OS Disk Write Data",
+                    "xyChart": {
+                        "chartOptions": {
+                            "mode": "COLOR"
+                        },
+                        "dataSets": [
+                            {
+                                "minAlignmentPeriod": "60s",
+                                "plotType": "STACKED_BAR",
+                                "timeSeriesQuery": {
+                                    "timeSeriesFilter": {
+                                        "aggregation": {
+                                            "perSeriesAligner": "ALIGN_RATE"
+                                        },
+                                        "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_virtualmachines/virtual_machine/disk/os_write_data\" resource.type=\"generic_node\"",
+                                        "secondaryAggregation": {
+                                            "perSeriesAligner": "ALIGN_MEAN"
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "timeshiftDuration": "0s",
+                        "yAxis": {
+                            "label": "y1Axis",
+                            "scale": "LINEAR"
+                        }
+                    }
+                },
+                "width": 12,
+                "yPos": 14
+            },
+            {
+                "height": 3,
+                "widget": {
+                    "title": "OS Disk Write Operations",
+                    "xyChart": {
+                        "chartOptions": {
+                            "mode": "COLOR"
+                        },
+                        "dataSets": [
+                            {
+                                "minAlignmentPeriod": "60s",
+                                "plotType": "STACKED_BAR",
+                                "timeSeriesQuery": {
+                                    "timeSeriesFilter": {
+                                        "aggregation": {
+                                            "perSeriesAligner": "ALIGN_RATE"
+                                        },
+                                        "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_virtualmachines/virtual_machine/disk/os_write_operations\"",
+                                        "secondaryAggregation": {
+                                            "perSeriesAligner": "ALIGN_MEAN"
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "timeshiftDuration": "0s",
+                        "yAxis": {
+                            "label": "y1Axis",
+                            "scale": "LINEAR"
+                        }
+                    }
+                },
+                "width": 12,
+                "yPos": 17
+            },
+            {
+                "height": 4,
+                "widget": {
+                    "title": "Azure VM - CPU Utilization",
+                    "xyChart": {
+                        "chartOptions": {
+                            "mode": "COLOR"
+                        },
+                        "dataSets": [
+                            {
+                                "minAlignmentPeriod": "60s",
+                                "plotType": "LINE",
+                                "timeSeriesQuery": {
+                                    "timeSeriesFilter": {
+                                        "aggregation": {
+                                            "perSeriesAligner": "ALIGN_MEAN"
+                                        },
+                                        "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_virtualmachines/virtual_machine/cpu/utilization\" resource.type=\"generic_node\"",
+                                        "secondaryAggregation": {}
+                                    }
+                                }
+                            }
+                        ],
+                        "timeshiftDuration": "0s",
+                        "yAxis": {
+                            "label": "y1Axis",
+                            "scale": "LINEAR"
+                        }
+                    }
+                },
+                "width": 12
+            },
+            {
+                "height": 4,
+                "widget": {
+                    "title": "Azure VM - Network Received ",
+                    "xyChart": {
+                        "chartOptions": {
+                            "mode": "COLOR"
+                        },
+                        "dataSets": [
+                            {
+                                "minAlignmentPeriod": "60s",
+                                "plotType": "LINE",
+                                "timeSeriesQuery": {
+                                    "timeSeriesFilter": {
+                                        "aggregation": {
+                                            "perSeriesAligner": "ALIGN_MEAN"
+                                        },
+                                        "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_virtualmachines/virtual_machine/network/received_data\" resource.type=\"generic_node\"",
+                                        "secondaryAggregation": {}
+                                    }
+                                }
+                            }
+                        ],
+                        "timeshiftDuration": "0s",
+                        "yAxis": {
+                            "label": "y1Axis",
+                            "scale": "LINEAR"
+                        }
+                    }
+                },
+                "width": 6,
+                "yPos": 4
+            },
+            {
+                "height": 4,
+                "widget": {
+                    "title": "Azure VM - Network Sent",
+                    "xyChart": {
+                        "chartOptions": {
+                            "mode": "COLOR"
+                        },
+                        "dataSets": [
+                            {
+                                "minAlignmentPeriod": "60s",
+                                "plotType": "LINE",
+                                "timeSeriesQuery": {
+                                    "timeSeriesFilter": {
+                                        "aggregation": {
+                                            "perSeriesAligner": "ALIGN_MEAN"
+                                        },
+                                        "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_virtualmachines/virtual_machine/network/sent_data\" resource.type=\"generic_node\"",
+                                        "secondaryAggregation": {}
+                                    }
+                                }
+                            }
+                        ],
+                        "timeshiftDuration": "0s",
+                        "yAxis": {
+                            "label": "y1Axis",
+                            "scale": "LINEAR"
+                        }
+                    }
+                },
+                "width": 6,
+                "xPos": 6,
+                "yPos": 4
+            }
+        ]
+    }
+}

--- a/dashboards/azure-virtual-machine/overview.json
+++ b/dashboards/azure-virtual-machine/overview.json
@@ -1,0 +1,244 @@
+{
+    "displayName": "Azure Virtual Machines Overview",
+    "mosaicLayout": {
+        "columns": 12,
+        "tiles": [
+            {
+                "height": 3,
+                "widget": {
+                    "title": "CPU Credits Consumed",
+                    "xyChart": {
+                        "chartOptions": {
+                            "mode": "COLOR"
+                        },
+                        "dataSets": [
+                            {
+                                "minAlignmentPeriod": "60s",
+                                "plotType": "LINE",
+                                "timeSeriesQuery": {
+                                    "timeSeriesFilter": {
+                                        "aggregation": {
+                                            "perSeriesAligner": "ALIGN_RATE"
+                                        },
+                                        "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_virtualmachines/virtual_machine/cpu/credits_consumed\" resource.type=\"generic_node\"",
+                                        "secondaryAggregation": {
+                                            "perSeriesAligner": "ALIGN_MEAN"
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "timeshiftDuration": "0s",
+                        "yAxis": {
+                            "label": "y1Axis",
+                            "scale": "LINEAR"
+                        }
+                    }
+                },
+                "width": 6,
+                "yPos": 3
+            },
+            {
+                "height": 3,
+                "widget": {
+                    "title": "CPU Credits Remaining",
+                    "xyChart": {
+                        "chartOptions": {
+                            "mode": "COLOR"
+                        },
+                        "dataSets": [
+                            {
+                                "minAlignmentPeriod": "60s",
+                                "plotType": "LINE",
+                                "timeSeriesQuery": {
+                                    "timeSeriesFilter": {
+                                        "aggregation": {
+                                            "perSeriesAligner": "ALIGN_MEAN"
+                                        },
+                                        "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_virtualmachines/virtual_machine/cpu/credits_remaining\" resource.type=\"generic_node\"",
+                                        "secondaryAggregation": {}
+                                    }
+                                }
+                            }
+                        ],
+                        "timeshiftDuration": "0s",
+                        "yAxis": {
+                            "label": "y1Axis",
+                            "scale": "LINEAR"
+                        }
+                    }
+                },
+                "width": 6,
+                "xPos": 6,
+                "yPos": 3
+            },
+            {
+                "height": 3,
+                "widget": {
+                    "title": "Network Received",
+                    "xyChart": {
+                        "chartOptions": {
+                            "mode": "COLOR"
+                        },
+                        "dataSets": [
+                            {
+                                "minAlignmentPeriod": "60s",
+                                "plotType": "STACKED_AREA",
+                                "timeSeriesQuery": {
+                                    "timeSeriesFilter": {
+                                        "aggregation": {
+                                            "perSeriesAligner": "ALIGN_MEAN"
+                                        },
+                                        "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_virtualmachines/virtual_machine/network/received_data\" resource.type=\"generic_node\"",
+                                        "secondaryAggregation": {}
+                                    }
+                                }
+                            }
+                        ],
+                        "timeshiftDuration": "0s",
+                        "yAxis": {
+                            "label": "y1Axis",
+                            "scale": "LINEAR"
+                        }
+                    }
+                },
+                "width": 6,
+                "yPos": 9
+            },
+            {
+                "height": 3,
+                "widget": {
+                    "title": "Disk Read",
+                    "xyChart": {
+                        "chartOptions": {
+                            "mode": "COLOR"
+                        },
+                        "dataSets": [
+                            {
+                                "minAlignmentPeriod": "60s",
+                                "plotType": "STACKED_BAR",
+                                "timeSeriesQuery": {
+                                    "timeSeriesFilter": {
+                                        "aggregation": {
+                                            "perSeriesAligner": "ALIGN_MEAN"
+                                        },
+                                        "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_virtualmachines/virtual_machine/disk/read_data\" resource.type=\"generic_node\"",
+                                        "secondaryAggregation": {}
+                                    }
+                                }
+                            }
+                        ],
+                        "timeshiftDuration": "0s",
+                        "yAxis": {
+                            "label": "y1Axis",
+                            "scale": "LINEAR"
+                        }
+                    }
+                },
+                "width": 6,
+                "yPos": 6
+            },
+            {
+                "height": 3,
+                "widget": {
+                    "title": "Disk Write",
+                    "xyChart": {
+                        "chartOptions": {
+                            "mode": "COLOR"
+                        },
+                        "dataSets": [
+                            {
+                                "minAlignmentPeriod": "60s",
+                                "plotType": "STACKED_BAR",
+                                "timeSeriesQuery": {
+                                    "timeSeriesFilter": {
+                                        "aggregation": {
+                                            "perSeriesAligner": "ALIGN_MEAN"
+                                        },
+                                        "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_virtualmachines/virtual_machine/disk/write_data\" resource.type=\"generic_node\"",
+                                        "secondaryAggregation": {}
+                                    }
+                                }
+                            }
+                        ],
+                        "timeshiftDuration": "0s",
+                        "yAxis": {
+                            "label": "y1Axis",
+                            "scale": "LINEAR"
+                        }
+                    }
+                },
+                "width": 6,
+                "xPos": 6,
+                "yPos": 6
+            },
+            {
+                "height": 3,
+                "widget": {
+                    "scorecard": {
+                        "gaugeView": {
+                            "upperBound": 100
+                        },
+                        "thresholds": [
+                            {
+                                "color": "RED",
+                                "direction": "ABOVE",
+                                "value": 80
+                            },
+                            {
+                                "color": "YELLOW",
+                                "direction": "ABOVE",
+                                "value": 50
+                            }
+                        ],
+                        "timeSeriesQuery": {
+                            "timeSeriesFilter": {
+                                "aggregation": {
+                                    "crossSeriesReducer": "REDUCE_MEAN",
+                                    "perSeriesAligner": "ALIGN_MEAN"
+                                },
+                                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_virtualmachines/virtual_machine/cpu/utilization\" resource.type=\"generic_node\""
+                            }
+                        }
+                    },
+                    "title": "CPU utilization"
+                },
+                "width": 12
+            },
+            {
+                "height": 3,
+                "widget": {
+                    "title": "Network Sent",
+                    "xyChart": {
+                        "chartOptions": {
+                            "mode": "COLOR"
+                        },
+                        "dataSets": [
+                            {
+                                "minAlignmentPeriod": "60s",
+                                "plotType": "STACKED_AREA",
+                                "timeSeriesQuery": {
+                                    "timeSeriesFilter": {
+                                        "aggregation": {
+                                            "perSeriesAligner": "ALIGN_MEAN"
+                                        },
+                                        "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_virtualmachines/virtual_machine/network/sent_data\" resource.type=\"generic_node\"",
+                                        "secondaryAggregation": {}
+                                    }
+                                }
+                            }
+                        ],
+                        "timeshiftDuration": "0s",
+                        "yAxis": {
+                            "label": "y1Axis",
+                            "scale": "LINEAR"
+                        }
+                    }
+                },
+                "width": 6,
+                "xPos": 6,
+                "yPos": 9
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Utilizes metrics from the [Azure Virtual Machine integration from BindPlane](https://docs.bindplane.bluemedora.com/docs/microsoft-azure-virtualmachines).


Included in this PR are the dashboards for OS metrics and also gives an Overview dashboard.

Example Screenshots:
os.json
![image](https://user-images.githubusercontent.com/32067685/107065359-ada05800-67aa-11eb-8cf0-686a14cd5924.png)

overview.json
![image](https://user-images.githubusercontent.com/32067685/107065752-22739200-67ab-11eb-89b6-484cbf17e26f.png)
