### PR TITLE
Initial Azure Container Service Dashboard

### DIFF
--- a/dashboards/azure-container-service/README.md
+++ b/dashboards/azure-container-service/README.md
@@ -1,0 +1,7 @@
+### Dashboards for Azure Container Service
+
+
+|Azure Container Service - Managed Cluster Overview|
+|:------------------------|
+|Filename: [cluster-overview.json](cluster-overview.json)|
+|This dashboard has 12 charts for the related [BindPlane Solution For Azure Container Service](https://docs.bindplane.bluemedora.com/docs/microsoft-azure-containerservice), including `CPU Available`, `Memory Available`, and counts of pods in `failed`, `pending`, `running`, `succeeded`, and `unknown` states.|

--- a/dashboards/azure-container-service/cluster-overview.json
+++ b/dashboards/azure-container-service/cluster-overview.json
@@ -1,0 +1,199 @@
+{
+  "displayName": "Azure Container Service - Managed Cluster Overview",
+  "mosaicLayout": {
+    "columns": 12,
+    "tiles": [
+      {
+        "height": 4,
+        "widget": {
+          "title": "CPU Available",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_containerservice/managed_cluster/cpu/available\" resource.type=\"generic_node\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Memory Available",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MAX"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_containerservice/managed_cluster/memory/available\" resource.type=\"generic_node\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6
+      },
+      {
+        "height": 1,
+        "widget": {
+          "text": {
+            "format": "RAW"
+          },
+          "title": "Pod Count by Status"
+        },
+        "width": 12,
+        "yPos": 4
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_MAX",
+                  "perSeriesAligner": "ALIGN_MAX"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_containerservice/managed_cluster/pod/count\" resource.type=\"generic_node\" metric.label.\"phase\"=\"running\""
+              }
+            }
+          },
+          "title": "Running"
+        },
+        "width": 6,
+        "yPos": 5
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_MAX",
+                  "perSeriesAligner": "ALIGN_MAX"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_containerservice/managed_cluster/pod/count\" resource.type=\"generic_node\" metric.label.\"phase\"=\"pending\""
+              }
+            }
+          },
+          "title": "Pending"
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 7
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_MEAN",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_containerservice/managed_cluster/pod/count\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "Ready"
+        },
+        "width": 6,
+        "yPos": 9
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_MAX",
+                  "perSeriesAligner": "ALIGN_MAX"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_containerservice/managed_cluster/pod/count\" resource.type=\"generic_node\" metric.label.\"phase\"=\"unknown\""
+              }
+            }
+          },
+          "title": "Unknown"
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 9
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_MAX",
+                  "perSeriesAligner": "ALIGN_MAX"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_containerservice/managed_cluster/pod/count\" resource.type=\"generic_node\" metric.label.\"phase\"=\"succeeded\""
+              }
+            }
+          },
+          "title": "Succeeded"
+        },
+        "width": 6,
+        "yPos": 7
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_MAX",
+                  "perSeriesAligner": "ALIGN_MAX"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/microsoft_azure_containerservice/managed_cluster/pod/count\" resource.type=\"generic_node\" metric.label.\"phase\"=\"failed\""
+              }
+            }
+          },
+          "title": "Failed"
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 5
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds an initial dashboard for `Microsoft Azure Container On-Demand Service` using metrics sourced from [BindPlane](https://docs.bindplane.bluemedora.com/docs/getting-started)

For a list of the metrics supported you can find them [here](https://docs.bindplane.bluemedora.com/docs/microsoft-azure-containerservice).

## Screenshots
`cluster-overview.json`
![image](https://user-images.githubusercontent.com/32067685/107554075-70213d80-6ba3-11eb-8fa4-e77d2b27d902.png)
