### PR TITLE
Add Initial Dashboards for GCVE

### DIFF
--- a/dashboards/vmware/README.md
+++ b/dashboards/vmware/README.md
@@ -1,0 +1,16 @@
+### Dashboards for VMware
+
+##### Notes:
+
+- [Bindplane](https://cloud.google.com/stackdriver/blue-medora) needs to be configured for some dashboards.
+- For a detailed list of all the metrics and set up information, you can find documentation [here](https://docs.bindplane.bluemedora.com/docs/vmware-vcenter).
+
+|GCVE Contention|
+|:---------------------|
+|Filename: [contention.json](contention.json)|
+|This dashboard has a variety of widgets and graphs that are split up into the sections for cluster, hosts and virtual machines to help identify resource allocation and distribution. Including such metrics as `Available Memory`, `Cpu Usage`, `Memory Utilization` etc.|
+
+|GCVE Overview|
+|:----------------------|
+|Filename: [overview.json](overview.json)|
+| This dashboard includes several widgets focusing on getting a quick glance summary of a single cluster being monitored. This includes metrics like `Running VMs`, `Total VMs`, `CPU Utilization`, and `Network Throughput Bytes` etc. |

--- a/dashboards/vmware/contention.json
+++ b/dashboards/vmware/contention.json
@@ -1,0 +1,552 @@
+{
+  "displayName": "GCVE Contention",
+  "mosaicLayout": {
+    "columns": 12,
+    "tiles": [
+      {
+        "height": 3,
+        "widget": {
+          "title": "Available CPU in Mhz",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/cluster/cpu/available\" resource.type=\"generic_node\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 1
+      },
+      {
+        "height": 3,
+        "widget": {
+          "title": "Available Memory",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/cluster/memory/available\" resource.type=\"generic_node\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 1
+      },
+      {
+        "height": 1,
+        "widget": {
+          "text": {
+            "format": "RAW"
+          },
+          "title": "Cluster"
+        },
+        "width": 12
+      },
+      {
+        "height": 1,
+        "widget": {
+          "text": {
+            "format": "RAW"
+          },
+          "title": "Hosts"
+        },
+        "width": 12,
+        "yPos": 4
+      },
+      {
+        "height": 3,
+        "widget": {
+          "title": "CPU Used",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MAX"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/host_system/cpu/used\" resource.type=\"generic_node\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 5
+      },
+      {
+        "height": 3,
+        "widget": {
+          "title": "Memory Used",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MAX"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/host_system/memory/used\" resource.type=\"generic_node\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 5
+      },
+      {
+        "height": 1,
+        "widget": {
+          "text": {
+            "format": "RAW"
+          },
+          "title": "Virtual Machines"
+        },
+        "width": 12,
+        "yPos": 16
+      },
+      {
+        "height": 3,
+        "widget": {
+          "title": "Memory Usage Bytes",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/virtual_machine/memory/usage_bytes\" resource.type=\"generic_node\"",
+                    "secondaryAggregation": {}
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 17
+      },
+      {
+        "height": 3,
+        "widget": {
+          "title": "CPU Usage in Mhz",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MAX"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/virtual_machine/cpu/usage\" resource.type=\"generic_node\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 17
+      },
+      {
+        "height": 3,
+        "widget": {
+          "title": "Disk Usage Bytes",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MAX"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/virtual_machine/disk/usage_bytes\" resource.type=\"generic_node\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 12,
+        "yPos": 26
+      },
+      {
+        "height": 3,
+        "widget": {
+          "title": "Memory Utilization",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_95",
+                      "groupByFields": [
+                        "resource.label.\"node_id\""
+                      ],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/host_system/memory/utilization\" resource.type=\"generic_node\"",
+                    "secondaryAggregation": {}
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 8,
+        "yPos": 11
+      },
+      {
+        "height": 3,
+        "widget": {
+          "scorecard": {
+            "gaugeView": {
+              "upperBound": 100
+            },
+            "timeSeriesQuery": {
+              "timeSeriesQueryLanguage": "fetch generic_node\n| metric\n    'external.googleapis.com/bluemedora/generic_node/vmware_vcenter/host_system/memory/utilization'\n| group_by 1m, [value_utilization_max: max(value.utilization)]\n| every 1m\n| group_by [resource.node_id],\n    [value_utilization_max_max: max(value_utilization_max)]\n| top 1"
+            }
+          },
+          "title": "Peak Memory Utilization"
+        },
+        "width": 4,
+        "xPos": 8,
+        "yPos": 11
+      },
+      {
+        "height": 3,
+        "widget": {
+          "title": "CPU Usage",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/host_system/cpu/usage\" resource.type=\"generic_node\"",
+                    "secondaryAggregation": {}
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 8,
+        "yPos": 8
+      },
+      {
+        "height": 3,
+        "widget": {
+          "scorecard": {
+            "gaugeView": {
+              "upperBound": 100
+            },
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_MEAN",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/host_system/cpu/usage\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "Peak CPU Usage"
+        },
+        "width": 4,
+        "xPos": 8,
+        "yPos": 8
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_SUM",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/virtual_machine/memory/usage_bytes\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "VM Total Memory Used"
+        },
+        "width": 3,
+        "xPos": 3,
+        "yPos": 20
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_MEAN",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/vsphere/hosts/powered_on\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "Powered On Hosts"
+        },
+        "width": 2,
+        "xPos": 8,
+        "yPos": 14
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_MEAN",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/vsphere/hosts/powered_off\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "Powered Off Hosts"
+        },
+        "width": 2,
+        "xPos": 10,
+        "yPos": 14
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_MEAN",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/cluster/memory/available\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "Memory Available In Cluster"
+        },
+        "width": 4,
+        "yPos": 14
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_SUM",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/host_system/memory/used\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "Memory Used By Hosts"
+        },
+        "width": 4,
+        "xPos": 4,
+        "yPos": 14
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_MEAN",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/cluster/memory/available\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "Memory Available in Cluster"
+        },
+        "width": 3,
+        "yPos": 20
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "gaugeView": {
+              "upperBound": 100
+            },
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_MEAN",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/virtual_machine/cpu/used_percent\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "Used CPU Percentage"
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 20
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "CPU Ready",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/virtual_machine/cpu/ready\" resource.type=\"generic_node\"",
+                    "secondaryAggregation": {}
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 12,
+        "yPos": 22
+      }
+    ]
+  }
+}

--- a/dashboards/vmware/overview.json
+++ b/dashboards/vmware/overview.json
@@ -1,0 +1,499 @@
+{
+  "displayName": "GCVE Overview",
+  "mosaicLayout": {
+    "columns": 12,
+    "tiles": [
+      {
+        "height": 3,
+        "widget": {
+          "title": "Memory Utilization",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_BAR",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MAX"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/host_system/memory/utilization\" resource.type=\"generic_node\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 4,
+        "xPos": 4,
+        "yPos": 9
+      },
+      {
+        "height": 1,
+        "widget": {
+          "text": {
+            "format": "RAW"
+          },
+          "title": "DATACENTER"
+        },
+        "width": 12
+      },
+      {
+        "height": 3,
+        "widget": {
+          "title": "Average Host CPU Utilization",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/datacenter/cpu/average_host_utilization\" resource.type=\"generic_node\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 12,
+        "yPos": 5
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_SUM",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/virtual_machine/disk/usage_bytes\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "Total Storage Used"
+        },
+        "width": 3,
+        "yPos": 3
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_SUM",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/virtual_machine/memory/usage_bytes\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "Total Memory Used "
+        },
+        "width": 3,
+        "xPos": 3,
+        "yPos": 3
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "thresholds": [
+              {
+                "color": "RED",
+                "direction": "ABOVE"
+              }
+            ],
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_MAX",
+                  "perSeriesAligner": "ALIGN_MAX"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/datacenter/hosts\" resource.type=\"generic_node\" metric.label.\"color\"=\"red\""
+              }
+            }
+          },
+          "title": "Red Hosts"
+        },
+        "width": 3,
+        "xPos": 6,
+        "yPos": 3
+      },
+      {
+        "height": 3,
+        "widget": {
+          "title": "CPU Usage %",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/host_system/cpu/usage\" resource.type=\"generic_node\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 4,
+        "yPos": 9
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_SUM",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/datacenter/virtual_machines\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "Running VMs"
+        },
+        "width": 3,
+        "xPos": 9,
+        "yPos": 3
+      },
+      {
+        "height": 3,
+        "widget": {
+          "title": "CPU Utilization Ratio",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/host_system/cpu/utilization_ratio\" resource.type=\"generic_node\"",
+                    "secondaryAggregation": {}
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 4,
+        "xPos": 8,
+        "yPos": 9
+      },
+      {
+        "height": 1,
+        "widget": {
+          "text": {
+            "format": "RAW"
+          },
+          "title": "HOSTS"
+        },
+        "width": 12,
+        "yPos": 8
+      },
+      {
+        "height": 1,
+        "widget": {
+          "text": {
+            "format": "RAW"
+          },
+          "title": "VMs"
+        },
+        "width": 12,
+        "yPos": 12
+      },
+      {
+        "height": 3,
+        "widget": {
+          "title": "CPU Used %",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/virtual_machine/cpu/used_percent\" resource.type=\"generic_node\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 4,
+        "xPos": 8,
+        "yPos": 13
+      },
+      {
+        "height": 3,
+        "widget": {
+          "title": "Memory Used %",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/virtual_machine/memory/used_percent\" resource.type=\"generic_node\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 4,
+        "xPos": 4,
+        "yPos": 13
+      },
+      {
+        "height": 3,
+        "widget": {
+          "title": "Disk Used Bytes",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_BAR",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/virtual_machine/disk/usage_bytes\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 4,
+        "yPos": 13
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_MEAN",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/vsphere/clusters/total\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "Clusters Total"
+        },
+        "width": 3,
+        "yPos": 1
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_MEAN",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/vsphere/datastores/total\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "Datastores Total"
+        },
+        "width": 3,
+        "xPos": 3,
+        "yPos": 1
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_MAX",
+                  "perSeriesAligner": "ALIGN_MAX"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/vsphere/hosts\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "Hosts Total"
+        },
+        "width": 3,
+        "xPos": 6,
+        "yPos": 1
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_MAX",
+                  "perSeriesAligner": "ALIGN_MAX"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/vsphere/virtual_machines/total\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "VMs Total"
+        },
+        "width": 3,
+        "xPos": 9,
+        "yPos": 1
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Memory Used Bytes",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/virtual_machine/memory/usage_bytes\" resource.type=\"generic_node\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 16
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Network Throughput Bytes",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_BAR",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/virtual_machine/network/throughput_bytes\" resource.type=\"generic_node\"",
+                    "secondaryAggregation": {}
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 16
+      }
+    ]
+  }
+}


### PR DESCRIPTION
These are the initial dashboards that were built around GCVE. One was built around trying to monitor contention and the other is a general overview dashboard. 

### Screenshots:
`contention.json`
![image](https://user-images.githubusercontent.com/32067685/107827511-e913c700-6d54-11eb-836f-66cfc8aef2e2.png)
![image](https://user-images.githubusercontent.com/32067685/107827535-f335c580-6d54-11eb-91a7-d62e12ff8637.png)
![image](https://user-images.githubusercontent.com/32067685/107827562-ff218780-6d54-11eb-99b5-7a7be91b3b6d.png)

`overview.json`
![image](https://user-images.githubusercontent.com/32067685/107827600-152f4800-6d55-11eb-8da8-893a2e5182e8.png)
![image](https://user-images.githubusercontent.com/32067685/107827619-20827380-6d55-11eb-8a96-dc771a27f896.png)
