### PR TITLE
Initial Kafka Dashboard

### DIFF
--- a/dashboards/kafka/README.md
+++ b/dashboards/kafka/README.md
@@ -1,0 +1,11 @@
+### Dashboards for Azure Virtual Machines
+
+#### Notes
+
+- These dashboards are built using [BindPlane](https://docs.bindplane.bluemedora.com/docs/getting-started)
+- The full list of metrics supported by BindPlane can be found in the [BindPlane Docs for Apache Kafka](https://docs.bindplane.bluemedora.com/docs/all-metrics-kafka)
+
+|Kafka Overview|
+|:------------------|
+|Filename: [overview.json](overview.json)|
+|This dashboard has 8 charts that give a summary of how the kafka environments are doing by outlining metrics like `Incoming Messages`, `Broker Errors`, `Total Requests`, `Incoming Bytes`, `Network Traffic`, `Memory Utilization`, and `Failed Requests.|

--- a/dashboards/kafka/overview.json
+++ b/dashboards/kafka/overview.json
@@ -1,0 +1,324 @@
+{
+  "displayName": "Kafka Overview",
+  "mosaicLayout": {
+    "columns": 12,
+    "tiles": [
+      {
+        "height": 4,
+        "widget": {
+          "title": "Broker Errors",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch generic_node\n| metric\n    'external.googleapis.com/bluemedora/generic_node/kafka/broker/error_count'\n| align delta(1m)\n| every 1m\n| group_by [], [value_error_count_aggregate: aggregate(value.error_count)]\n| aggregate"
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 12,
+        "yPos": 6
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Memory Utilization",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch generic_node\n| metric\n    'external.googleapis.com/bluemedora/generic_node/kafka/broker/memory/utilization'\n| group_by 1m, [value_utilization_mean: mean(value.utilization)]\n| every 1m\n| group_by [resource.project_id, resource.node_id],\n    [value_utilization_mean_mean: mean(value_utilization_mean)]\n| cast_units '%'"
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 12,
+        "yPos": 14
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Incoming Bytes",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/kafka/broker/incoming_bytes\" resource.type=\"generic_node\"",
+                    "secondaryAggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 12,
+        "yPos": 10
+      },
+      {
+        "height": 1,
+        "widget": {
+          "text": {
+            "format": "RAW"
+          },
+          "title": "Broker Metrics"
+        },
+        "width": 12,
+        "yPos": 2
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_SUM",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/kafka/cluster/producer_count\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "Producers"
+        },
+        "width": 4
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_MEAN",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/kafka/cluster/broker_count\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "Consumers"
+        },
+        "width": 4,
+        "xPos": 4
+      },
+      {
+        "height": 3,
+        "widget": {
+          "title": "Incoming Messages",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/kafka/broker/topics/incoming_message_count\" resource.type=\"generic_node\"",
+                    "secondaryAggregation": {
+                      "crossSeriesReducer": "REDUCE_MEAN",
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 3
+      },
+      {
+        "height": 3,
+        "widget": {
+          "title": "Total Requests",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/kafka/network/request_count\" resource.type=\"generic_node\"",
+                    "secondaryAggregation": {
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 3
+      },
+      {
+        "height": 1,
+        "widget": {
+          "text": {
+            "format": "RAW"
+          },
+          "title": "Topics"
+        },
+        "width": 12,
+        "yPos": 18
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Network Traffic",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/kafka/broker/topics/traffic\" resource.type=\"generic_node\"",
+                    "secondaryAggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 19
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Failed Requests",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "groupByFields": [
+                        "resource.label.\"node_id\""
+                      ],
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/kafka/broker/topics/failed_request_count\" resource.type=\"generic_node\"",
+                    "secondaryAggregation": {
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [
+                        "resource.label.\"node_id\""
+                      ],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 19
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_SUM",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/kafka/cluster/broker_count\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "Brokers"
+        },
+        "width": 4,
+        "xPos": 8
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds a single Kafka dashboard built around [BindPlane Metrics For Apache Kafka](https://docs.bindplane.bluemedora.com/docs/all-metrics-kafka)

Aims to provide an overview of utilization of the Kafka environment.

#### Screenshots 
`overview.json` 

![image](https://user-images.githubusercontent.com/32067685/108545876-59bb6600-72b6-11eb-89e2-65be4afd5821.png)

![image](https://user-images.githubusercontent.com/32067685/108545792-3db7c480-72b6-11eb-999e-2708f825c855.png)
