### PR TITLE
Add Initial Mongo Dashboards

### DIFF
--- a/dashboards/mongodb/README.md
+++ b/dashboards/mongodb/README.md
@@ -1,0 +1,15 @@
+### Dashboards for MongoDB
+
+### Notes
+
+- These metrics are supplied from [BindPlane's agent integration for MongoDB](https://docs.bindplane.bluemedora.com/docs/stackdriver-agent-migration-mongodb)
+- For some metrics, they are written to different monitored resources. The migration guide calls for the collector to be installed on the host of the mongo environment. 
+  - If the host exists in AWS it will be written to the monitored resource `aws_ec2_instance`.
+  - If the host exists in GCP it will be written to `gce_instance` (what is included in these sample dashboards)
+  - If the host is running externally then the monitored resource will be `generic_node`
+- For this reason, there may be some more additional setup and extension to get dashboards working for everyone
+
+|MongoDB Overview|
+|:------------------|
+|Filename: [overview.json](overview.json)|
+|This dashboard has several charts for the related [BindPlane metrics for MongoDB](https://docs.bindplane.bluemedora.com/docs/stackdriver-metrics-mongodb), including metrics like `Indexes`, `Available Connections`, `Active Connections`, `Data Size`,`Memory Usage`, `Number of Objects`, and `Throughput`.|

--- a/dashboards/mongodb/overview.json
+++ b/dashboards/mongodb/overview.json
@@ -1,0 +1,426 @@
+{
+  "displayName": "MongoDB Overview",
+  "mosaicLayout": {
+    "columns": 12,
+    "tiles": [
+      {
+        "height": 4,
+        "widget": {
+          "title": "Throughput",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch generic_node\n| metric\n    'external.googleapis.com/bluemedora/generic_node/mongodb/mongod/network/traffic_count'\n| align delta(1m)\n| every 1m\n| cast_units 'By'"
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 10
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Memory Usage",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch gce_instance\n| metric 'agent.googleapis.com/mongodb/memory_usage'\n| group_by 1m, [value_memory_usage_mean: mean(value.memory_usage)]\n| every 1m\n| cast_units 'MBy'"
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 2
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Cache Misses",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"agent.googleapis.com/mongodb/cache/misses\" resource.type=\"gce_instance\"",
+                    "secondaryAggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 18
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Storage Size",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch gce_instance\n| metric\n    'agent.googleapis.com/mongodb/database/collection/storage_size'\n| group_by 1m, [value_storage_size_mean: mean(value.storage_size)]\n| every 1m\n| cast_units 'By'"
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 6
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Number of Objects",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [
+                        "metric.label.\"database_name\"",
+                        "resource.label.\"project_id\""
+                      ],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"agent.googleapis.com/mongodb/objects\" resource.type=\"gce_instance\"",
+                    "secondaryAggregation": {}
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 10
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Assert Count",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_BAR",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "groupByFields": [
+                        "metric.label.\"type\""
+                      ],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/mongodb/mongod/assert/count\" resource.type=\"generic_node\"",
+                    "secondaryAggregation": {
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [
+                        "metric.label.\"type\""
+                      ],
+                      "perSeriesAligner": "ALIGN_SUM"
+                    }
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 14
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_MEAN",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/mongodb/database/collection/total_indexes\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "Indexes"
+        },
+        "width": 2
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_MEAN",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/mongodb/mongod/connection/available_count\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "Available Connections"
+        },
+        "width": 2,
+        "xPos": 2
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_MEAN",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/mongodb/connections\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "Active Server Connections"
+        },
+        "width": 2,
+        "xPos": 4
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_SUM",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"agent.googleapis.com/mongodb/collections\" resource.type=\"gce_instance\""
+              }
+            }
+          },
+          "title": "Collections"
+        },
+        "width": 2,
+        "xPos": 8
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "crossSeriesReducer": "REDUCE_MEAN",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/mongodb/mongod/tickets\" resource.type=\"generic_node\""
+              }
+            }
+          },
+          "title": "Tickets"
+        },
+        "width": 2,
+        "xPos": 6
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Extents",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [
+                        "metric.label.\"database_name\""
+                      ],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"agent.googleapis.com/mongodb/extents\" resource.type=\"gce_instance\"",
+                    "secondaryAggregation": {}
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 2
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Mongod Operation Count",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_BAR",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "groupByFields": [
+                        "metric.label.\"operation\""
+                      ],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/mongodb/mongod/documents/operation_count\" resource.type=\"generic_node\"",
+                    "secondaryAggregation": {
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [
+                        "metric.label.\"operation\""
+                      ],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    }
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 14
+      },
+      {
+        "height": 2,
+        "widget": {
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "perSeriesAligner": "ALIGN_RATE"
+                },
+                "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/mongodb/mongod/page_faults\" resource.type=\"generic_node\"",
+                "secondaryAggregation": {
+                  "crossSeriesReducer": "REDUCE_SUM",
+                  "perSeriesAligner": "ALIGN_MEAN"
+                }
+              }
+            }
+          },
+          "title": "Page Faults"
+        },
+        "width": 2,
+        "xPos": 10
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Database Data Size",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch gce_instance\n| metric 'agent.googleapis.com/mongodb/data_size'\n| group_by 1m, [value_data_size_mean: mean(value.data_size)]\n| every 1m\n| group_by [metric.database_name],\n    [value_data_size_mean_mean: mean(value_data_size_mean)]\n| cast_units 'By'"
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 6
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds an initial MongoDB dashboard, which is built around the [BindPlane agent integration for MongoDB](https://docs.bindplane.bluemedora.com/docs/stackdriver-agent-migration-mongodb).

### Screenshots
![image](https://user-images.githubusercontent.com/32067685/109036450-9b258a00-7697-11eb-9b6a-15af4b8cdaf4.png)
![image](https://user-images.githubusercontent.com/32067685/109036598-c27c5700-7697-11eb-9523-3b8fd7def6be.png)
