### PR TITLE
Add Initial EC2 Dashboards

### DIFF
--- a/dashboards/amazon-ec2/README.md
+++ b/dashboards/amazon-ec2/README.md
@@ -1,0 +1,12 @@
+### Dashboards for Amazon EC2
+
+
+|EC2 Overview|
+|:------------------|
+|Filename: [overview.json](overview.json)|
+|This dashboard has 6 charts for the related [BindPlane metrics for Amazon EC2](https://docs.bindplane.bluemedora.com/docs/amazon-ec2), including metrics like `Average CPU Balance`, `Average CPU Credit Usage`, `Average CPU Utilization`, `Average Disk Bytes Read`,`Average Network Bytes Read`, `Average Network Bytes Written`, and `Average Disk Bytes Written`.|
+
+|EC2 Failed Status Checks|
+|:------------------|
+|Filename: [failed-status-checks.json](failed-status-checks.json)|
+|This dashboard has 3 charts for the related [BindPlane metrics for Amazon EC2](https://docs.bindplane.bluemedora.com/docs/amazon-ec2), including metrics like `Failed status checks`, `Failed instance status checks`, and `Failed system status checks`.|

--- a/dashboards/amazon-ec2/failed-status-checks.json
+++ b/dashboards/amazon-ec2/failed-status-checks.json
@@ -1,0 +1,113 @@
+{
+  "displayName": "AWS EC2 - Failed Status Checks",
+  "mosaicLayout": {
+    "columns": 12,
+    "tiles": [
+      {
+        "height": 4,
+        "widget": {
+          "title": "Failed instance status checks",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/EC2/StatusCheckFailed_Instance/Sum\" resource.type=\"aws_ec2_instance\"",
+                    "secondaryAggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 4
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Failed status checks",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/EC2/StatusCheckFailed/Sum\" resource.type=\"aws_ec2_instance\"",
+                    "secondaryAggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 12
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Failed system status checks",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/EC2/StatusCheckFailed_System/Sum\" resource.type=\"aws_ec2_instance\"",
+                    "secondaryAggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 4
+      }
+    ]
+  }
+}

--- a/dashboards/amazon-ec2/overview.json
+++ b/dashboards/amazon-ec2/overview.json
@@ -1,0 +1,239 @@
+{
+  "displayName": "AWS EC2 Overview",
+  "mosaicLayout": {
+    "columns": 12,
+    "tiles": [
+      {
+        "height": 4,
+        "widget": {
+          "title": "Average CPU credit balance",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/EC2/CPUCreditBalance/Average\"",
+                    "secondaryAggregation": {}
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Average CPU credit usage",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/EC2/CPUCreditUsage/Average\"",
+                    "secondaryAggregation": {}
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6
+      },
+      {
+        "height": 3,
+        "widget": {
+          "title": "Average CPU utilization",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/EC2/CPUUtilization/Average\"",
+                    "secondaryAggregation": {}
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 12,
+        "yPos": 4
+      },
+      {
+        "height": 3,
+        "widget": {
+          "title": "Average Disk Bytes Read",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/EC2/DiskReadBytes/Average\"",
+                    "secondaryAggregation": {}
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 7
+      },
+      {
+        "height": 3,
+        "widget": {
+          "title": "Average Disk Bytes Written",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/EC2/DiskWriteBytes/Average\"",
+                    "secondaryAggregation": {}
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 7
+      },
+      {
+        "height": 3,
+        "widget": {
+          "title": "Average Network Bytes Read",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_BAR",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/EC2/NetworkIn/Average\"",
+                    "secondaryAggregation": {}
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 12,
+        "yPos": 10
+      },
+      {
+        "height": 3,
+        "widget": {
+          "title": "Average Network Bytes Written",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_BAR",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/EC2/NetworkOut/Average\"",
+                    "secondaryAggregation": {}
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 12,
+        "yPos": 13
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds two dashboards built around the [BindPlane namespaced metrics for EC2](https://docs.bindplane.bluemedora.com/docs/amazon-ec2)

#### Screenshots
`failed-status-checks.json` 
![image](https://user-images.githubusercontent.com/32067685/109183756-4861d600-775c-11eb-84fc-82bfc5b6f8e7.png)

`overview.json`
![image](https://user-images.githubusercontent.com/32067685/109183965-7b0bce80-775c-11eb-8493-88f9d805fb85.png)
![image](https://user-images.githubusercontent.com/32067685/109183992-83640980-775c-11eb-8f28-d8918c49abad.png)
![image](https://user-images.githubusercontent.com/32067685/109184038-8eb73500-775c-11eb-9d4a-3b7707ae9691.png)
