### PR TITLE
GCVE Virtual Machine Performance Dashboard

### DIFF
--- a/dashboards/vmware/README.md
+++ b/dashboards/vmware/README.md
@@ -14,3 +14,9 @@
 |:----------------------|
 |Filename: [overview.json](overview.json)|
 | This dashboard includes several widgets focusing on getting a quick glance summary of a single cluster being monitored. This includes metrics like `Running VMs`, `Total VMs`, `CPU Utilization`, and `Network Throughput Bytes` etc. |
+
+
+|GCVE Virtual Machine Performance|
+|:----------------------|
+|Filename: [virtual-machine-performance.json](virtual-machine-performance.json)|
+| This sample dashboard focuses specifically on virtual machine metrics. Allowing users to filter via instance name to draw comparisons and summary of a given virtual machine. This includes key performance indicators like `CPU Usage`, `Memory Utilization`, `Network Throughput`, and `Disk Space Usage` etc. |

--- a/dashboards/vmware/virtual-machine-performance.json
+++ b/dashboards/vmware/virtual-machine-performance.json
@@ -1,0 +1,240 @@
+{
+  "displayName": "GCVE Virtual Machine Performance",
+  "mosaicLayout": {
+    "columns": 12,
+    "tiles": [
+      {
+        "height": 4,
+        "widget": {
+          "title": "CPU Usage",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/virtual_machine/cpu/usage\" resource.type=\"generic_node\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Disk Space Used",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_BAR",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/virtual_machine/disk/usage_bytes\" resource.type=\"generic_node\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 8
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Memory Utilization",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/virtual_machine/memory/used_percent\" resource.type=\"generic_node\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 4
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Network Throughput Bytes [MEAN]",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/virtual_machine/network/throughput_bytes\" resource.type=\"generic_node\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 4
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "CPU Utilization",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/virtual_machine/cpu/used_percent\" resource.type=\"generic_node\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Disk Space Free",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_BAR",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/virtual_machine/disk/free_bytes\" resource.type=\"generic_node\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 8
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Disk Utilization",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/generic_node/vmware_vcenter/virtual_machine/disk/used_percent\" resource.type=\"generic_node\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 12
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds another sample dashboard around the monitoring of GCVE VMs. A good use case for this dashboard is to filter via the `instance_name` metric label for a finer look into a specific VM.

### Screenshots
No Filters
<img width="1508" alt="image" src="https://user-images.githubusercontent.com/32067685/112211338-2ab84d00-8bf2-11eb-886c-22da8b8ca626.png">
<img width="1502" alt="image" src="https://user-images.githubusercontent.com/32067685/112211643-87b40300-8bf2-11eb-980e-f27a74bdb813.png">


Filtered by instance_name and power_state metric labels
<img width="1509" alt="image" src="https://user-images.githubusercontent.com/32067685/112211290-16745000-8bf2-11eb-9672-476ff5c6eb18.png">
<img width="1505" alt="image" src="https://user-images.githubusercontent.com/32067685/112211494-56d3ce00-8bf2-11eb-9cc8-e7c6d054aeba.png">
