### PR TITLE
Cloud Ops agent Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+terraform/agents/cloud-opts/.terraform
+terraform/agents/cloud-opts/.terraform.*
+terraform/agents/cloud-opts/terraform.tfstate
+terraform/agents/cloud-opts/terraform.tfstate.backup

--- a/terraform/agents/README.md
+++ b/terraform/agents/README.md
@@ -1,0 +1,10 @@
+# Using Terraform to deploy monitoring agents
+
+## Deploying Cloud Opts Agent with Terraform
+
+See the `cloud-opts/` directory for Terraform deployment examples on Linux and Windows. 
+
+Useful documentation
+
+- Official [opts agent documentation](https://cloud.google.com/stackdriver/docs/solutions/ops-agent)
+- Managing [ops agents at scale](https://cloud.google.com/stackdriver/docs/solutions/ops-agent/fleet-installation) Terraform, Ansible, Google Agent Policy

--- a/terraform/agents/cloud-opts/README.md
+++ b/terraform/agents/cloud-opts/README.md
@@ -4,7 +4,7 @@ This directory serves as an example on how to leverage Terraform's [template_fil
 
 ## Prerequisite
 
-- [Gcloud SDK](https://cloud.google.com/sdk/docs/install)
+- [Google Cloud SDK](https://cloud.google.com/sdk/docs/install)
 - [Terraform](https://www.terraform.io/downloads.html)
 - run `gcloud auth login`
 - run `gcloud auth application-default login`

--- a/terraform/agents/cloud-opts/README.md
+++ b/terraform/agents/cloud-opts/README.md
@@ -1,0 +1,42 @@
+# Deploying Cloud Opts Agent with Terraform
+
+This directory serves as an example on how to leverage Terraform's [template_file](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) to deploy the Ops Agent to Linux and Windows.
+
+## Prerequisite
+
+- [Gcloud SDK](https://cloud.google.com/sdk/docs/install)
+- [Terraform](https://www.terraform.io/downloads.html)
+- run `gcloud auth login`
+- run `gcloud auth application-default login`
+
+## Usage
+
+This example will deploy a Linux and Windows compute instance, with the Ops Agent install during deployment.
+
+1. Deploy
+
+```bash
+terraform init
+terraform plan -var project=<your project id>
+terraform apply -var project=<your project id>
+```
+
+2. Test
+
+Log into both compute instances and check the status of the cloud ops agent
+
+Linux
+```
+sudo systemctl status google-cloud-ops-agent*
+```
+
+Windows (Powershell 'as Administrator')
+```
+Get-Service google-cloud-ops-agent
+```
+
+3. Cleanup
+
+```
+terraform destroy -var project=<your project id>
+```

--- a/terraform/agents/cloud-opts/linux.tf
+++ b/terraform/agents/cloud-opts/linux.tf
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "script_endpoint_linux" {
+  description = "The endpoint for the Linux agent script"
+  type        = string
+  default     = "https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh"
+}
+
+variable "agent_version_linux" {
+  description = "The Linux Ops Agent version to install"
+  type        = string
+  default     = "1.0.2"
+}
+
+data "template_file" "google-cloud-opts-agent-linux" {
+  template = file("${path.module}/scripts/install.sh")
+  vars = {
+    script_endpoint = var.script_endpoint_linux
+    agent_version   = var.agent_version_linux
+  }
+}
+
+resource "google_compute_instance" "debian10" {
+  project      = var.project
+  name         = "debian-10-opts-agent"
+  machine_type = "e2-small"
+  zone         = "us-east1-b"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-10"
+    }
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  metadata_startup_script = "${data.template_file.google-cloud-opts-agent-linux.rendered};"
+}
+
+
+output "linux-service-command" {
+  value = "sudo systemctl status google-cloud-ops-agent*"
+}

--- a/terraform/agents/cloud-opts/scripts/install.ps1
+++ b/terraform/agents/cloud-opts/scripts/install.ps1
@@ -1,0 +1,24 @@
+# Injecting environment variables
+
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Set Azure vars
+$env:scriptEndpoint="${scriptEndpoint}"
+$env:agentVersion="${agentVersion}"
+
+
+googet addrepo google-cloud-ops-agent-windows $env:scriptEndpoint
+googet -noconfirm install google-cloud-ops-agent.x86_64.$env:agentVersion

--- a/terraform/agents/cloud-opts/scripts/install.ps1
+++ b/terraform/agents/cloud-opts/scripts/install.ps1
@@ -1,6 +1,5 @@
 # Injecting environment variables
 
-#!/usr/bin/env bash
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/terraform/agents/cloud-opts/scripts/install.ps1
+++ b/terraform/agents/cloud-opts/scripts/install.ps1
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Set Azure vars
+# Set variables injected by Terraform template
 $env:scriptEndpoint="${scriptEndpoint}"
 $env:agentVersion="${agentVersion}"
 

--- a/terraform/agents/cloud-opts/scripts/install.sh
+++ b/terraform/agents/cloud-opts/scripts/install.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+curl -s ${script_endpoint} -o /tmp/agent.sh
+sudo bash /tmp/agent.sh \
+  --also-install \
+  --version=${agent_version}

--- a/terraform/agents/cloud-opts/variables.tf
+++ b/terraform/agents/cloud-opts/variables.tf
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project" {
+  description = "The GCP project to deploy to"
+  type        = string
+}

--- a/terraform/agents/cloud-opts/windows.tf
+++ b/terraform/agents/cloud-opts/windows.tf
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "script_endpoint_windows" {
+  description = "The endpoint for the Windows agent script"
+  type        = string
+  default     = "https://packages.cloud.google.com/yuck/repos/google-cloud-ops-agent-windows-all"
+}
+
+variable "agent_version_windows" {
+  // https://cloud.google.com/stackdriver/docs/solutions/ops-agent/installation#agent-install-latest-windows
+  description = "The Windows Ops Agent version to install"
+  type        = string
+  default     = "1.0.1@1"
+}
+
+data "template_file" "google-cloud-opts-agent-windows" {
+  template = file("${path.module}/scripts/install.ps1")
+  vars = {
+    scriptEndpoint = var.script_endpoint_windows
+    agentVersion   = var.agent_version_windows
+  }
+}
+
+/**
+
+Caution: Windows requires more resources than Linux, this example uses a larger
+instance type and ssd storage.
+
+**/
+
+resource "google_compute_instance" "windows2019" {
+  project      = var.project
+  name         = "windows-2019-opts-agent"
+  machine_type = "n1-standard-1"
+  zone         = "us-east1-b"
+
+  boot_disk {
+    initialize_params {
+      image = "windows-cloud/windows-2019"
+      type  = "pd-ssd"
+      size  = "120"
+    }
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  metadata = {
+    windows-startup-script-ps1 = "${data.template_file.google-cloud-opts-agent-windows.rendered}"
+  }
+}
+
+
+output "windows-service-command" {
+  value = "Get-Service google-cloud-ops-agent"
+}

--- a/terraform/agents/cloud-opts/windows.tf
+++ b/terraform/agents/cloud-opts/windows.tf
@@ -45,7 +45,7 @@ instance type and ssd storage.
 resource "google_compute_instance" "windows2019" {
   project      = var.project
   name         = "windows-2019-opts-agent"
-  machine_type = "n1-standard-1"
+  machine_type = "n2-standard-2"
   zone         = "us-east1-b"
 
   boot_disk {


### PR DESCRIPTION
- Added terraform/agent/cloud-opts directory, which will hold all Terraform examples for cloud-ops and future agents
- Added Terraform + Linux Cloud Opts agent example
- Added Terraform + Windows Cloud Opts agent example