### PR TITLE
Fix metric name in GCE VM dashboard

### DIFF
--- a/dashboards/compute/gce-vm-instance-monitoring.json
+++ b/dashboards/compute/gce-vm-instance-monitoring.json
@@ -221,7 +221,7 @@
                   "aggregation": {
                     "perSeriesAligner": "ALIGN_RATE"
                   },
-                  "filter": "metric.type=\"compute.googleapis.com/nat/sent_packets_count\" resource.type=\"gce_instance\"",
+                  "filter": "metric.type=\"compute.googleapis.com/instance/network/sent_packets_count\" resource.type=\"gce_instance\"",
                   "secondaryAggregation": {}
                 },
                 "unitOverride": "{packet}"


### PR DESCRIPTION
I believe the intended behavior is to monitor sent packets by GCE VM, not Cloud NAT. Otherwise, it might be useful to update the title to something more explicit: `Cloud NAT - Sent packets count`.