### PR TITLE
Reformat networking README

### DIFF
--- a/dashboards/networking/README.md
+++ b/dashboards/networking/README.md
@@ -6,6 +6,7 @@
 |This dashboard has 12 charts for the [Cloud CDN metrics](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-loadbalancing) `CDN traffic overview`.|
 
 &nbsp;
+
 |Cloud DNS Monitoring|
 |:-------------------|
 |Filename: [clouddns-monitoring.json](clouddns-monitoring.json)|


### PR DESCRIPTION
Added a new line between the non-breaking space and the table to ensure the README file can be properly parsed.