### PR TITLE
Restore failed-status-checks dashboard and rename Active Directory dashboard

### DIFF
--- a/dashboards/multicloud-amazon-ec2/failed-status-checks.json
+++ b/dashboards/multicloud-amazon-ec2/failed-status-checks.json
@@ -1,0 +1,113 @@
+{
+  "displayName": "Multicloud AWS EC2 - Failed Status Checks",
+  "mosaicLayout": {
+    "columns": 12,
+    "tiles": [
+      {
+        "height": 4,
+        "widget": {
+          "title": "Failed instance status checks",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/EC2/StatusCheckFailed_Instance/Sum\" resource.type=\"aws_ec2_instance\"",
+                    "secondaryAggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "yPos": 4
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Failed status checks",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/EC2/StatusCheckFailed/Sum\" resource.type=\"aws_ec2_instance\"",
+                    "secondaryAggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 12
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Failed system status checks",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"external.googleapis.com/bluemedora/EC2/StatusCheckFailed_System/Sum\" resource.type=\"aws_ec2_instance\"",
+                    "secondaryAggregation": {
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 4
+      }
+    ]
+  }
+}

--- a/dashboards/windows/README.md
+++ b/dashboards/windows/README.md
@@ -2,7 +2,7 @@
 
 Note: [Blue Medora Bindplane](https://cloud.google.com/stackdriver/blue-medora) needs to be configured for some dashboards. For detailed instructions, please review the setup doc from Blue Medora.
 
-|Active Directory Monitoring|
+|Windows Active Directory Monitoring|
 |:---------------------|
 |Filename: [active-directory-monitoring.json](active-directory-monitoring.json)|
 |This dashboard has 8 charts to display the metrics for the `Active directory servers`. Blue Medora needs to be [configured](https://bluemedora.com/monitoring-microsoft-active-directory-with-stackdriver-logging/). The metrics include resource utilization and service status.|

--- a/dashboards/windows/active-directory-monitoring.json
+++ b/dashboards/windows/active-directory-monitoring.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "Active Directory",
+  "displayName": "Windows Active Directory",
   "gridLayout": {
     "columns": "2",
     "widgets": [


### PR DESCRIPTION
The failed-status-checks dashboard was accidentally deleted as part of #61 