### PR TITLE
Small Bug: Fix typo in vmware contention dashboard

### DIFF
--- a/dashboards/vmware/contention.json
+++ b/dashboards/vmware/contention.json
@@ -216,7 +216,7 @@
                     "aggregation": {
                       "perSeriesAligner": "ALIGN_MAX"
                     },
-                    "filter": "metric.type=\"external.googleapis.com/vmware/vcenter.vcenter.vm.cpu.usage\" resource.type=\"generic_node\""
+                    "filter": "metric.type=\"external.googleapis.com/vmware/vcenter.vm.cpu.usage\" resource.type=\"generic_node\""
                   }
                 }
               }


### PR DESCRIPTION
There was a small typo in the cpu usage metric.

Here's what the actual metric is called.

<img width="1422" alt="image" src="https://user-images.githubusercontent.com/32067685/145072810-b54ea60b-551c-4398-824e-1ef803fa9133.png">
