### PR TITLE
Fix table formatting in README files

### DIFF
--- a/dashboards/activemq/README.md
+++ b/dashboards/activemq/README.md
@@ -8,5 +8,4 @@
 |ActiveMQ GCE Overview|
 |:------------------|
 |Filename: [activemq-gce-overview.json](activemq-gce-overview.json)|
-|This dashboard has 14 charts for viewing ActiceMQ when monitored by 
-[Google's Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/activemq#monitored-metrics), including `Memory Usage`, `Store Usage`, `Temp Usage`, `Connections`, `Producers`, `Messages Waiting`, `Messages Enqueued`, `Messages Dequeued`,`Total Current Messages`,`Consumers`, `Average Wait Time`, `CPU % Top 5 VMs`, `Memory % Top 5 VMs`, and `Hosts by Region`
+|This dashboard has 14 charts for viewing ActiceMQ when monitored by [Google's Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/activemq#monitored-metrics), including `Memory Usage`, `Store Usage`, `Temp Usage`, `Connections`, `Producers`, `Messages Waiting`, `Messages Enqueued`, `Messages Dequeued`,`Total Current Messages`,`Consumers`, `Average Wait Time`, `CPU % Top 5 VMs`, `Memory % Top 5 VMs`, and `Hosts by Region`

--- a/dashboards/cassandra/README.md
+++ b/dashboards/cassandra/README.md
@@ -8,5 +8,4 @@
 |Cassandra GCE Overview|
 |:------------------|
 |Filename: [cassandra-gce-overview.json](cassandra-gce-overview.json)|
-|This dashboard has 12 charts for viewing Cassandra when monitored by 
-[Google's Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/cassandra#monitored-metrics), including `Latency Percentile`, `Max Latency`, `Operation Rate`, `Operation Error Rate`, `Tasks Completed`, `Tasks Pending`, `Storage Load`, `Total Hints`, `Total Hints In Progress`, `CPU % Top 5 VMs`, `Memory % Top 5 VMs`, and `Hosts by Region`.
+|This dashboard has 12 charts for viewing Cassandra when monitored by [Google's Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/cassandra#monitored-metrics), including `Latency Percentile`, `Max Latency`, `Operation Rate`, `Operation Error Rate`, `Tasks Completed`, `Tasks Pending`, `Storage Load`, `Total Hints`, `Total Hints In Progress`, `CPU % Top 5 VMs`, `Memory % Top 5 VMs`, and `Hosts by Region`.

--- a/dashboards/couchdb/README.md
+++ b/dashboards/couchdb/README.md
@@ -9,5 +9,4 @@
 |Couchdb GCE Overview|
 |:------------------|
 |Filename: [couchdb-gce-overview.json](couchdb-gce-overview.json)|
-|This dashboard has 12 charts for viewing couchdb when monitored by 
-[Google's Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/couchdb#monitored-metrics), including `Requests by Method`, `Responses by Status Code`, `Average Request Time`, `Bulk Requests`, `Views`, `Database Operations`, `Open Files Descriptors`, `Open Databases`, `CPU % Top 5 VMs`, `Memory % Top VMs` and `Hosts By Region`. There is also a `Couchdb Monitoring Link` card with links to docs and couchdb log in Cloud Logging.
+|This dashboard has 12 charts for viewing couchdb when monitored by [Google's Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/couchdb#monitored-metrics), including `Requests by Method`, `Responses by Status Code`, `Average Request Time`, `Bulk Requests`, `Views`, `Database Operations`, `Open Files Descriptors`, `Open Databases`, `CPU % Top 5 VMs`, `Memory % Top VMs` and `Hosts By Region`. There is also a `Couchdb Monitoring Link` card with links to docs and couchdb log in Cloud Logging.

--- a/dashboards/elasticsearch/README.md
+++ b/dashboards/elasticsearch/README.md
@@ -1,5 +1,7 @@
 ### Dashboards for Elasticsearch
 
+#### Notes
+
 - This dashboard is based on Google's [Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent).
 
 

--- a/dashboards/hadoop/README.md
+++ b/dashboards/hadoop/README.md
@@ -9,5 +9,4 @@
 |Hadoop GCE Overview|
 |:------------------|
 |Filename: [hadoop-gce-overview.json](hadoop-gce-overview.json)|
-|This dashboard has 12 charts for viewing hadoop when monitored by 
-[Google's Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/hadoop#monitored-metrics), including `Data Nodes`, `Volume Failures`, `Capacity Used`, `Capacity Limit`, `Block Count`, `Corrupt Blocks`, `Missing Blocks`, `File Count`, `File Load`, `CPU % Top 5 VMs`, `Memory % Top 5 VMs` and`Hosts By Region`. There is also a `Hadoop Monitoring Link` card with links to docs and hadoop log in Cloud Logging.
+|This dashboard has 12 charts for viewing hadoop when monitored by [Google's Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/hadoop#monitored-metrics), including `Data Nodes`, `Volume Failures`, `Capacity Used`, `Capacity Limit`, `Block Count`, `Corrupt Blocks`, `Missing Blocks`, `File Count`, `File Load`, `CPU % Top 5 VMs`, `Memory % Top 5 VMs` and`Hosts By Region`. There is also a `Hadoop Monitoring Link` card with links to docs and hadoop log in Cloud Logging.

--- a/dashboards/hbase/README.md
+++ b/dashboards/hbase/README.md
@@ -8,11 +8,9 @@
 |Hbase GCE Overview|
 |:------------------|
 |Filename: [hbase-gce-overview.json](cassandra-gce-overview.json)|
-|This dashboard has charts for viewing Hbase when monitored by 
-[Google's Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/cassandra#monitored-metrics), including `Region Servers`, `Dead Region Servers`, `Regions in Transition`, `Regions in Transition Over Threshold`, `Read Requests`, and `Write Requests`. |
+|This dashboard has charts for viewing Hbase when monitored by [Google's Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/cassandra#monitored-metrics), including `Region Servers`, `Dead Region Servers`, `Regions in Transition`, `Regions in Transition Over Threshold`, `Read Requests`, and `Write Requests`. |
 
 |Hbase GCE Operations Overview|
 |:------------------|
 |Filename: [hbase-gce-overview.json](cassandra-gce-overview.json)|
-|This dashboard has charts for viewing Hbase Operations when monitored by 
-[Google's Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/cassandra#monitored-metrics), including `Slow Get Operations`, `Slow Append Operations`, `Slow Delete Operations`, `Slow Put Operations`, `Slow Get Operations`, `Get Operations 99 Percentile`, `Append Operations 99 Percentile`, `Delete Operations 99 Percentile`, `Put Operations 99 Percentile`, `Increment Operations 99 Percentile`, and `Replay Operations 99 Percentile`. |
+|This dashboard has charts for viewing Hbase Operations when monitored by [Google's Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/cassandra#monitored-metrics), including `Slow Get Operations`, `Slow Append Operations`, `Slow Delete Operations`, `Slow Put Operations`, `Slow Get Operations`, `Get Operations 99 Percentile`, `Append Operations 99 Percentile`, `Delete Operations 99 Percentile`, `Put Operations 99 Percentile`, `Increment Operations 99 Percentile`, and `Replay Operations 99 Percentile`. |

--- a/dashboards/kafka/README.md
+++ b/dashboards/kafka/README.md
@@ -8,5 +8,4 @@
 |Kafka GCE Overview|
 |:------------------|
 |Filename: [kafka-gce-overview.json](kafka-gce-overview.json)|
-|This dashboard has 12 charts for viewing Kafka when monitored by 
-[Google's Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/kafka#monitored-metrics), including `Messages`, `Network IO`, `Requests`, `Failed Requests`, `Purgatory`, `Partitions`, `Offline Partitions`, `Under Replicated Partitions`, `ISR Operations`, `CPU % Top 5 VMs`, `Memory % Top 5 VMs`, and `Hosts by Region`.
+|This dashboard has 12 charts for viewing Kafka when monitored by [Google's Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/kafka#monitored-metrics), including `Messages`, `Network IO`, `Requests`, `Failed Requests`, `Purgatory`, `Partitions`, `Offline Partitions`, `Under Replicated Partitions`, `ISR Operations`, `CPU % Top 5 VMs`, `Memory % Top 5 VMs`, and `Hosts by Region`.

--- a/dashboards/mysql/README.md
+++ b/dashboards/mysql/README.md
@@ -8,20 +8,4 @@
 |MySQL Overview|
 |:------------------|
 |Filename: [overview.json](overview.json)|
-|This dashboard has charts displaying:
-- `Buffer Pool Operations`
-- `Buffer Pool Pages`
-- `Buffer Pool Size`
-- `Handlers`
-- `Double Writes`
-- `Page Operations`
-- `Operations`
-- `Log Operations`
-- `Row Operations`
-- `Row Locks`
-- `Locks`
-- `Commands`
-- `Sorts` 
-- `Threads` 
-
-from MySQL as well as charts of infrastructure related metrics for the running MySQL VMs: `CPU % Top 5 VMs` and `MySQL VMs by Region` for a count of VMs over time. There is also a card with links to docs and MySQL log in Cloud Logging.|
+|This dashboard has charts displaying: `Buffer Pool Operations`, `Buffer Pool Pages`, `Buffer Pool Size`, `Handlers`, `Double Writes`, `Page Operations`, `Operations`, `Log Operations`, `Row Operations`, `Row Locks`, `Locks`, `Commands`, `Sorts`, and `Threads` from MySQL as well as charts of infrastructure related metrics for the running MySQL VMs: `CPU % Top 5 VMs` and `MySQL VMs by Region` for a count of VMs over time. There is also a card with links to docs and MySQL log in Cloud Logging.|

--- a/dashboards/postgresql/README.md
+++ b/dashboards/postgresql/README.md
@@ -8,5 +8,4 @@
 |PostgreSQL GCE Overview|
 |:------------------|
 |Filename: [postgresql-gce-overview.json](postgresql-gce-overview.json)|
-|This dashboard has 9 charts for viewing PostgreSQL when monitored by 
-[Google's Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/postgresql#monitored-metrics), including `Backends`, `Commits/Rollbacks`, `Database Size`, `Database Rows`, `Blocks Read`, `Operations`, `CPU % Top 5 VMs`, `Memory % Top 5 VMs`, and `Hosts by Region`.
+|This dashboard has 9 charts for viewing PostgreSQL when monitored by [Google's Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/postgresql#monitored-metrics), including `Backends`, `Commits/Rollbacks`, `Database Size`, `Database Rows`, `Blocks Read`, `Operations`, `CPU % Top 5 VMs`, `Memory % Top 5 VMs`, and `Hosts by Region`.

--- a/dashboards/solr/README.md
+++ b/dashboards/solr/README.md
@@ -8,5 +8,4 @@
 |Solr GCE Overview|
 |:------------------|
 |Filename: [solr-gce-overview.json](solr-gce-overview.json)|
-|This dashboard has charts for viewing Solr when monitored by 
-Google's Ops Agent including `Documents`, `Index Size`, `Cache Hit Ratio`, `Cache Size`, `Queries`, `Query Errors`, `Average Query Time`, `Updates`, `Update Errors`, `Average Update Time`, `CPU % Top 5 VMs`, `Memory % Top 5 VMs`, and `Hosts by Region`.
+|This dashboard has charts for viewing Solr when monitored by Google's Ops Agent including `Documents`, `Index Size`, `Cache Hit Ratio`, `Cache Size`, `Queries`, `Query Errors`, `Average Query Time`, `Updates`, `Update Errors`, `Average Update Time`, `CPU % Top 5 VMs`, `Memory % Top 5 VMs`, and `Hosts by Region`.

--- a/dashboards/tomcat/README.md
+++ b/dashboards/tomcat/README.md
@@ -8,5 +8,4 @@
 |Tomcat GCE Overview|
 |:------------------|
 |Filename: [tomcat-gce-overview.json](tomcat-gce-overview.json)|
-|This dashboard has charts for viewing Tomcat when monitored by 
-Google's Ops Agent including `Traffic`, `Errors - Top 5 VMs`, `Processing Time`, `Active Sessions`, `Threads`, `Requests`, `Max Processing Time`, `CPU % Top 5 VMs`, `Memory % Top 5 VMs`, and `Hosts by Region`.
+|This dashboard has charts for viewing Tomcat when monitored by Google's Ops Agent including `Traffic`, `Errors - Top 5 VMs`, `Processing Time`, `Active Sessions`, `Threads`, `Requests`, `Max Processing Time`, `CPU % Top 5 VMs`, `Memory % Top 5 VMs`, and `Hosts by Region`.

--- a/dashboards/zookeeper/README.md
+++ b/dashboards/zookeeper/README.md
@@ -8,5 +8,4 @@
 |Zookeeper GCE Overview|
 |:------------------|
 |Filename: [zookeeper-gce-overview.json](zookeeper-gce-overview.json)|
-|This dashboard has 11 charts for viewing Zookeeper when monitored by 
-[Google's Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/zookeeper#monitored-metrics), including `Active Connections`, `Active Requests`, `Average Max Latency`, `Packets`, `Followers`, `ZNodes`, `Data Tree Size`, `File Descriptors`,  `CPU % Top 5 VMs`, `Memory % Top 5 VMs`, and `Hosts by Region`.
+|This dashboard has 11 charts for viewing Zookeeper when monitored by [Google's Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/zookeeper#monitored-metrics), including `Active Connections`, `Active Requests`, `Average Max Latency`, `Packets`, `Followers`, `ZNodes`, `Data Tree Size`, `File Descriptors`,  `CPU % Top 5 VMs`, `Memory % Top 5 VMs`, and `Hosts by Region`.


### PR DESCRIPTION
Fixes broken table formatting in a number of dashboard README files.

Before:
| A broken table |
|:-----------------|
|Content spilling
over! |

After:
| A fixed table |
|:---------------|
|Content contained!|

Also adds a missing "Notes" header to the Elasticsearch README.