### PR TITLE
Fix missing anthos and hbase dashboards

### DIFF
--- a/dashboards/anthos-config-management/README.md
+++ b/dashboards/anthos-config-management/README.md
@@ -4,7 +4,5 @@
 
 |Anthos Config Management ConfigSync |
 |:---------------------|
-|Filename: [ACM-ConfigSync.json](Anthos-ConfigSync.json)|
-|This dashboard surfaces metrics related to resources managed by ConfigSync and
-some usage metrics.|
-
+|Filename: [ACM-ConfigSync.json](ACM-ConfigSync.json)|
+|This dashboard surfaces metrics related to resources managed by ConfigSync and some usage metrics.|

--- a/dashboards/hbase/README.md
+++ b/dashboards/hbase/README.md
@@ -12,5 +12,5 @@
 
 |Hbase GCE Operations Overview|
 |:------------------|
-|Filename: [hbase-gce-overview.json](hbase-gce-overview.json)|
+|Filename: [hbase-gce-operation-overview.json](hbase-gce-operation-overview.json)|
 |This dashboard has charts for viewing Hbase Operations when monitored by [Google's Ops Agent](https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party/hbase#monitored-metrics), including `Slow Get Operations`, `Slow Append Operations`, `Slow Delete Operations`, `Slow Put Operations`, `Slow Get Operations`, `Get Operations 99 Percentile`, `Append Operations 99 Percentile`, `Delete Operations 99 Percentile`, `Put Operations 99 Percentile`, `Increment Operations 99 Percentile`, and `Replay Operations 99 Percentile`. |


### PR DESCRIPTION
The linked dashboard json file names for these 2 dashboards were incorrect.