### PR TITLE
Alert policies for MSSQL ops agent (DRAFT)

### DIFF
--- a/dashboards/mssql-server/alerts/connections-near-limit.json
+++ b/dashboards/mssql-server/alerts/connections-near-limit.json
@@ -1,0 +1,38 @@
+{
+    "displayName": "MSSQL - Connections Near Limit",
+    "documentation": {
+        "content": "If the amount of connections is within 10% of the maximum connections, default being 32,767 (threshold is defaulted to 29490), then that could be cause to look for ways to increase performance and load management.",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "MSSQL - User Connections Near Limit",
+            "conditionThreshold": {
+                "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/sqlserver.user.connection.count\"",
+                "aggregations": [
+                    {
+                        "alignmentPeriod": "600s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                ],
+                "comparison": "COMPARISON_GT",
+                "duration": "0s",
+                "trigger": {
+                    "count": 1
+                },
+                "thresholdValue": 29490
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "604800s",
+        "notificationPrompts": [
+            "OPENED"
+        ]
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}

--- a/dashboards/mssql-server/alerts/documentation.md
+++ b/dashboards/mssql-server/alerts/documentation.md
@@ -1,0 +1,14 @@
+
+# Alerts for MSSQL in the Ops Agent
+
+## Connections Near Limit
+
+If the amount of connections is within 10% of the maximum connections, then unexpected behavior can occur with connection establishment, queries and operations. By default the upper limit is `32,767` so the alert is specified for `29,490` connections. If limit is reached, it would be a potential cause of decreased performance of the instance.
+
+## High Page Split Rates
+
+If ‘page.split.rate’ is spiking above a user defined threshold (defaulted to `100 pages/sec`), it could show if the fill factor needs to increase. Excess page splitting can cause excessive disk I/O and contribute to slow performance of the instance.
+
+## High Lock Wait Rates
+
+If ‘lock.wait.rate’ is above a user defined value (defaulted to `3 requests/sec`) it shows that your resources are being blocked waiting for locks to be lifted slowing down the server.

--- a/dashboards/mssql-server/alerts/high-lock-wait-rates.json
+++ b/dashboards/mssql-server/alerts/high-lock-wait-rates.json
@@ -1,0 +1,38 @@
+{
+    "displayName": "MSSQL - High Lock Wait Rates",
+    "documentation": {
+        "content": "If 'lock.wait.rate' is above a user defined value it shows that your resources are being blocked waiting for locks to be lifted slowing down the server.\n",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "VM Instance - workload/sqlserver.lock.wait.rate",
+            "conditionThreshold": {
+                "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/sqlserver.lock.wait.rate\"",
+                "aggregations": [
+                    {
+                        "alignmentPeriod": "300s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                ],
+                "comparison": "COMPARISON_GT",
+                "duration": "0s",
+                "trigger": {
+                    "count": 1
+                },
+                "thresholdValue": 3
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "604800s",
+        "notificationPrompts": [
+            "OPENED"
+        ]
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}

--- a/dashboards/mssql-server/alerts/high-page-split-rate.json
+++ b/dashboards/mssql-server/alerts/high-page-split-rate.json
@@ -1,0 +1,38 @@
+{
+    "displayName": "MSSQL - HIgh Page Split Rates",
+    "documentation": {
+        "content": "If `page.split.rate` is spiking above a user defined threshold, it could show if the fill factor needs to increase. Excess page splitting can cause excessive disk I/O and contribute to slow performance.",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "VM Instance - workload/sqlserver.page.split.rate",
+            "conditionThreshold": {
+                "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/sqlserver.page.split.rate\"",
+                "aggregations": [
+                    {
+                        "alignmentPeriod": "300s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                ],
+                "comparison": "COMPARISON_GT",
+                "duration": "0s",
+                "trigger": {
+                    "count": 1
+                },
+                "thresholdValue": 100
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "604800s",
+        "notificationPrompts": [
+            "OPENED"
+        ]
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}


### PR DESCRIPTION
Adds policies for a new ops agent integration located in [this PR](https://github.com/GoogleCloudPlatform/ops-agent/pull/554).

The alerts intended to be added:
- User Connections near limit - if the amount of connections is within 10% of the maximum connections default being 32,767, then that could be cause to look for ways to increase performance and load management
- High Page Split Rates - if ‘page.split.rate’ is spiking above a user defined threshold, it could show if the fill factor needs to increase. Excess page splitting can cause excessive disk I/O and contribute to slow performance.
- High Lock Wait Rates - if ‘lock.wait.rate’ is above a user defined value it shows that your resources are being blocked waiting for locks to be lifted slowing down the server.


