### PR TITLE
Fix the minimum supported version for Jetty

### DIFF
--- a/integrations/jetty/ops_agent_metadata.yaml
+++ b/integrations/jetty/ops_agent_metadata.yaml
@@ -5,7 +5,7 @@ platforms:
   agent_requirement:
     logs_minimum_supported_version:
       major: 2
-      minor: 9
+      minor: 16
       patch: 0
   detections:
   - characteristic_log:


### PR DESCRIPTION
PRs fixing in the ops-agent repo source:
https://github.com/GoogleCloudPlatform/ops-agent/pull/619
https://github.com/GoogleCloudPlatform/ops-agent/pull/621

Root cause: https://github.com/GoogleCloudPlatform/ops-agent/pull/573#discussion_r876282280
