### PR TITLE
Add Ops Agent Cassandra alert policies

### DIFF
--- a/alerts/cassandra/README.md
+++ b/alerts/cassandra/README.md
@@ -6,13 +6,13 @@ This Alert generally is looking at unexpected increases of throughput in the Cas
 
 ## High Errors
 
-This alert looks at the amount of requests made and the amount of errors received and alerts if ratios of exceptions exceeds 10% of the total amount of requests. Things captured in this alert could include timeouts, write exceptions, unavailable exceptions and etc. These generally require further investigation and indicate an issue with the Cassandra node.
+This alert policy looks at the amount of requests made and the amount of errors received. An alert is triggered alerts if the number of exceptions exceeds 10% of the total amount of requests. Things captured in this alert could include timeouts, write exceptions, unavailable exceptions, etc. These generally require further investigation and indicate an issue with the Cassandra node.
 
 ## High Read Latency
 
-Read latency is generally considered the slower operation in cassandra due to hardware limitations or the data model. Read latency is a good indicator of how well those affectors are fitting to the cassandra environment and if read latency is high, it might be time to update the hardware or dig deeper into why cassandra is losing performance. Feel free to tune this alert for your hardware and latency tolerance, but 4000 µs was the initial threshold specified in this alert. For this alert the median 50th percentile was chosen.
+Read latency is generally considered the slower operation in Cassandra due to hardware limitations or the data model. Read latency is a good indicator of how well those affectors are fitting to the Cassandra environment and if read latency is high, it might be time to update the hardware or dig deeper into why Cassandra is losing performance. Feel free to tune this alert for your hardware and latency tolerance, but 4000 µs was the initial threshold specified in this alert. For this alert the median 50th percentile was chosen.
 
-### Creating notification Channels and User Labels
+### Creating Notification Channels and User Labels
 
 Whether these alert policies are being used as standalones or base templates for a deployment strategy like terraform, one thing that should be utilized is notification channels and user labels.
 

--- a/alerts/cassandra/README.md
+++ b/alerts/cassandra/README.md
@@ -1,0 +1,39 @@
+# Alerts for Cassandra in Ops Agent
+
+## High Write Throughput
+
+This Alert generally is looking at unexpected increases of throughput in the Cassandra requests. The threshold will be mostly determined based off normalcy of the environment the node is in, but the alert is defaulted to 20000 writes-per-second. Feel free to adjust threshold to fit your environment. It is generally good to keep an eye on the number of write requests going into detect any anomalies in either lack of writes or overbearance of rights.
+
+## High Errors
+
+This alert looks at the amount of requests made and the amount of errors received and alerts if ratios of exceptions exceeds 10% of the total amount of requests. Things captured in this alert could include timeouts, write exceptions, unavailable exceptions and etc. These generally require further investigation and indicate an issue with the Cassandra node.
+
+## High Read Latency
+
+Read latency is generally considered the slower operation in cassandra due to hardware limitations or the data model. Read latency is a good indicator of how well those affectors are fitting to the cassandra environment and if read latency is high, it might be time to update the hardware or dig deeper into why cassandra is losing performance. Feel free to tune this alert for your hardware and latency tolerance, but 4000 µs was the initial threshold specified in this alert. For this alert the median 50th percentile was chosen.
+
+### Creating notification Channels and User Labels
+
+Whether these alert policies are being used as standalones or base templates for a deployment strategy like terraform, one thing that should be utilized is notification channels and user labels.
+
+### User Labels
+
+Supplying user labels could give extra identification information about the firing alert:
+
+i.e.
+
+```json
+    "userLabels": {
+        "datacenter": "central"
+    }
+```
+
+#### Notification Channels
+
+The ID of the notification channel to be notifed.
+
+```json
+    "notificationChannels": [
+        "projects/project-id/notificationChannels/1234567
+    ]
+```

--- a/alerts/cassandra/high-error-rate.json
+++ b/alerts/cassandra/high-error-rate.json
@@ -1,7 +1,7 @@
 {
     "displayName": "Cassandra - High Error Rate",
     "documentation": {
-        "content": "This alert looks at the amount of requests made and the amount of errors received and alerts if ratios of exceptions exceeds 10% of the total amount of requests. Things captured in this alert could include timeouts, write exceptions, unavailable exceptions and etc. These generally require further investigation and indicate an issue with the Cassandra node.",
+        "content": "This alert policy looks at the amount of requests made and the amount of errors received. An alert is triggered alerts if the number of exceptions exceeds 10% of the total amount of requests. Things captured in this alert could include timeouts, write exceptions, unavailable exceptions, etc. These generally require further investigation and indicate an issue with the Cassandra node.",
         "mimeType": "text/markdown"
     },
     "userLabels": {},

--- a/alerts/cassandra/high-error-rate.json
+++ b/alerts/cassandra/high-error-rate.json
@@ -1,0 +1,26 @@
+{
+    "displayName": "Cassandra - High Error Rate",
+    "documentation": {
+        "content": "This alert looks at the amount of requests made and the amount of errors received and alerts if ratios of exceptions exceeds 10% of the total amount of requests. Things captured in this alert could include timeouts, write exceptions, unavailable exceptions and etc. These generally require further investigation and indicate an issue with the Cassandra node.",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "Error Rate higher than 10%",
+            "conditionMonitoringQueryLanguage": {
+                "duration": "0s",
+                "trigger": {
+                    "count": 1
+                },
+                "query": "{\n    t_0: fetch gce_instance::workload.googleapis.com/cassandra.client.request.count\n    ; \n    t_1: fetch gce_instance::workload.googleapis.com/cassandra.client.request.error.count\n}\n| outer_join 1\n| group_by [metric.status, metric.operation]\n| value val(1) / if(has_value(val(0)), 1, val(0))\n| window 1m\n| condition val() > .1"
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "3600s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}

--- a/alerts/cassandra/high-error-rate.json
+++ b/alerts/cassandra/high-error-rate.json
@@ -9,11 +9,10 @@
         {
             "displayName": "Error Rate higher than 10%",
             "conditionMonitoringQueryLanguage": {
-                "duration": "1m",
+                "duration": "0s",
                 "trigger": {
                     "count": 1
                 },
-                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
                 "query": "{\n    t_0: fetch gce_instance::workload.googleapis.com/cassandra.client.request.count\n    ; \n    t_1: fetch gce_instance::workload.googleapis.com/cassandra.client.request.error.count\n}\n| outer_join 1\n| group_by [metric.status, metric.operation]\n| value val(1) / if(has_value(val(0)), 1, val(0))\n| window 1m\n| condition val() > .1"
             }
         }

--- a/alerts/cassandra/high-error-rate.json
+++ b/alerts/cassandra/high-error-rate.json
@@ -13,6 +13,7 @@
                 "trigger": {
                     "count": 1
                 },
+                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
                 "query": "{\n    t_0: fetch gce_instance::workload.googleapis.com/cassandra.client.request.count\n    ; \n    t_1: fetch gce_instance::workload.googleapis.com/cassandra.client.request.error.count\n}\n| outer_join 1\n| group_by [metric.status, metric.operation]\n| value val(1) / if(has_value(val(0)), 1, val(0))\n| window 1m\n| condition val() > .1"
             }
         }

--- a/alerts/cassandra/high-error-rate.json
+++ b/alerts/cassandra/high-error-rate.json
@@ -9,7 +9,7 @@
         {
             "displayName": "Error Rate higher than 10%",
             "conditionMonitoringQueryLanguage": {
-                "duration": "30s",
+                "duration": "1m",
                 "trigger": {
                     "count": 1
                 },

--- a/alerts/cassandra/high-error-rate.json
+++ b/alerts/cassandra/high-error-rate.json
@@ -9,7 +9,7 @@
         {
             "displayName": "Error Rate higher than 10%",
             "conditionMonitoringQueryLanguage": {
-                "duration": "0s",
+                "duration": "30s",
                 "trigger": {
                     "count": 1
                 },

--- a/alerts/cassandra/high-read-latency.json
+++ b/alerts/cassandra/high-read-latency.json
@@ -1,35 +1,36 @@
 {
     "displayName": "Cassandra - High Read Latency",
     "documentation": {
-      "content": "Read latency is generally considered the slower operation in cassandra due to hardware limitations or the data model. Read latency is a good indicator of how well those affectors are fitting to the cassandra environment and if read latency is high, it might be time to update the hardware or dig deeper into why cassandra is losing performance. Feel free to tune this alert for your hardware and latency tolerance, but 4000 µs was the initial threshold specified in this alert. For this alert the median 50th percentile was chosen.",
-      "mimeType": "text/markdown"
+        "content": "Read latency is generally considered the slower operation in cassandra due to hardware limitations or the data model. Read latency is a good indicator of how well those affectors are fitting to the cassandra environment and if read latency is high, it might be time to update the hardware or dig deeper into why cassandra is losing performance. Feel free to tune this alert for your hardware and latency tolerance, but 4000 µs was the initial threshold specified in this alert. For this alert the median 50th percentile was chosen.",
+        "mimeType": "text/markdown"
     },
     "userLabels": {},
     "conditions": [
-      {
-        "displayName": "VM Instance - workload/cassandra.client.request.read.latency.50p",
-        "conditionThreshold": {
-          "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/cassandra.client.request.read.latency.50p\"",
-          "aggregations": [
-            {
-              "alignmentPeriod": "60s",
-              "crossSeriesReducer": "REDUCE_NONE",
-              "perSeriesAligner": "ALIGN_MEAN"
+        {
+            "displayName": "VM Instance - workload/cassandra.client.request.read.latency.50p",
+            "conditionThreshold": {
+                "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/cassandra.client.request.read.latency.50p\"",
+                "aggregations": [
+                    {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                ],
+                "comparison": "COMPARISON_GT",
+                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
+                "duration": "0s",
+                "trigger": {
+                    "count": 1
+                },
+                "thresholdValue": 4000
             }
-          ],
-          "comparison": "COMPARISON_GT",
-          "duration": "0s",
-          "trigger": {
-            "count": 1
-          },
-          "thresholdValue": 4000
         }
-      }
     ],
     "alertStrategy": {
-      "autoClose": "3600s"
+        "autoClose": "3600s"
     },
     "combiner": "OR",
     "enabled": true,
     "notificationChannels": []
-  }
+}

--- a/alerts/cassandra/high-read-latency.json
+++ b/alerts/cassandra/high-read-latency.json
@@ -19,7 +19,7 @@
                 ],
                 "comparison": "COMPARISON_GT",
                 "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
-                "duration": "30s",
+                "duration": "1m",
                 "trigger": {
                     "count": 1
                 },

--- a/alerts/cassandra/high-read-latency.json
+++ b/alerts/cassandra/high-read-latency.json
@@ -1,0 +1,35 @@
+{
+    "displayName": "Cassandra - High Read Latency",
+    "documentation": {
+      "content": "Read latency is generally considered the slower operation in cassandra due to hardware limitations or the data model. Read latency is a good indicator of how well those affectors are fitting to the cassandra environment and if read latency is high, it might be time to update the hardware or dig deeper into why cassandra is losing performance. Feel free to tune this alert for your hardware and latency tolerance, but 4000 µs was the initial threshold specified in this alert. For this alert the median 50th percentile was chosen.",
+      "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+      {
+        "displayName": "VM Instance - workload/cassandra.client.request.read.latency.50p",
+        "conditionThreshold": {
+          "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/cassandra.client.request.read.latency.50p\"",
+          "aggregations": [
+            {
+              "alignmentPeriod": "60s",
+              "crossSeriesReducer": "REDUCE_NONE",
+              "perSeriesAligner": "ALIGN_MEAN"
+            }
+          ],
+          "comparison": "COMPARISON_GT",
+          "duration": "0s",
+          "trigger": {
+            "count": 1
+          },
+          "thresholdValue": 4000
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "3600s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+  }

--- a/alerts/cassandra/high-read-latency.json
+++ b/alerts/cassandra/high-read-latency.json
@@ -1,7 +1,7 @@
 {
     "displayName": "Cassandra - High Read Latency",
     "documentation": {
-        "content": "Read latency is generally considered the slower operation in cassandra due to hardware limitations or the data model. Read latency is a good indicator of how well those affectors are fitting to the cassandra environment and if read latency is high, it might be time to update the hardware or dig deeper into why cassandra is losing performance. Feel free to tune this alert for your hardware and latency tolerance, but 4000 µs was the initial threshold specified in this alert. For this alert the median 50th percentile was chosen.",
+        "content": "Read latency is generally considered the slower operation in Cassandra due to hardware limitations or the data model. Read latency is a good indicator of how well those affectors are fitting to the Cassandra environment and if read latency is high, it might be time to update the hardware or dig deeper into why Cassandra is losing performance. Feel free to tune this alert for your hardware and latency tolerance, but 4000 µs was the initial threshold specified in this alert. For this alert the median 50th percentile was chosen.",
         "mimeType": "text/markdown"
     },
     "userLabels": {},

--- a/alerts/cassandra/high-read-latency.json
+++ b/alerts/cassandra/high-read-latency.json
@@ -19,7 +19,7 @@
                 ],
                 "comparison": "COMPARISON_GT",
                 "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
-                "duration": "0s",
+                "duration": "30s",
                 "trigger": {
                     "count": 1
                 },

--- a/alerts/cassandra/high-read-latency.json
+++ b/alerts/cassandra/high-read-latency.json
@@ -18,8 +18,7 @@
                     }
                 ],
                 "comparison": "COMPARISON_GT",
-                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
-                "duration": "1m",
+                "duration": "0s",
                 "trigger": {
                     "count": 1
                 },

--- a/alerts/cassandra/high-throughput.json
+++ b/alerts/cassandra/high-throughput.json
@@ -17,6 +17,7 @@
                         "perSeriesAligner": "ALIGN_RATE"
                     }
                 ],
+                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
                 "comparison": "COMPARISON_GT",
                 "duration": "0s",
                 "trigger": {

--- a/alerts/cassandra/high-throughput.json
+++ b/alerts/cassandra/high-throughput.json
@@ -19,7 +19,7 @@
                 ],
                 "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
                 "comparison": "COMPARISON_GT",
-                "duration": "30s",
+                "duration": "1m",
                 "trigger": {
                     "count": 1
                 },

--- a/alerts/cassandra/high-throughput.json
+++ b/alerts/cassandra/high-throughput.json
@@ -17,9 +17,8 @@
                         "perSeriesAligner": "ALIGN_RATE"
                     }
                 ],
-                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
                 "comparison": "COMPARISON_GT",
-                "duration": "1m",
+                "duration": "0s",
                 "trigger": {
                     "count": 1
                 },

--- a/alerts/cassandra/high-throughput.json
+++ b/alerts/cassandra/high-throughput.json
@@ -19,7 +19,7 @@
                 ],
                 "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
                 "comparison": "COMPARISON_GT",
-                "duration": "0s",
+                "duration": "30s",
                 "trigger": {
                     "count": 1
                 },

--- a/alerts/cassandra/high-throughput.json
+++ b/alerts/cassandra/high-throughput.json
@@ -1,0 +1,35 @@
+{
+    "displayName": "Cassandra - High Write Throughput",
+    "documentation": {
+        "content": "This Alert generally is looking at unexpected increases of throughput in the Cassandra requests. The threshold will be mostly determined based off normalcy of the environment the node is in, but the alert is defaulted to 20000 writes-per-second. Feel free to adjust threshold to fit your environment. It is generally good to keep an eye on the number of write requests going into detect any anomalies in either lack of writes or overbearance of rights.\n",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "VM Instance - workload/cassandra.client.request.count",
+            "conditionThreshold": {
+                "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/cassandra.client.request.count\"",
+                "aggregations": [
+                    {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_RATE"
+                    }
+                ],
+                "comparison": "COMPARISON_GT",
+                "duration": "0s",
+                "trigger": {
+                    "count": 1
+                },
+                "thresholdValue": 20000
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "3600s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}


### PR DESCRIPTION
Intending to add these alerts:

## High Write Throughput

This Alert generally is looking at unexpected increases of throughput in the Cassandra requests. The threshold will be mostly determined based off normalcy of the environment the node is in, but the alert is defaulted to 20000 writes-per-second. Feel free to adjust threshold to fit your environment. It is generally good to keep an eye on the number of write requests going into detect any anomalies in either lack of writes or overbearance of rights.

## High Errors

This alert looks at the amount of requests made and the amount of errors received and alerts if ratios of exceptions exceeds 10% of the total amount of requests. Things captured in this alert could include timeouts, write exceptions, unavailable exceptions and etc. These generally require further investigation and indicate an issue with the Cassandra node.

## High Read Latency

Read latency is generally considered the slower operation in cassandra due to hardware limitations or the data model. Read latency is a good indicator of how well those affectors are fitting to the cassandra environment and if read latency is high, it might be time to update the hardware or dig deeper into why cassandra is losing performance. Feel free to tune this alert for your hardware and latency tolerance, but 4000 µs was the initial threshold specified in this alert. For this alert the median 50th percentile was chosen.