### PR TITLE
Add Ops agent Varnish alert polices

### DIFF
--- a/alerts/varnish/README.md
+++ b/alerts/varnish/README.md
@@ -1,0 +1,34 @@
+# Varnish Alerts for Ops Agent
+
+### Notification Channels
+For all alerts, a notification channel needs to be set up or the alert will fire silently.
+
+### User Labels
+User labels can be used for these policies by modifying the userLabels fields of the policies. i.e.
+
+```json
+{ 
+  "userLabels": {
+    "datacenter": "central"
+  }
+}
+```
+## Sessions dropped alert
+
+Sessions dropped alert is triggered when 'workload.googleapis.com/varnish.session.count is greater than 0. This occurs when varnish is out of worker threads and the session queue is filled up. This means incoming requests may be dropped indicating that either varnish is overloaded or the thread pool needs to be increased.
+
+## High cache evictions alert
+
+High cache evictions alert is triggered when 'workload.googleapis.com/varnish.object.nuked' increases at an alarming rate that exceeds a user-defined threshold. This objects are evicting at a faster rate because of the lack of space, so increasing the cache size would help.
+
+
+## High server limit alert
+
+High server limit alert is triggered when 'workload.googleapis.com/varnish.thread.operation.count' is greater than zero. If a thread fails, then you likely exceeded your servers limit or attempted to create threads too rapidly.
+
+## Backend connection failure alert
+
+Backend connection failure alert is triggered when `workload.googleapis.com/varnish.backend.connection.count` is greater than zero. Backend connection failures can indicate different failure scenarios such as:
+- A tcp connection has timed out from a network issue, overload or unresponsive backend.
+- A request is sent to the backend, but the backend did not respond within a certain time. 
+- A backend started streaming a response but stopped sending data without closing the connection.

--- a/alerts/varnish/README.md
+++ b/alerts/varnish/README.md
@@ -1,8 +1,5 @@
 # Varnish Alerts for Ops Agent
 
-### Notification Channels
-For all alerts, a notification channel needs to be set up or the alert will fire silently.
-
 ### User Labels
 User labels can be used for these policies by modifying the userLabels fields of the policies. i.e.
 
@@ -32,3 +29,6 @@ Backend connection failure alert is triggered when `workload.googleapis.com/varn
 - A tcp connection has timed out from a network issue, overload or unresponsive backend.
 - A request is sent to the backend, but the backend did not respond within a certain time. 
 - A backend started streaming a response but stopped sending data without closing the connection.
+
+### Notification Channels
+For all alerts, a notification channel needs to be set up or the alert will fire silently.

--- a/alerts/varnish/backend-connection-failure.json
+++ b/alerts/varnish/backend-connection-failure.json
@@ -26,10 +26,7 @@
       }
     ],
     "alertStrategy": {
-      "autoClose": "604800s",
-      "notificationPrompts": [
-        "OPENED"
-      ]
+      "autoClose": "604800s"
     },
     "combiner": "OR",
     "enabled": true,

--- a/alerts/varnish/backend-connection-failure.json
+++ b/alerts/varnish/backend-connection-failure.json
@@ -1,0 +1,36 @@
+{
+    "name": "projects/otel-agent-dev/alertPolicies/15816128761328501269",
+    "displayName": "Varnish - backend connection failure",
+    "documentation": {},
+    "userLabels": {},
+    "conditions": [
+      {
+        "name": "projects/otel-agent-dev/alertPolicies/15816128761328501269/conditions/15816128761328501466",
+        "displayName": "VM Instance - workload/varnish.backend.connection.count",
+        "conditionThreshold": {
+          "aggregations": [
+            {
+              "alignmentPeriod": "300s",
+              "perSeriesAligner": "ALIGN_RATE"
+            }
+          ],
+          "comparison": "COMPARISON_GT",
+          "duration": "0s",
+          "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/varnish.backend.connection.count\" AND metric.labels.kind = \"fail\"",
+          "thresholdValue": 10,
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s",
+      "notificationPrompts": [
+        "OPENED"
+      ]
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+  }

--- a/alerts/varnish/backend-connection-failure.json
+++ b/alerts/varnish/backend-connection-failure.json
@@ -1,11 +1,12 @@
 {
-    "name": "projects/otel-agent-dev/alertPolicies/15816128761328501269",
     "displayName": "Varnish - backend connection failure",
-    "documentation": {},
+    "documentation": {
+      "content": "Backend connection failure alert is triggered when `workload.googleapis.com/varnish.backend.connection.count` is greater than zero.",
+      "mimeType": "text/markdown"
+  },
     "userLabels": {},
     "conditions": [
       {
-        "name": "projects/otel-agent-dev/alertPolicies/15816128761328501269/conditions/15816128761328501466",
         "displayName": "VM Instance - workload/varnish.backend.connection.count",
         "conditionThreshold": {
           "aggregations": [

--- a/alerts/varnish/high-cache-evictions.json
+++ b/alerts/varnish/high-cache-evictions.json
@@ -26,10 +26,7 @@
       }
     ],
     "alertStrategy": {
-      "autoClose": "604800s",
-      "notificationPrompts": [
-        "OPENED"
-      ]
+      "autoClose": "604800s"
     },
     "combiner": "OR",
     "enabled": true,

--- a/alerts/varnish/high-cache-evictions.json
+++ b/alerts/varnish/high-cache-evictions.json
@@ -1,11 +1,12 @@
 {
-    "name": "projects/otel-agent-dev/alertPolicies/13277237989178709151",
     "displayName": "Varnish - High cache evictions",
-    "documentation": {},
+    "documentation": {
+      "content": "High cache evictions alert is triggered when 'workload.googleapis.com/varnish.object.nuked' increases at an alarming rate that exceeds a user-defined threshold. This objects are evicting at a faster rate because of the lack of space, so increasing the cache size would help.",
+      "mimeType": "text/markdown"
+  },
     "userLabels": {},
     "conditions": [
       {
-        "name": "projects/otel-agent-dev/alertPolicies/13277237989178709151/conditions/13277237989178708376",
         "displayName": "VM Instance - workload/varnish.object.nuked",
         "conditionThreshold": {
           "aggregations": [

--- a/alerts/varnish/high-cache-evictions.json
+++ b/alerts/varnish/high-cache-evictions.json
@@ -1,0 +1,36 @@
+{
+    "name": "projects/otel-agent-dev/alertPolicies/13277237989178709151",
+    "displayName": "Varnish - High cache evictions",
+    "documentation": {},
+    "userLabels": {},
+    "conditions": [
+      {
+        "name": "projects/otel-agent-dev/alertPolicies/13277237989178709151/conditions/13277237989178708376",
+        "displayName": "VM Instance - workload/varnish.object.nuked",
+        "conditionThreshold": {
+          "aggregations": [
+            {
+              "alignmentPeriod": "300s",
+              "perSeriesAligner": "ALIGN_RATE"
+            }
+          ],
+          "comparison": "COMPARISON_GT",
+          "duration": "0s",
+          "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/varnish.object.nuked\"",
+          "thresholdValue": 10,
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s",
+      "notificationPrompts": [
+        "OPENED"
+      ]
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+  }

--- a/alerts/varnish/high-server-limit.json
+++ b/alerts/varnish/high-server-limit.json
@@ -1,0 +1,35 @@
+{
+    "name": "projects/otel-agent-dev/alertPolicies/7298978230498782881",
+    "displayName": "Varnish - high server limit",
+    "documentation": {},
+    "userLabels": {},
+    "conditions": [
+      {
+        "name": "projects/otel-agent-dev/alertPolicies/7298978230498782881/conditions/7298978230498779876",
+        "displayName": "VM Instance - workload/varnish.thread.operation.count",
+        "conditionThreshold": {
+          "aggregations": [
+            {
+              "alignmentPeriod": "300s",
+              "perSeriesAligner": "ALIGN_RATE"
+            }
+          ],
+          "comparison": "COMPARISON_GT",
+          "duration": "0s",
+          "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/varnish.thread.operation.count\" AND metric.labels.operation = \"failed\"",
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s",
+      "notificationPrompts": [
+        "OPENED"
+      ]
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+  }

--- a/alerts/varnish/high-server-limit.json
+++ b/alerts/varnish/high-server-limit.json
@@ -1,11 +1,12 @@
 {
-    "name": "projects/otel-agent-dev/alertPolicies/7298978230498782881",
     "displayName": "Varnish - high server limit",
-    "documentation": {},
+    "documentation": {
+      "content": "High server limit alert is triggered when 'workload.googleapis.com/varnish.thread.operation.count' is greater than zero. If a thread fails, then you likely exceeded your servers limit or attempted to create threads too rapidly.",
+      "mimeType": "text/markdown"
+  },
     "userLabels": {},
     "conditions": [
       {
-        "name": "projects/otel-agent-dev/alertPolicies/7298978230498782881/conditions/7298978230498779876",
         "displayName": "VM Instance - workload/varnish.thread.operation.count",
         "conditionThreshold": {
           "aggregations": [

--- a/alerts/varnish/high-server-limit.json
+++ b/alerts/varnish/high-server-limit.json
@@ -25,10 +25,7 @@
       }
     ],
     "alertStrategy": {
-      "autoClose": "604800s",
-      "notificationPrompts": [
-        "OPENED"
-      ]
+      "autoClose": "604800s"
     },
     "combiner": "OR",
     "enabled": true,

--- a/alerts/varnish/sessions-dropped.json
+++ b/alerts/varnish/sessions-dropped.json
@@ -25,10 +25,7 @@
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s",
-    "notificationPrompts": [
-      "OPENED"
-    ]
+    "autoClose": "604800s"
   },
   "combiner": "OR",
   "enabled": true,

--- a/alerts/varnish/sessions-dropped.json
+++ b/alerts/varnish/sessions-dropped.json
@@ -1,0 +1,35 @@
+{
+  "name": "projects/otel-agent-dev/alertPolicies/15537161145972419755",
+  "displayName": "Varnish - Sessions Dropped",
+  "documentation": {},
+  "userLabels": {},
+  "conditions": [
+    {
+      "name": "projects/otel-agent-dev/alertPolicies/15537161145972419755/conditions/15537161145972416590",
+      "displayName": "VM Instance - workload/varnish.session.count",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_RATE"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/varnish.session.count\" AND metric.labels.kind = \"dropped\"",
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/varnish/sessions-dropped.json
+++ b/alerts/varnish/sessions-dropped.json
@@ -1,11 +1,12 @@
 {
-  "name": "projects/otel-agent-dev/alertPolicies/15537161145972419755",
   "displayName": "Varnish - Sessions Dropped",
-  "documentation": {},
+  "documentation": {
+    "content": "Sessions dropped alert is triggered when 'workload.googleapis.com/varnish.session.count is greater than 0. This occurs when varnish is out of worker threads and the session queue is filled up. This means incoming requests may be dropped indicating that either varnish is overloaded or the thread pool needs to be increased.",
+    "mimeType": "text/markdown"
+},
   "userLabels": {},
   "conditions": [
     {
-      "name": "projects/otel-agent-dev/alertPolicies/15537161145972419755/conditions/15537161145972416590",
       "displayName": "VM Instance - workload/varnish.session.count",
       "conditionThreshold": {
         "aggregations": [


### PR DESCRIPTION
Intending to add these alerts:

## Sessions dropped alert

Sessions dropped alert is triggered when 'workload.googleapis.com/varnish.session.count is greater than 0. This occurs when varnish is out of worker threads and the session queue is filled up. This means incoming requests may be dropped indicating that either varnish is overloaded or the thread pool needs to be increased.

## High cache evictions alert

High cache evictions alert is triggered when 'workload.googleapis.com/varnish.object.nuked' increases at an alarming rate that exceeds a user-defined threshold. This objects are evicting at a faster rate because of the lack of space, so increasing the cache size would help.


## High server limit alert

High server limit alert is triggered when 'workload.googleapis.com/varnish.thread.operation.count' is greater than zero. If a thread fails, then you likely exceeded your servers limit or attempted to create threads too rapidly.

## Backend connection failure alert

Backend connection failure alert is triggered when `workload.googleapis.com/varnish.backend.connection.count` is greater than zero. Backend connection failures can indicate different failure scenarios such as:
- A tcp connection has timed out from a network issue, overload or unresponsive backend.
- A request is sent to the backend, but the backend did not respond within a certain time. 
- A backend started streaming a response but stopped sending data without closing the connection.
