### PR TITLE
Add Ops agent Apache alert polices

### DIFF
--- a/alerts/apache/README.md
+++ b/alerts/apache/README.md
@@ -1,0 +1,39 @@
+# Apache Alerts for Ops Agent
+
+### Notification Channels
+For all alerts, a notification channel needs to be set up or the alert will fire silently.
+
+### User Labels
+User labels can be used for these policies by modifying the userLabels fields of the policies. i.e.
+
+```json
+{ 
+  "userLabels": {
+    "datacenter": "central"
+  }
+}
+```
+
+## High request rate alert
+The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is above this threshold, then that means there is a large spike in traffic which logs can help diagnose if these are nefarious requests.
+
+The `"thresholdValue"` can be adjusted based adjusted depending on what is considered to be a high request rate.
+
+## Low request rate alert
+The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is below this threshold, then that means there is an environment problem that are limiting the request rates.
+
+The `"thresholdValue"` can be adjusted based adjusted depending on what is considered to be a low request rate.
+
+## High server error rate alert
+The server error rate is derived from processing access logs status code. The server error rate value is the number of 5xx status codes / total status codes per 5 minute window. When the server error rate spikes suddenly, then you have a high priority server problem as backends are experiencing 5xx errors and clients are not being served successfully.
+
+### Prerequisites
+
+The name of the metric should be:
+`apache.server.error.count`
+
+The filter for the metric should be:
+```
+logName:"apache_access"
+httpRequest.status >= 500
+```

--- a/alerts/apache/README.md
+++ b/alerts/apache/README.md
@@ -1,28 +1,14 @@
 # Apache Alerts for Ops Agent
 
-### Notification Channels
-For all alerts, a notification channel needs to be set up or the alert will fire silently.
-
-### User Labels
-User labels can be used for these policies by modifying the userLabels fields of the policies. i.e.
-
-```json
-{ 
-  "userLabels": {
-    "datacenter": "central"
-  }
-}
-```
-
 ## High request rate alert
-The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is above this threshold, then that means there is a large spike in traffic which logs can help diagnose if these are nefarious requests.
+The request rate is derived from the requests metrics taken as a rate of every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When the request rate is above the established threshold, then that means there is a large spike in traffic which logs can help diagnose if these are nefarious requests being made.
 
-The `"thresholdValue"` can be adjusted based adjusted depending on what is considered to be a high request rate.
+The `"thresholdValue"` can be adjusted depending on what is considered to be a high request rate.
 
 ## Low request rate alert
-The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is below this threshold, then that means there is an environment problem that are limiting the request rates.
+The request rate is derived from the requests metrics taken as a rate of every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When the request rate is below the established threshold, then that means there is an environment problem that is limiting the request rates.
 
-The `"thresholdValue"` can be adjusted based adjusted depending on what is considered to be a low request rate.
+The `"thresholdValue"` can be adjusted depending on what is considered to be a low request rate.
 
 ## High server error rate alert
 The server error rate is derived from processing access logs status code. The server error rate value is the number of 5xx status codes per 5 minute window. When the server error rate spikes suddenly, then you have a high priority server problem as backends are experiencing 5xx errors and clients are not being served successfully.
@@ -36,4 +22,18 @@ The filter for the metric should be:
 ```
 logName:"apache_access"
 httpRequest.status >= 500
+```
+
+### Notification Channels
+For all alerts, a notification channel needs to be set up or the alert will fire silently.
+
+### User Labels
+User labels can be used for these policies by modifying the userLabels fields of the policies. i.e.
+
+```json
+{ 
+  "userLabels": {
+    "datacenter": "central"
+  }
+}
 ```

--- a/alerts/apache/README.md
+++ b/alerts/apache/README.md
@@ -25,7 +25,7 @@ The request rate is derived from the requests metrics taken as a rate every 5 mi
 The `"thresholdValue"` can be adjusted based adjusted depending on what is considered to be a low request rate.
 
 ## High server error rate alert
-The server error rate is derived from processing access logs status code. The server error rate value is the number of 5xx status codes / total status codes per 5 minute window. When the server error rate spikes suddenly, then you have a high priority server problem as backends are experiencing 5xx errors and clients are not being served successfully.
+The server error rate is derived from processing access logs status code. The server error rate value is the number of 5xx status codes per 5 minute window. When the server error rate spikes suddenly, then you have a high priority server problem as backends are experiencing 5xx errors and clients are not being served successfully.
 
 ### Prerequisites
 

--- a/alerts/apache/high-request-rate.json
+++ b/alerts/apache/high-request-rate.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Apache - high-request-rate",
   "documentation": {
-    "content": "The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is above this threshold, then that means there is a large spike in traffic which logs can help diagnose if these are nefarious requests.",
+    "content": "The request rate is derived from the requests metrics taken as a rate of every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When the request rate is above the established threshold, then that means there is a large spike in traffic which logs can help diagnose if these are nefarious requests being made.",
     "mimeType": "text/markdown"
   },
   "userLabels": {},

--- a/alerts/apache/high-request-rate.json
+++ b/alerts/apache/high-request-rate.json
@@ -1,0 +1,39 @@
+{
+  "name": "projects/otel-agent-dev/alertPolicies/16729498787080340915",
+  "displayName": "Apache - high-request-rate",
+  "documentation": {
+    "content": "The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is above this threshold, then that means there is a large spike in traffic which logs can help diagnose if these are nefarious requests.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "name": "projects/otel-agent-dev/alertPolicies/16729498787080340915/conditions/16729498787080341174",
+      "displayName": "VM Instance - workload/apache.requests",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_RATE"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/apache.requests\"",
+        "thresholdValue": 100,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/apache/high-request-rate.json
+++ b/alerts/apache/high-request-rate.json
@@ -26,10 +26,7 @@
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s",
-    "notificationPrompts": [
-      "OPENED"
-    ]
+    "autoClose": "604800s"
   },
   "combiner": "OR",
   "enabled": true,

--- a/alerts/apache/high-request-rate.json
+++ b/alerts/apache/high-request-rate.json
@@ -1,5 +1,4 @@
 {
-  "name": "projects/otel-agent-dev/alertPolicies/16729498787080340915",
   "displayName": "Apache - high-request-rate",
   "documentation": {
     "content": "The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is above this threshold, then that means there is a large spike in traffic which logs can help diagnose if these are nefarious requests.",
@@ -8,7 +7,6 @@
   "userLabels": {},
   "conditions": [
     {
-      "name": "projects/otel-agent-dev/alertPolicies/16729498787080340915/conditions/16729498787080341174",
       "displayName": "VM Instance - workload/apache.requests",
       "conditionThreshold": {
         "aggregations": [

--- a/alerts/apache/high-server-error-rate.json
+++ b/alerts/apache/high-server-error-rate.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Apache - high server error rate",
   "documentation": {
-    "content": "The server error rate is derived from processing access logs status code. The server error rate value is the number of 5xx status codes / total status codes per 5 minute window. When the server error rate spikes suddenly, then you have a high priority server problem as backends are experiencing 5xx errors and clients are not being served successfully.",
+    "content": "The server error rate is derived from processing access logs status code. The server error rate value is the number of 5xx status codes per 5 minute window. When the server error rate spikes suddenly, then you have a high priority server problem as backends are experiencing 5xx errors and clients are not being served successfully.",
     "mimeType": "text/markdown"
   },
   "userLabels": {},

--- a/alerts/apache/high-server-error-rate.json
+++ b/alerts/apache/high-server-error-rate.json
@@ -18,7 +18,7 @@
         ],
         "comparison": "COMPARISON_GT",
         "duration": "0s",
-        "filter": "metric.type=\"logging.googleapis.com/user/apache.server.error.count\"",
+        "filter": "resource.type = \"gce_instance\" AND metric.type=\"logging.googleapis.com/user/apache.server.error.count\"",
         "thresholdValue": 1,
         "trigger": {
           "count": 1
@@ -27,10 +27,7 @@
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s",
-    "notificationPrompts": [
-      "OPENED"
-    ]
+    "autoClose": "604800s"
   },
   "combiner": "OR",
   "enabled": true,

--- a/alerts/apache/high-server-error-rate.json
+++ b/alerts/apache/high-server-error-rate.json
@@ -1,0 +1,40 @@
+{
+  "name": "projects/otel-agent-dev/alertPolicies/771874405992657112",
+  "displayName": "Apache - high server error rate",
+  "documentation": {
+    "content": "The server error rate is derived from processing access logs status code. The server error rate value is the number of 5xx status codes / total status codes per 5 minute window. When the server error rate spikes suddenly, then you have a high priority server problem as backends are experiencing 5xx errors and clients are not being served successfully.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "name": "projects/otel-agent-dev/alertPolicies/771874405992657112/conditions/771874405992659929",
+      "displayName": "New condition",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "crossSeriesReducer": "REDUCE_SUM",
+            "perSeriesAligner": "ALIGN_RATE"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "metric.type=\"logging.googleapis.com/user/apache.server.error.count\"",
+        "thresholdValue": 1,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/apache/high-server-error-rate.json
+++ b/alerts/apache/high-server-error-rate.json
@@ -1,5 +1,4 @@
 {
-  "name": "projects/otel-agent-dev/alertPolicies/771874405992657112",
   "displayName": "Apache - high server error rate",
   "documentation": {
     "content": "The server error rate is derived from processing access logs status code. The server error rate value is the number of 5xx status codes / total status codes per 5 minute window. When the server error rate spikes suddenly, then you have a high priority server problem as backends are experiencing 5xx errors and clients are not being served successfully.",
@@ -8,7 +7,6 @@
   "userLabels": {},
   "conditions": [
     {
-      "name": "projects/otel-agent-dev/alertPolicies/771874405992657112/conditions/771874405992659929",
       "displayName": "New condition",
       "conditionThreshold": {
         "aggregations": [

--- a/alerts/apache/low-request-rate.json
+++ b/alerts/apache/low-request-rate.json
@@ -1,5 +1,4 @@
 {
-  "name": "projects/otel-agent-dev/alertPolicies/13079207946690506619",
   "displayName": "Apache - low request rate",
   "documentation": {
     "content": "The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is below this threshold, then that means there is an environment problem that are limiting the request rates.",
@@ -8,7 +7,6 @@
   "userLabels": {},
   "conditions": [
     {
-      "name": "projects/otel-agent-dev/alertPolicies/13079207946690506619/conditions/13079207946690503092",
       "displayName": "VM Instance - workload/apache.requests",
       "conditionThreshold": {
         "aggregations": [

--- a/alerts/apache/low-request-rate.json
+++ b/alerts/apache/low-request-rate.json
@@ -1,0 +1,39 @@
+{
+  "name": "projects/otel-agent-dev/alertPolicies/13079207946690506619",
+  "displayName": "Apache - low request rate",
+  "documentation": {
+    "content": "The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is below this threshold, then that means there is an environment problem that are limiting the request rates.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "name": "projects/otel-agent-dev/alertPolicies/13079207946690506619/conditions/13079207946690503092",
+      "displayName": "VM Instance - workload/apache.requests",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_RATE"
+          }
+        ],
+        "comparison": "COMPARISON_LT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/apache.requests\"",
+        "thresholdValue": 10,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/apache/low-request-rate.json
+++ b/alerts/apache/low-request-rate.json
@@ -26,10 +26,7 @@
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s",
-    "notificationPrompts": [
-      "OPENED"
-    ]
+    "autoClose": "604800s"
   },
   "combiner": "OR",
   "enabled": true,

--- a/alerts/apache/low-request-rate.json
+++ b/alerts/apache/low-request-rate.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Apache - low request rate",
   "documentation": {
-    "content": "The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is below this threshold, then that means there is an environment problem that are limiting the request rates.",
+    "content": "The request rate is derived from the requests metrics taken as a rate of every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When the request rate is below the established threshold, then that means there is an environment problem that is limiting the request rates.",
     "mimeType": "text/markdown"
   },
   "userLabels": {},


### PR DESCRIPTION
Intending to add these alerts:

## High request rate alert
The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is above this threshold, then that means there is a large spike in traffic which logs can help diagnose if these are nefarious requests.

The `"thresholdValue"` can be adjusted based adjusted depending on what is considered to be a high request rate.

## Low request rate alert
The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is below this threshold, then that means there is an environment problem that are limiting the request rates.

The `"thresholdValue"` can be adjusted based adjusted depending on what is considered to be a low request rate.

## High server error rate alert
The server error rate is derived from processing access logs status code. The server error rate value is the number of 5xx status codes / total status codes per 5 minute window. When the server error rate spikes suddenly, then you have a high priority server problem as backends are experiencing 5xx errors and clients are not being served successfully.