### PR TITLE
Add Ops agent Flink alert polices

### DIFF
--- a/alerts/flink/README.md
+++ b/alerts/flink/README.md
@@ -1,5 +1,17 @@
 # Flink Alerts for Ops Agent
 
+## High job restarts alert
+When the job restarts delta value exceeds a threshold value(default is 5), that indicates the flink jobs are not running in a healthy state.
+
+## High failed checkpoints alert
+When the checkpoint delta value exceeds a threshold value(default is 5), that indicates that your system may be overworking having higher processing time and lower throughput.
+
+## High JVM memory heap usage alert
+When the JVM heap ratio of heap used over max heap exceeds a threshold(default is 90%), then application's performance may start to degrade. This alert can trigger when for a jobmanager or a taskmanager. To specify a jobmanager, the resource_type should be jobmanager. To specify a taskmanager, the taskmanager_id filter should target the correct taskmanager instance.
+
+## High JVM memory non-heap usage
+When the JVM nonheap ratio of nonheap used over max nonheap exceeds a threshold(default is 90%), then application's performance may start to degrade. This alert can trigger when for a jobmanager or a taskmanager. To specify a jobmanager, the resource_type should be jobmanager. To specify a taskmanager, the taskmanager_id filter should target the correct taskmanager instance.
+
 ### Notification Channels
 For all alerts, a notification channel needs to be set up or the alert will fire silently.
 
@@ -13,15 +25,3 @@ User labels can be used for these policies by modifying the userLabels fields of
   }
 }
 ```
-
-## High job restarts alert
-When the job restarts delta value exceeds a threshold value, that indicates the flink jobs are not running in a healthy state.
-
-## High failed checkpoints alert
-When the checkpoint delta value exceeds a threshold value, that indicates that your system may be overworking having higher processing time and lower throughput.
-
-## High jvm memory heap usage alert
-When the jvm heap ratio of heap used over max heap exceeds a threshold, then application's performance may start to degrade. This alert can trigger when for a jobmanager or a taskmanager. To specify a jobmanager, the resource_type should be jobmanager. To specify a taskmanager, the taskmanager_id filter should target the correct taskmanager instance.
-
-## High jvm memory non-heap usage
-When the jvm nonheap ratio of nonheap used over max nonheap exceeds a threshold, then application's performance may start to degrade. This alert can trigger when for a jobmanager or a taskmanager. To specify a jobmanager, the resource_type should be jobmanager. To specify a taskmanager, the taskmanager_id filter should target the correct taskmanager instance.

--- a/alerts/flink/README.md
+++ b/alerts/flink/README.md
@@ -1,0 +1,27 @@
+# Flink Alerts for Ops Agent
+
+### Notification Channels
+For all alerts, a notification channel needs to be set up or the alert will fire silently.
+
+### User Labels
+User labels can be used for these policies by modifying the userLabels fields of the policies. i.e.
+
+```json
+{ 
+  "userLabels": {
+    "datacenter": "central"
+  }
+}
+```
+
+## High job restarts alert
+When the job restarts delta value exceeds a threshold value, that indicates the flink jobs are not running in a healthy state.
+
+## High failed checkpoints alert
+When the checkpoint delta value exceeds a threshold value, that indicates that your system may be overworking having higher processing time and lower throughput.
+
+## High jvm memory heap usage alert
+When the jvm heap ratio of heap used over max heap exceeds a threshold, then application's performance may start to degrade. This alert can trigger when for a jobmanager or a taskmanager. To specify a jobmanager, the resource_type should be jobmanager. To specify a taskmanager, the taskmanager_id filter should target the correct taskmanager instance.
+
+## High jvm memory non-heap usage
+When the jvm nonheap ratio of nonheap used over max nonheap exceeds a threshold, then application's performance may start to degrade. This alert can trigger when for a jobmanager or a taskmanager. To specify a jobmanager, the resource_type should be jobmanager. To specify a taskmanager, the taskmanager_id filter should target the correct taskmanager instance.

--- a/alerts/flink/flink-high job-restarts.json
+++ b/alerts/flink/flink-high job-restarts.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "Flink - high job restarts",
+  "documentation": {
+    "content": "When the job restarts delta value exceeds a threshold value, that indicates the flink jobs are not running in a healthy state.",
+    "mimeType": "text/markdown"
+},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/flink.job.restart.count",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_DELTA"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/flink.job.restart.count\"",
+        "thresholdValue": 5,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/flink/flink-high job-restarts.json
+++ b/alerts/flink/flink-high job-restarts.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Flink - high job restarts",
   "documentation": {
-    "content": "When the job restarts delta value exceeds a threshold value, that indicates the flink jobs are not running in a healthy state.",
+    "content": "When the job restarts delta value exceeds a threshold value(default is 5), that indicates the flink jobs are not running in a healthy state.",
     "mimeType": "text/markdown"
 },
   "userLabels": {},

--- a/alerts/flink/flink-high-failed-checkpoints.json
+++ b/alerts/flink/flink-high-failed-checkpoints.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "Flink - high failed checkpoints",
+  "documentation": {
+    "content": "When the checkpoint delta value exceeds a threshold value, that indicates that your system may be overworking having higher processing time and lower throughput.",
+    "mimeType": "text/markdown"
+},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/flink.job.checkpoint.count",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_DELTA"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/flink.job.checkpoint.count\" AND metric.labels.checkpoint = \"failed\"",
+        "thresholdValue": 5,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/flink/flink-high-failed-checkpoints.json
+++ b/alerts/flink/flink-high-failed-checkpoints.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Flink - high failed checkpoints",
   "documentation": {
-    "content": "When the checkpoint delta value exceeds a threshold value, that indicates that your system may be overworking having higher processing time and lower throughput.",
+    "content": "When the checkpoint delta value exceeds a threshold value(default is 5), that indicates that your system may be overworking having higher processing time and lower throughput.",
     "mimeType": "text/markdown"
 },
   "userLabels": {},

--- a/alerts/flink/flink-high-jvm-memory-non-heap-usage.json
+++ b/alerts/flink/flink-high-jvm-memory-non-heap-usage.json
@@ -1,0 +1,26 @@
+{
+  "displayName": "Flink - high jvm memory non-heap usage",
+  "documentation": {
+    "content": "When the jvm nonheap ratio of nonheap used over max nonheap exceeds a threshold, then application's performance may start to degrade. This alert can trigger when for a jobmanager or a taskmanager. To specify a jobmanager, the resource_type should be jobmanager. To specify a taskmanager, the taskmanager_id filter should target the correct taskmanager instance.",
+    "mimeType": "text/markdown"
+},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Flink - JVM Heap Memory Near Max",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "0s",
+        "query": "fetch gce_instance\n| {\nt_0: metric 'workload.googleapis.com/flink.jvm.memory.nonheap.used'\n| filter (metric.resource_type == 'jobmanager');\nt_1: metric 'workload.googleapis.com/flink.jvm.memory.nonheap.max'\n| filter (metric.resource_type == 'jobmanager')\n}\n| outer_join 0\n| value t_0.value.used / t_1.value.max\n| condition val() > .9\n| every 5m\n| window 5m",
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/flink/flink-high-jvm-memory-non-heap-usage.json
+++ b/alerts/flink/flink-high-jvm-memory-non-heap-usage.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Flink - high jvm memory non-heap usage",
   "documentation": {
-    "content": "When the jvm nonheap ratio of nonheap used over max nonheap exceeds a threshold, then application's performance may start to degrade. This alert can trigger when for a jobmanager or a taskmanager. To specify a jobmanager, the resource_type should be jobmanager. To specify a taskmanager, the taskmanager_id filter should target the correct taskmanager instance.",
+    "content": "When the JVM nonheap ratio of nonheap used over max nonheap exceeds a threshold(default is 90%), then application's performance may start to degrade. This alert can trigger when for a jobmanager or a taskmanager. To specify a jobmanager, the resource_type should be jobmanager. To specify a taskmanager, the taskmanager_id filter should target the correct taskmanager instance.",
     "mimeType": "text/markdown"
 },
   "userLabels": {},

--- a/alerts/flink/flink-high-jvm-memory-usage.json
+++ b/alerts/flink/flink-high-jvm-memory-usage.json
@@ -1,0 +1,26 @@
+{
+  "displayName": "Flink - high jvm heap memory usage",
+  "documentation": {
+    "content": "When the jvm heap ratio of heap used over max heap exceeds a threshold, then application's performance may start to degrade. This alert can trigger when for a jobmanager or a taskmanager. To specify a jobmanager, the resource_type should be jobmanager. To specify a taskmanager, the taskmanager_id filter should target the correct taskmanager instance.",
+    "mimeType": "text/markdown"
+},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Flink - JVM Heap Memory Near Max",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "0s",
+        "query": "fetch gce_instance\n| {\nt_0: metric 'workload.googleapis.com/flink.jvm.memory.heap.used'\n| filter (metric.resource_type == 'jobmanager');\nt_1: metric 'workload.googleapis.com/flink.jvm.memory.heap.max'\n| filter (metric.resource_type == 'jobmanager')\n}\n| outer_join 0\n| value t_0.value.used / t_1.value.max\n| condition val() > .9\n| every 5m\n| window 5m",
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/flink/flink-high-jvm-memory-usage.json
+++ b/alerts/flink/flink-high-jvm-memory-usage.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Flink - high jvm heap memory usage",
   "documentation": {
-    "content": "When the jvm heap ratio of heap used over max heap exceeds a threshold, then application's performance may start to degrade. This alert can trigger when for a jobmanager or a taskmanager. To specify a jobmanager, the resource_type should be jobmanager. To specify a taskmanager, the taskmanager_id filter should target the correct taskmanager instance.",
+    "content": "When the JVM heap ratio of heap used over max heap exceeds a threshold(default is 90%), then application's performance may start to degrade. This alert can trigger when for a jobmanager or a taskmanager. To specify a jobmanager, the resource_type should be jobmanager. To specify a taskmanager, the taskmanager_id filter should target the correct taskmanager instance.",
     "mimeType": "text/markdown"
 },
   "userLabels": {},


### PR DESCRIPTION
Intending to add these alerts:

## High job restarts alert
When the job restarts delta value exceeds a threshold value, that indicates the flink jobs are not running in a healthy state.

## High failed checkpoints alert
When the checkpoint delta value exceeds a threshold value, that indicates that your system may be overworking having higher processing time and lower throughput.

## High jvm memory heap usage alert
When the jvm heap ratio of heap used over max heap exceeds a threshold, then application's performance may start to degrade. This alert can trigger when for a jobmanager or a taskmanager. To specify a jobmanager, the resource_type should be jobmanager. To specify a taskmanager, the taskmanager_id filter should target the correct taskmanager instance.

## High jvm memory non-heap usage
When the jvm nonheap ratio of nonheap used over max nonheap exceeds a threshold, then application's performance may start to degrade. This alert can trigger when for a jobmanager or a taskmanager. To specify a jobmanager, the resource_type should be jobmanager. To specify a taskmanager, the taskmanager_id filter should target the correct taskmanager instance.
