### PR TITLE
Add Ops agent Couchdb alert polices

### DIFF
--- a/alerts/couchdb/README.md
+++ b/alerts/couchdb/README.md
@@ -14,12 +14,15 @@ User labels can be used for these policies by modifying the userLabels fields of
 }
 ```
 
-## High request time alert
-
 ## High request rate alert
 The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is above this threshold, then that means there is a large spike in traffic which logs can help diagnose if these are nefarious requests.
 
 The `"thresholdValue"` can be adjusted based adjusted depending on what is considered to be a high request rate.
+
+## Low request rate alert
+The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is below this threshold, then that means there is an environment problem that are limiting the request rates.
+
+The "thresholdValue" can be adjusted based adjusted depending on what is considered to be a low request rate.
 
 ## High server error rate alert
 The server error rate is derived from processing access logs status code. The server error rate value is the number of 5xx status codes / total status codes per 5 minutes. When the server error rate spikes suddenly, then you have a high priority server problem as clients are experiencing 5xx errors and are not being served successfully.

--- a/alerts/couchdb/README.md
+++ b/alerts/couchdb/README.md
@@ -1,28 +1,14 @@
 # Couchdb Alerts for Ops Agent
 
-### Notification Channels
-For all alerts, a notification channel needs to be set up or the alert will fire silently.
-
-### User Labels
-User labels can be used for these policies by modifying the userLabels fields of the policies. i.e.
-
-```json
-{ 
-  "userLabels": {
-    "datacenter": "central"
-  }
-}
-```
-
 ## High request rate alert
-The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is above this threshold, then that means there is a large spike in traffic which logs can help diagnose if these are nefarious requests.
+The request rate is derived from the requests metrics taken as a rate of every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is above this threshold, then that means there is a large spike in traffic which logs can help diagnose if these are nefarious requests.
 
-The `"thresholdValue"` can be adjusted based adjusted depending on what is considered to be a high request rate.
+The `"thresholdValue"` can be adjusted depending on what is considered to be a high request rate.
 
 ## Low request rate alert
-The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is below this threshold, then that means there is an environment problem that are limiting the request rates.
+The request rate is derived from the requests metrics taken as a rate of every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is below this threshold, then that means there is an environment problem that are limiting the request rates.
 
-The "thresholdValue" can be adjusted based adjusted depending on what is considered to be a low request rate.
+The "thresholdValue" can be adjusted depending on what is considered to be a low request rate.
 
 ## High server error rate alert
 The server error rate is derived from processing access logs status code. The server error rate value is the number of 5xx status codes per 5 minute window. When the server error rate spikes suddenly, then you have a high priority server problem as backends are experiencing 5xx errors and clients are not being served successfully.
@@ -36,4 +22,18 @@ The filter for the metric should be:
 ```
 logName:"couchdb"
 httpRequest.status >= 500
+```
+
+### Notification Channels
+For all alerts, a notification channel needs to be set up or the alert will fire silently.
+
+### User Labels
+User labels can be used for these policies by modifying the userLabels fields of the policies. i.e.
+
+```json
+{ 
+  "userLabels": {
+    "datacenter": "central"
+  }
+}
 ```

--- a/alerts/couchdb/README.md
+++ b/alerts/couchdb/README.md
@@ -25,7 +25,7 @@ The request rate is derived from the requests metrics taken as a rate every 5 mi
 The "thresholdValue" can be adjusted based adjusted depending on what is considered to be a low request rate.
 
 ## High server error rate alert
-The server error rate is derived from processing access logs status code. The server error rate value is the number of 5xx status codes / total status codes per 5 minutes. When the server error rate spikes suddenly, then you have a high priority server problem as clients are experiencing 5xx errors and are not being served successfully.
+The server error rate is derived from processing access logs status code. The server error rate value is the number of 5xx status codes per 5 minute window. When the server error rate spikes suddenly, then you have a high priority server problem as backends are experiencing 5xx errors and clients are not being served successfully.
 
 ### Prerequisites
 

--- a/alerts/couchdb/README.md
+++ b/alerts/couchdb/README.md
@@ -1,0 +1,36 @@
+# Couchdb Alerts for Ops Agent
+
+### Notification Channels
+For all alerts, a notification channel needs to be set up or the alert will fire silently.
+
+### User Labels
+User labels can be used for these policies by modifying the userLabels fields of the policies. i.e.
+
+```json
+{ 
+  "userLabels": {
+    "datacenter": "central"
+  }
+}
+```
+
+## High request time alert
+
+## High request rate alert
+The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is above this threshold, then that means there is a large spike in traffic which logs can help diagnose if these are nefarious requests.
+
+The `"thresholdValue"` can be adjusted based adjusted depending on what is considered to be a high request rate.
+
+## High server error rate alert
+The server error rate is derived from processing access logs status code. The server error rate value is the number of 5xx status codes / total status codes per 5 minutes. When the server error rate spikes suddenly, then you have a high priority server problem as clients are experiencing 5xx errors and are not being served successfully.
+
+### Prerequisites
+
+The name of the metric should be:
+`couchdb.server.error.count`
+
+The filter for the metric should be:
+```
+logName:"couchdb"
+httpRequest.status >= 500
+```

--- a/alerts/couchdb/couchdb-high-request-rate.json
+++ b/alerts/couchdb/couchdb-high-request-rate.json
@@ -1,0 +1,42 @@
+{
+  "displayName": "Couchdb - high request rate",
+  "documentation": {
+    "content": "The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is above this threshold, then that means there is a large spike in traffic which logs can help diagnose if these are nefarious requests.",
+    "mimeType": "text/markdown"
+},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/couchdb.httpd.requests",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_RATE"
+          },
+          {
+            "alignmentPeriod": "300s",
+            "crossSeriesReducer": "REDUCE_SUM",
+            "groupByFields": [
+              "resource.label.instance_id"
+            ],
+            "perSeriesAligner": "ALIGN_SUM"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/couchdb.httpd.requests\"",
+        "thresholdValue": 100,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/couchdb/couchdb-high-request-rate.json
+++ b/alerts/couchdb/couchdb-high-request-rate.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Couchdb - high request rate",
   "documentation": {
-    "content": "The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is above this threshold, then that means there is a large spike in traffic which logs can help diagnose if these are nefarious requests.",
+    "content": "The request rate is derived from the requests metrics taken as a rate of every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is above this threshold, then that means there is a large spike in traffic which logs can help diagnose if these are nefarious requests.",
     "mimeType": "text/markdown"
 },
   "userLabels": {},

--- a/alerts/couchdb/couchdb-high-server-error-rate.json
+++ b/alerts/couchdb/couchdb-high-server-error-rate.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "Couchdb - high server error rate",
+  "documentation": {
+    "content": "The server error rate is derived from processing access logs status code. The server error rate value is the number of 5xx status codes / total status codes per 5 minutes. When the server error rate spikes suddenly, then you have a high priority server problem as clients are experiencing 5xx errors and are not being served successfully.",
+    "mimeType": "text/markdown"
+},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "New condition",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "crossSeriesReducer": "REDUCE_SUM",
+            "perSeriesAligner": "ALIGN_RATE"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "metric.type=\"logging.googleapis.com/user/couchdb.server.error.count\"",
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/couchdb/couchdb-high-server-error-rate.json
+++ b/alerts/couchdb/couchdb-high-server-error-rate.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Couchdb - high server error rate",
   "documentation": {
-    "content": "The server error rate is derived from processing access logs status code. The server error rate value is the number of 5xx status codes / total status codes per 5 minutes. When the server error rate spikes suddenly, then you have a high priority server problem as clients are experiencing 5xx errors and are not being served successfully.",
+    "content": "The server error rate is derived from processing access logs status code. The server error rate value is the number of 5xx status codes per 5 minute window. When the server error rate spikes suddenly, then you have a high priority server problem as backends are experiencing 5xx errors and clients are not being served successfully.",
     "mimeType": "text/markdown"
 },
   "userLabels": {},

--- a/alerts/couchdb/couchdb-high-server-error-rate.json
+++ b/alerts/couchdb/couchdb-high-server-error-rate.json
@@ -18,7 +18,7 @@
         ],
         "comparison": "COMPARISON_GT",
         "duration": "0s",
-        "filter": "metric.type=\"logging.googleapis.com/user/couchdb.server.error.count\"",
+        "filter": "resource.type = \"gce_instance\" AND metric.type=\"logging.googleapis.com/user/couchdb.server.error.count\"",
         "trigger": {
           "count": 1
         }

--- a/alerts/couchdb/couchdb-low-request-rate.json
+++ b/alerts/couchdb/couchdb-low-request-rate.json
@@ -1,0 +1,42 @@
+{
+  "displayName": "Couchdb - low request rate",
+  "documentation": {
+    "content": "The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is below this threshold, then that means there is an environment problem that are limiting the request rates.",
+    "mimeType": "text/markdown"
+},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/couchdb.httpd.requests",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_RATE"
+          },
+          {
+            "alignmentPeriod": "300s",
+            "crossSeriesReducer": "REDUCE_SUM",
+            "groupByFields": [
+              "resource.label.instance_id"
+            ],
+            "perSeriesAligner": "ALIGN_SUM"
+          }
+        ],
+        "comparison": "COMPARISON_LT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/couchdb.httpd.requests\"",
+        "thresholdValue": 10,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/couchdb/couchdb-low-request-rate.json
+++ b/alerts/couchdb/couchdb-low-request-rate.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Couchdb - low request rate",
   "documentation": {
-    "content": "The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is below this threshold, then that means there is an environment problem that are limiting the request rates.",
+    "content": "The request rate is derived from the requests metrics taken as a rate of every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is below this threshold, then that means there is an environment problem that are limiting the request rates.",
     "mimeType": "text/markdown"
 },
   "userLabels": {},


### PR DESCRIPTION
Intending to add these alerts:

## High request rate alert
The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is above this threshold, then that means there is a large spike in traffic which logs can help diagnose if these are nefarious requests.

The `"thresholdValue"` can be adjusted based adjusted depending on what is considered to be a high request rate.

## Low request rate alert
The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is below this threshold, then that means there is an environment problem that are limiting the request rates.

The "thresholdValue" can be adjusted based adjusted depending on what is considered to be a low request rate.

## High server error rate alert
The server error rate is derived from processing access logs status code. The server error rate value is the number of 5xx status codes / total status codes per 5 minutes. When the server error rate spikes suddenly, then you have a high priority server problem as clients are experiencing 5xx errors and are not being served successfully.
