### PR TITLE
Add Ops agent Hadoop alert polices

### DIFF
--- a/alerts/hadoop/README.md
+++ b/alerts/hadoop/README.md
@@ -1,5 +1,14 @@
 # Alerts for Hadoop in the Ops Agent
 
+## Low available capacity alert
+A low available capacity means that the total disk space usage across all HDFS clusters is over 80% of the capacity limit and therefore the capacity limit should be increased.
+
+## Volume failure alert
+A failed volume means a hardware failure has occurred. With replication, no data should be lost, but the failed hardware should be replaced.
+
+## Dead data nodes alert
+A dead data node can cause network activity problems as the NameNode initiates replication of blocks lost on the data nodes. When multiple data nodes are lost, data loss can occur.
+
 ### Notification Channels
 For all alerts, a notification channel needs to be set up or the alert will fire silently.
 
@@ -13,12 +22,3 @@ User labels can be used for these policies by modifying the userLabels fields of
   }
 }
 ```
-
-## Low available capacity alert
-A low available capacity means that the total available disk space capacity across all HDFS clusters is low and should be increased.
-
-## Volume failure alert
-A failed volume means a hardware failure has occurred. With replication, no data should be lost, but the failed hardware should be replaced.
-
-## Dead data nodes alert
-A dead data node can cause network activity problems as the NameNode initiates replication of blocks lost on the data nodes.When multiple data nodes are lost, data loss can occur.

--- a/alerts/hadoop/README.md
+++ b/alerts/hadoop/README.md
@@ -1,0 +1,24 @@
+# Alerts for Hadoop in the Ops Agent
+
+### Notification Channels
+For all alerts, a notification channel needs to be set up or the alert will fire silently.
+
+### User Labels
+User labels can be used for these policies by modifying the userLabels fields of the policies. i.e.
+
+```json
+{ 
+  "userLabels": {
+    "datacenter": "central"
+  }
+}
+```
+
+## Low available capacity alert
+A low available capacity means that the total available disk space capacity across all HDFS clusters is low and should be increased.
+
+## Volume failure alert
+A failed volume means a hardware failure has occurred. With replication, no data should be lost, but the failed hardware should be replaced.
+
+## Dead data nodes alert
+A dead data node can cause network activity problems as the NameNode initiates replication of blocks lost on the data nodes.When multiple data nodes are lost, data loss can occur.

--- a/alerts/hadoop/hadoop-dead-data-nodes.json
+++ b/alerts/hadoop/hadoop-dead-data-nodes.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "hadoop - dead data nodes",
+  "documentation": {
+    "content": "A dead data node can cause network activity problems as the NameNode initiates replication of blocks lost on the data nodes.When multiple data nodes are lost, data loss can occur.",
+    "mimeType": "text/markdown"
+},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/hadoop.name_node.data_node.count",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_MEAN"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/hadoop.name_node.data_node.count\" AND metric.labels.state = \"dead\"",
+        "thresholdValue": 5,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/hadoop/hadoop-low-available-capacity.json
+++ b/alerts/hadoop/hadoop-low-available-capacity.json
@@ -1,0 +1,26 @@
+{
+  "displayName": "hadoop - low available capacity",
+  "documentation": {
+    "content": "A low available capacity means that the total available disk space capacity across all HDFS clusters is low and should be increased.",
+    "mimeType": "text/markdown"
+},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/hadoop.name_node.capacity.usage",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "0s",
+        "query": "fetch gce_instance\n| { \n    t_0: metric workload.googleapis.com/hadoop.name_node.capacity.usage;\n    t_1: metric workload.googleapis.com/hadoop.name_node.capacity.limit\n}\n| outer_join 0\n| value val(0) / val(1)\n| condition val() > .80\n| every 5m\n| window 5m",
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/hadoop/hadoop-low-available-capacity.json
+++ b/alerts/hadoop/hadoop-low-available-capacity.json
@@ -1,7 +1,7 @@
 {
   "displayName": "hadoop - low available capacity",
   "documentation": {
-    "content": "A low available capacity means that the total available disk space capacity across all HDFS clusters is low and should be increased.",
+    "content": "A low available capacity means that the total disk space usage across all HDFS clusters is over 80% of the capacity limit and therefore the capacity limit should be increased.",
     "mimeType": "text/markdown"
 },
   "userLabels": {},

--- a/alerts/hadoop/hadoop-volume-failure.json
+++ b/alerts/hadoop/hadoop-volume-failure.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "hadoop - volume failure",
+  "documentation": {
+    "content": "A failed volume means a hardware failure has occurred. With replication, no data should be lost, but the failed hardware should be replaced.",
+    "mimeType": "text/markdown"
+},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/hadoop.name_node.volume.failed",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_MEAN"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/hadoop.name_node.volume.failed\"",
+        "thresholdValue": 1,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}


### PR DESCRIPTION
Intending to add these alerts:

## Low available capacity alert
A low available capacity means that the total available disk space capacity across all HDFS clusters is low and should be increased.

## Volume failure alert
A failed volume means a hardware failure has occurred. With replication, no data should be lost, but the failed hardware should be replaced.

## Dead data nodes alert
A dead data node can cause network activity problems as the NameNode initiates replication of blocks lost on the data nodes.When multiple data nodes are lost, data loss can occur.
