### PR TITLE
Add Ops agent Elasticsearch alert polices

### DIFF
--- a/alerts/elasticsearch/README.md
+++ b/alerts/elasticsearch/README.md
@@ -1,0 +1,24 @@
+# Elasticsearch Alerts for Ops Agent
+
+### Notification Channels
+For all alerts, a notification channel needs to be set up or the alert will fire silently.
+
+### User Labels
+User labels can be used for these policies by modifying the userLabels fields of the policies. i.e.
+
+```json
+{ 
+  "userLabels": {
+    "datacenter": "central"
+  }
+}
+```
+
+## Yellow cluster status alert
+When red cluster status duration exceeds 5 minute, at least one replica shard is unallocated or missing.
+
+## Red cluster status alert
+When red cluster status duration is exceeds minute, at least one primary shard is missing, and you are missing data.
+
+## High jvm memory heap usage alert
+When the jvm heap ratio of heap used over max heap exceeds a threshold, then application's performance may start to degrade.

--- a/alerts/elasticsearch/README.md
+++ b/alerts/elasticsearch/README.md
@@ -18,7 +18,7 @@ User labels can be used for these policies by modifying the userLabels fields of
 When red cluster status duration exceeds 5 minute, at least one replica shard is unallocated or missing.
 
 ## Red cluster status alert
-When red cluster status duration is exceeds minute, at least one primary shard is missing, and you are missing data.
+When red cluster status duration is exceeds 1 minute, at least one primary shard is missing, and data is missing.
 
-## High jvm memory heap usage alert
-When the jvm heap ratio of heap used over max heap exceeds a threshold, then application's performance may start to degrade.
+## High JVM memory heap usage alert
+When the JVM heap ratio of heap used over max heap exceeds a threshold, then application's performance may start to degrade.

--- a/alerts/elasticsearch/README.md
+++ b/alerts/elasticsearch/README.md
@@ -1,5 +1,14 @@
 # Elasticsearch Alerts for Ops Agent
 
+## Yellow cluster status alert
+When red cluster status duration exceeds 5 minute, at least one replica shard is unallocated or missing.
+
+## Red cluster status alert
+When red cluster status duration is exceeds 1 minute, at least one primary shard is missing, and data is missing.
+
+## High JVM memory heap usage alert
+When the JVM heap ratio of heap used over max heap exceeds a threshold, then application's performance may start to degrade.
+
 ### Notification Channels
 For all alerts, a notification channel needs to be set up or the alert will fire silently.
 
@@ -13,12 +22,3 @@ User labels can be used for these policies by modifying the userLabels fields of
   }
 }
 ```
-
-## Yellow cluster status alert
-When red cluster status duration exceeds 5 minute, at least one replica shard is unallocated or missing.
-
-## Red cluster status alert
-When red cluster status duration is exceeds 1 minute, at least one primary shard is missing, and data is missing.
-
-## High JVM memory heap usage alert
-When the JVM heap ratio of heap used over max heap exceeds a threshold, then application's performance may start to degrade.

--- a/alerts/elasticsearch/elasticsearch-high-jvm-memory-usage.json
+++ b/alerts/elasticsearch/elasticsearch-high-jvm-memory-usage.json
@@ -1,0 +1,26 @@
+{
+  "displayName": "Elasticsearch - high jvm memory usage",
+  "documentation": {
+    "content": "When the jvm heap ratio of heap used over max heap exceeds a threshold, then application's performance may start to degrade.",
+    "mimeType": "text/markdown"
+},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/jvm.memory.heap.used",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "0s",
+        "query": "fetch gce_instance\n| { \nt_0: metric 'workload.googleapis.com/jvm.memory.heap.used';\nt_1: metric 'workload.googleapis.com/jvm.memory.heap.max'\n}\n| outer_join 0\n| value t_0.value.used / t_1.value.max\n| condition val() > .9\n| every 5m\n| window 5m\n",
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/elasticsearch/elasticsearch-high-jvm-memory-usage.json
+++ b/alerts/elasticsearch/elasticsearch-high-jvm-memory-usage.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Elasticsearch - high jvm memory usage",
   "documentation": {
-    "content": "When the jvm heap ratio of heap used over max heap exceeds a threshold, then application's performance may start to degrade.",
+    "content": "When the JVM heap ratio of heap used over max heap exceeds a threshold, then application's performance may start to degrade.",
     "mimeType": "text/markdown"
 },
   "userLabels": {},

--- a/alerts/elasticsearch/elasticsearch-red-cluster-status.json
+++ b/alerts/elasticsearch/elasticsearch-red-cluster-status.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "Elasticsearch - red cluster status",
+  "documentation": {
+    "content": "When red cluster status duration is exceeds minute, at least one primary shard is missing, and you are missing data.",
+    "mimeType": "text/markdown"
+},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/elasticsearch.cluster.health",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "60s",
+            "perSeriesAligner": "ALIGN_MEAN"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/elasticsearch.cluster.health\" AND metric.labels.status = \"red\"",
+        "thresholdValue": 1,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/elasticsearch/elasticsearch-red-cluster-status.json
+++ b/alerts/elasticsearch/elasticsearch-red-cluster-status.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Elasticsearch - red cluster status",
   "documentation": {
-    "content": "When red cluster status duration is exceeds minute, at least one primary shard is missing, and you are missing data.",
+    "content": "When red cluster status duration is exceeds 1 minute, at least one primary shard is missing, and data is missing.",
     "mimeType": "text/markdown"
 },
   "userLabels": {},

--- a/alerts/elasticsearch/elasticsearch-yellow-cluster-status.json
+++ b/alerts/elasticsearch/elasticsearch-yellow-cluster-status.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "Elasticsearch - yellow cluster status",
+  "documentation": {
+    "content": "When red cluster status duration exceeds 5 minute, at least one replica shard is unallocated or missing.",
+    "mimeType": "text/markdown"
+},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/elasticsearch.cluster.health",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_MEAN"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/elasticsearch.cluster.health\" AND metric.labels.status = \"yellow\"",
+        "thresholdValue": 1,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}


### PR DESCRIPTION
Intending to add these alerts:

## Yellow cluster status alert
When red cluster status duration exceeds 5 minute, at least one replica shard is unallocated or missing.

## Red cluster status alert
When red cluster status duration is exceeds minute, at least one primary shard is missing, and you are missing data.

## High jvm memory heap usage alert
When the jvm heap ratio of heap used over max heap exceeds a threshold, then application's performance may start to degrade.
