### PR TITLE
Add Ops agent RabbitMQ alert polices 

### DIFF
--- a/alerts/rabbitmq/README.md
+++ b/alerts/rabbitmq/README.md
@@ -1,0 +1,24 @@
+# RabbitMQ Alerts for Ops Agent
+
+### Notification Channels
+For all alerts, a notification channel needs to be set up or the alert will fire silently.
+
+### User Labels
+User labels can be used for these policies by modifying the userLabels fields of the policies. i.e.
+
+```json
+{ 
+  "userLabels": {
+    "datacenter": "central"
+  }
+}
+```
+
+## High unacknowledged messages alert
+When the message unacknowledged mean is higher than a threshold, then errors or performance issues may arise.
+
+## High unroutable messages alert
+When the unroutable message rate is greater than a threshold, then the consumers are not getting every message.
+
+## Low deliverable messages alert
+When the deliverable message rate are lower than a threshold, then there may be an issue with a producer or routing logic.

--- a/alerts/rabbitmq/README.md
+++ b/alerts/rabbitmq/README.md
@@ -21,4 +21,4 @@ When the message unacknowledged mean is higher than a threshold, then errors or 
 When the unroutable message rate is greater than a threshold, then the consumers are not getting every message.
 
 ## Low deliverable messages alert
-When the deliverable message rate are lower than a threshold, then there may be an issue with a producer or routing logic.
+When the deliverable message rate is lower than a threshold, then there may be an issue with a producer or routing logic.

--- a/alerts/rabbitmq/README.md
+++ b/alerts/rabbitmq/README.md
@@ -1,5 +1,14 @@
 # RabbitMQ Alerts for Ops Agent
 
+## High unacknowledged messages alert
+When the message unacknowledged mean is higher than a threshold, then errors or performance issues may arise.
+
+## High unroutable messages alert
+When the unroutable message rate is greater than a threshold, then the consumers are not getting every message.
+
+## Low deliverable messages alert
+When the deliverable message rate is lower than a threshold, then there may be an issue with a producer or routing logic.
+
 ### Notification Channels
 For all alerts, a notification channel needs to be set up or the alert will fire silently.
 
@@ -13,12 +22,3 @@ User labels can be used for these policies by modifying the userLabels fields of
   }
 }
 ```
-
-## High unacknowledged messages alert
-When the message unacknowledged mean is higher than a threshold, then errors or performance issues may arise.
-
-## High unroutable messages alert
-When the unroutable message rate is greater than a threshold, then the consumers are not getting every message.
-
-## Low deliverable messages alert
-When the deliverable message rate is lower than a threshold, then there may be an issue with a producer or routing logic.

--- a/alerts/rabbitmq/rabbitmq-high-unacknowledged-messages.json
+++ b/alerts/rabbitmq/rabbitmq-high-unacknowledged-messages.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "Rabbitmq - high unacknowledged messages",
+  "documentation": {
+    "content": "When the message unacknowledged rate is higher than a threshold, then errors or performance issues may arise.",
+    "mimeType": "text/markdown"
+},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/rabbitmq.message.current",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_MEAN"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/rabbitmq.message.current\" AND metadata.system_labels.state = \" unacknowledged\"",
+        "thresholdValue": 5,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/rabbitmq/rabbitmq-high-unroutable-messages.json
+++ b/alerts/rabbitmq/rabbitmq-high-unroutable-messages.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "Rabbitmq - high unroutable messages",
+  "documentation": {
+    "content": "When the unroutable message count is greater than a threshold, that means consumers are not getting every message.",
+    "mimeType": "text/markdown"
+},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload.googleapis.com/rabbitmq.message.dropped",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_RATE"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/rabbitmq.message.dropped\"",
+        "thresholdValue": 1,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/rabbitmq/rabbitmq-low-deliverable-messages alert.json
+++ b/alerts/rabbitmq/rabbitmq-low-deliverable-messages alert.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Rabbitmq - low deliverable messages alert",
   "documentation": {
-    "content": "When the deliverable message rate are lower than a threshold, then there may be an issue with a producer or routing logic.",
+    "content": "When the deliverable message rate is lower than a threshold, then there may be an issue with a producer or routing logic.",
     "mimeType": "text/markdown"
 },
   "userLabels": {},

--- a/alerts/rabbitmq/rabbitmq-low-deliverable-messages alert.json
+++ b/alerts/rabbitmq/rabbitmq-low-deliverable-messages alert.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "Rabbitmq - low deliverable messages alert",
+  "documentation": {
+    "content": "When the deliverable message rate are lower than a threshold, then there may be an issue with a producer or routing logic.",
+    "mimeType": "text/markdown"
+},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/rabbitmq.message.delivered",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_RATE"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/rabbitmq.message.delivered\"",
+        "thresholdValue": 1,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}


### PR DESCRIPTION
Intending to add these alerts:

## High unacknowledged messages alert
When the message unacknowledged mean is higher than a threshold, then errors or performance issues may arise.

## High unroutable messages alert
When the unroutable message rate is greater than a threshold, then the consumers are not getting every message.

## Low deliverable messages alert
When the deliverable message rate are lower than a threshold, then there may be an issue with a producer or routing logic.
