### PR TITLE
Add couchbase alerts

### DIFF
--- a/alerts/couchbase/README.md
+++ b/alerts/couchbase/README.md
@@ -30,7 +30,7 @@ i.e.
 
 #### Notification Channels
 
-The ID of the notification channel to be notifed.
+The ID of the notification channel to be notified.
 
 ```json
     "notificationChannels": [

--- a/alerts/couchbase/README.md
+++ b/alerts/couchbase/README.md
@@ -2,17 +2,17 @@
 
 ## Spiking Evictions
 
-if ‘bucket.item.ejection.count’ begins to spike by 10 or a user defined threshold it could show that there is unexpected memory pressure.
+If ‘bucket.item.ejection.count’ begins to spike this could indicate that there is unexpected memory pressure. The default threshold is set to 10 for the alert policy and this can be customized for your environment.
 
 ## Unrecoverable OOM Errors
 
-if `bucket.error.oom.count` that are `unrecoverable` increase above 0 should be a cause for concern
+If `bucket.error.oom.count` that are `unrecoverable` increase above 0 should be a cause for concern because it implies the couchbase server is either underprovisioned or an application is over-utilizing the couchbase server.
 
 ## High Memory Usage
 
-if `bucket.memory.usage` bytes is higher than what is anticipated it could show that the bucket needs to be allocated more. Subjective to environment, configure threshold knowingly.
+If `bucket.memory.usage` bytes is higher than what is anticipated it could show that the bucket needs to be allocated more. Subjective to environment and this alert can be customized for your environment.
 
-### Creating notification Channels and User Labels
+### Creating Notification Channels and User Labels
 
 Whether these alert policies are being used as standalones or base templates for a deployment strategy like terraform, one thing that should be utilized is notification channels and user labels.
 

--- a/alerts/couchbase/README.md
+++ b/alerts/couchbase/README.md
@@ -1,0 +1,39 @@
+# Alerts for Couchbase in the Ops Agent
+
+## Spiking Evictions
+
+if ‘bucket.item.ejection.count’ begins to spike by 10 or a user defined threshold it could show that there is unexpected memory pressure.
+
+## Unrecoverable OOM Errors
+
+if `bucket.error.oom.count` that are `unrecoverable` increase above 0 should be a cause for concern
+
+## High Memory Usage
+
+if `bucket.memory.usage` bytes is higher than what is anticipated it could show that the bucket needs to be allocated more. Subjective to environment, configure threshold knowingly.
+
+### Creating notification Channels and User Labels
+
+Whether these alert policies are being used as standalones or base templates for a deployment strategy like terraform, one thing that should be utilized is notification channels and user labels.
+
+### User Labels
+
+Supplying user labels could give extra identification information about the firing alert:
+
+i.e.
+
+```json
+    "userLabels": {
+        "datacenter": "central"
+    }
+```
+
+#### Notification Channels
+
+The ID of the notification channel to be notifed.
+
+```json
+    "notificationChannels": [
+        "projects/project-id/notificationChannels/1234567
+    ]
+```

--- a/alerts/couchbase/high-memory-usage.json
+++ b/alerts/couchbase/high-memory-usage.json
@@ -18,8 +18,7 @@
                     }
                 ],
                 "comparison": "COMPARISON_GT",
-                "duration": "1m",
-                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
+                "duration": "0s",
                 "trigger": {
                     "count": 1
                 },

--- a/alerts/couchbase/high-memory-usage.json
+++ b/alerts/couchbase/high-memory-usage.json
@@ -1,7 +1,7 @@
 {
     "displayName": "Couchbase - High Bucket Memory Usage",
     "documentation": {
-        "content": "if `bucket.memory.usage` bytes is higher than what is anticipated it could show that the bucket needs to be allocated more .",
+        "content": "If `bucket.memory.usage` bytes is higher than what is anticipated it could show that the bucket needs to be allocated more. Subjective to environment and this alert can be customized for your environment.",
         "mimeType": "text/markdown"
     },
     "userLabels": {},

--- a/alerts/couchbase/high-memory-usage.json
+++ b/alerts/couchbase/high-memory-usage.json
@@ -18,7 +18,7 @@
                     }
                 ],
                 "comparison": "COMPARISON_GT",
-                "duration": "30s",
+                "duration": "1m",
                 "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
                 "trigger": {
                     "count": 1

--- a/alerts/couchbase/high-memory-usage.json
+++ b/alerts/couchbase/high-memory-usage.json
@@ -18,7 +18,7 @@
                     }
                 ],
                 "comparison": "COMPARISON_GT",
-                "duration": "0s",
+                "duration": "30s",
                 "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
                 "trigger": {
                     "count": 1

--- a/alerts/couchbase/high-memory-usage.json
+++ b/alerts/couchbase/high-memory-usage.json
@@ -1,0 +1,36 @@
+{
+    "displayName": "Couchbase - High Bucket Memory Usage",
+    "documentation": {
+        "content": "if `bucket.memory.usage` bytes is higher than what is anticipated it could show that the bucket needs to be allocated more .",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "VM Instance - workload/couchbase.bucket.item.ejection.count",
+            "conditionThreshold": {
+                "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/couchbase.bucket.memory.usage\"",
+                "aggregations": [
+                    {
+                        "alignmentPeriod": "300s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                ],
+                "comparison": "COMPARISON_GT",
+                "duration": "0s",
+                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
+                "trigger": {
+                    "count": 1
+                },
+                "thresholdValue": 5000000000
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "3600s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}

--- a/alerts/couchbase/spiking-evictions.json
+++ b/alerts/couchbase/spiking-evictions.json
@@ -1,7 +1,7 @@
 {
     "displayName": "Couchbase - Spiking Ejections",
     "documentation": {
-        "content": " if `bucket.error.oom.count` that are `unrecoverable` increase above 0 should be a cause for concern.",
+        "content": "If `bucket.item.ejection.count` begins to spike this could indicate that there is unexpected memory pressure. The default threshold is set to 10 for the alert policy and this can be customized for your environment.",
         "mimeType": "text/markdown"
     },
     "userLabels": {},

--- a/alerts/couchbase/spiking-evictions.json
+++ b/alerts/couchbase/spiking-evictions.json
@@ -18,7 +18,7 @@
                     }
                 ],
                 "comparison": "COMPARISON_GT",
-                "duration": "30s",
+                "duration": "1m",
                 "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
                 "trigger": {
                     "count": 1

--- a/alerts/couchbase/spiking-evictions.json
+++ b/alerts/couchbase/spiking-evictions.json
@@ -14,12 +14,11 @@
                     {
                         "alignmentPeriod": "300s",
                         "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_MEAN"
+                        "perSeriesAligner": "ALIGN_RATE"
                     }
                 ],
                 "comparison": "COMPARISON_GT",
-                "duration": "1m",
-                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
+                "duration": "0s",
                 "trigger": {
                     "count": 1
                 },

--- a/alerts/couchbase/spiking-evictions.json
+++ b/alerts/couchbase/spiking-evictions.json
@@ -1,0 +1,36 @@
+{
+    "displayName": "Couchbase - Spiking Ejections",
+    "documentation": {
+        "content": " if `bucket.error.oom.count` that are `unrecoverable` increase above 0 should be a cause for concern.",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "VM Instance - workload/couchbase.bucket.item.ejection.count",
+            "conditionThreshold": {
+                "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/couchbase.bucket.item.ejection.count\"",
+                "aggregations": [
+                    {
+                        "alignmentPeriod": "300s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                ],
+                "comparison": "COMPARISON_GT",
+                "duration": "0s",
+                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
+                "trigger": {
+                    "count": 1
+                },
+                "thresholdValue": 10
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "3600s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}

--- a/alerts/couchbase/spiking-evictions.json
+++ b/alerts/couchbase/spiking-evictions.json
@@ -18,7 +18,7 @@
                     }
                 ],
                 "comparison": "COMPARISON_GT",
-                "duration": "0s",
+                "duration": "30s",
                 "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
                 "trigger": {
                     "count": 1

--- a/alerts/couchbase/unrecoverable-oom-errors.json
+++ b/alerts/couchbase/unrecoverable-oom-errors.json
@@ -18,8 +18,7 @@
                     }
                 ],
                 "comparison": "COMPARISON_GT",
-                "duration": "1m",
-                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
+                "duration": "0s",
                 "trigger": {
                     "count": 1
                 },

--- a/alerts/couchbase/unrecoverable-oom-errors.json
+++ b/alerts/couchbase/unrecoverable-oom-errors.json
@@ -18,7 +18,7 @@
                     }
                 ],
                 "comparison": "COMPARISON_GT",
-                "duration": "30s",
+                "duration": "1m",
                 "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
                 "trigger": {
                     "count": 1

--- a/alerts/couchbase/unrecoverable-oom-errors.json
+++ b/alerts/couchbase/unrecoverable-oom-errors.json
@@ -1,0 +1,36 @@
+{
+    "displayName": "Couchbase - Unrecoverable OOM Errors",
+    "documentation": {
+        "content": " if `bucket.error.oom.count` that are `unrecoverable` increase above 0 should be a cause for concern.",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "VM Instance - workload/couchbase.bucket.oom.count",
+            "conditionThreshold": {
+                "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/couchbase.bucket.oom.count\" AND metric.labels.error_type = \"unrecoverable\"",
+                "aggregations": [
+                    {
+                        "alignmentPeriod": "300s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                ],
+                "comparison": "COMPARISON_GT",
+                "duration": "0s",
+                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
+                "trigger": {
+                    "count": 1
+                },
+                "thresholdValue": 1
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "3600s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}

--- a/alerts/couchbase/unrecoverable-oom-errors.json
+++ b/alerts/couchbase/unrecoverable-oom-errors.json
@@ -18,7 +18,7 @@
                     }
                 ],
                 "comparison": "COMPARISON_GT",
-                "duration": "0s",
+                "duration": "30s",
                 "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
                 "trigger": {
                     "count": 1

--- a/alerts/couchbase/unrecoverable-oom-errors.json
+++ b/alerts/couchbase/unrecoverable-oom-errors.json
@@ -1,7 +1,7 @@
 {
     "displayName": "Couchbase - Unrecoverable OOM Errors",
     "documentation": {
-        "content": " if `bucket.error.oom.count` that are `unrecoverable` increase above 0 should be a cause for concern.",
+        "content": "If `bucket.error.oom.count` that are `unrecoverable` increase above 0 should be a cause for concern because it implies the couchbase server is either underprovisioned or an application is over-utilizing the couchbase server.",
         "mimeType": "text/markdown"
     },
     "userLabels": {},


### PR DESCRIPTION
# Alerts for Couchbase in the Ops Agent

## Spiking Evictions

if ‘bucket.item.ejection.count’ begins to spike by 10 or a user defined threshold it could show that there is unexpected memory pressure.

## Unrecoverable OOM Errors

if `bucket.error.oom.count` that are `unrecoverable` increase above 0 should be a cause for concern

## High Memory Usage

if `bucket.memory.usage` bytes is higher than what is anticipated it could show that the bucket needs to be allocated more. Subjective to environment, configure threshold knowingly.
