### PR TITLE
Add Ops agent Tomcat alert polices

### DIFF
--- a/alerts/tomcat/README.md
+++ b/alerts/tomcat/README.md
@@ -1,19 +1,5 @@
 # Alerts for Tomcat in the Ops Agent
 
-### Notification Channels
-For all alerts, a notification channel needs to be set up or the alert will fire silently.
-
-### User Labels
-User labels can be used for these policies by modifying the userLabels fields of the policies. i.e.
-
-```json
-{ 
-  "userLabels": {
-    "datacenter": "central"
-  }
-}
-```
-
 ## High request rate alert
 The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is above this threshold, then that means there is a large spike in traffic which logs can help diagnose if these are nefarious requests.
 
@@ -36,4 +22,18 @@ The filter for the metric should be:
 ```
 logName:"tomcat_access"
 httpRequest.status >= 500
+```
+
+### Notification Channels
+For all alerts, a notification channel needs to be set up or the alert will fire silently.
+
+### User Labels
+User labels can be used for these policies by modifying the userLabels fields of the policies. i.e.
+
+```json
+{ 
+  "userLabels": {
+    "datacenter": "central"
+  }
+}
 ```

--- a/alerts/tomcat/README.md
+++ b/alerts/tomcat/README.md
@@ -1,0 +1,39 @@
+# Alerts for Tomcat in the Ops Agent
+
+### Notification Channels
+For all alerts, a notification channel needs to be set up or the alert will fire silently.
+
+### User Labels
+User labels can be used for these policies by modifying the userLabels fields of the policies. i.e.
+
+```json
+{ 
+  "userLabels": {
+    "datacenter": "central"
+  }
+}
+```
+
+## High request rate alert
+The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is above this threshold, then that means there is a large spike in traffic which logs can help diagnose if these are nefarious requests.
+
+The `"thresholdValue"` can be adjusted based adjusted depending on what is considered to be a high request rate.
+
+## Low request rate alert
+The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is below this threshold, then that means there is an environment problem that are limiting the request rates.
+
+The `"thresholdValue"` can be adjusted based adjusted depending on what is considered to be a low request rate.
+
+## High server error rate alert
+The server error rate is derived from processing access logs status code. The server error rate value is the number of 5xx status codes per 5 minute window. When the server error rate spikes suddenly, then you have a high priority server problem as backends are experiencing 5xx errors and clients are not being served successfully.
+
+### Prerequisites
+
+The name of the metric should be:
+`tomcat.server.error.count`
+
+The filter for the metric should be:
+```
+logName:"tomcat_access"
+httpRequest.status >= 500
+```

--- a/alerts/tomcat/README.md
+++ b/alerts/tomcat/README.md
@@ -17,12 +17,12 @@ User labels can be used for these policies by modifying the userLabels fields of
 ## High request rate alert
 The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is above this threshold, then that means there is a large spike in traffic which logs can help diagnose if these are nefarious requests.
 
-The `"thresholdValue"` can be adjusted based adjusted depending on what is considered to be a high request rate.
+The `"thresholdValue"` can be adjusted depending on what is considered to be a high request rate.
 
 ## Low request rate alert
 The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is below this threshold, then that means there is an environment problem that are limiting the request rates.
 
-The `"thresholdValue"` can be adjusted based adjusted depending on what is considered to be a low request rate.
+The `"thresholdValue"` can be adjusted depending on what is considered to be a low request rate.
 
 ## High server error rate alert
 The server error rate is derived from processing access logs status code. The server error rate value is the number of 5xx status codes per 5 minute window. When the server error rate spikes suddenly, then you have a high priority server problem as backends are experiencing 5xx errors and clients are not being served successfully.

--- a/alerts/tomcat/tomcat-high-request-rate.json
+++ b/alerts/tomcat/tomcat-high-request-rate.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "Tomcat - high request rate",
+  "documentation": {
+    "content": "The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is above this threshold, then that means there is a large spike in traffic which logs can help diagnose if these are nefarious requests.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/tomcat.request_count",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_RATE"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/tomcat.request_count\"",
+        "thresholdValue": 100,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/tomcat/tomcat-high-server-error-rate.json
+++ b/alerts/tomcat/tomcat-high-server-error-rate.json
@@ -1,0 +1,35 @@
+{
+  "displayName": "Tomcat - high server error rate",
+  "documentation": {
+    "content": "The server error rate is derived from processing access logs status code. The server error rate value is the number of 5xx status codes per 5 minute window. When the server error rate spikes suddenly, then you have a high priority server problem as backends are experiencing 5xx errors and clients are not being served successfully.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "http request >= 500",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "crossSeriesReducer": "REDUCE_SUM",
+            "perSeriesAligner": "ALIGN_RATE"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "metric.type=\"logging.googleapis.com/user/tomcat.server.error.count\"",
+        "thresholdValue": 1,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/tomcat/tomcat-high-server-error-rate.json
+++ b/alerts/tomcat/tomcat-high-server-error-rate.json
@@ -18,7 +18,7 @@
         ],
         "comparison": "COMPARISON_GT",
         "duration": "0s",
-        "filter": "metric.type=\"logging.googleapis.com/user/tomcat.server.error.count\"",
+        "filter": "resource.type = \"gce_instance\" AND metric.type=\"logging.googleapis.com/user/tomcat.server.error.count\"",
         "thresholdValue": 1,
         "trigger": {
           "count": 1

--- a/alerts/tomcat/tomcat-low-request-rate.json
+++ b/alerts/tomcat/tomcat-low-request-rate.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "Tomcat - low request rate",
+  "documentation": {
+    "content": "The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is above this threshold, then that means there is a large spike in traffic which logs can help diagnose if these are nefarious requests.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/tomcat.request_count",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_RATE"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/tomcat.request_count\"",
+        "thresholdValue": 10,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}


### PR DESCRIPTION
Intending to add these alerts:

## High request rate alert
The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is above this threshold, then that means there is a large spike in traffic which logs can help diagnose if these are nefarious requests.

## Low request rate alert
The request rate is derived from the requests metrics taken as a rate every 5 minutes. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When request rate is below this threshold, then that means there is an environment problem that are limiting the request rates.

## High server error rate alert
The server error rate is derived from processing access logs status code. The server error rate value is the number of 5xx status codes per 5 minute window. When the server error rate spikes suddenly, then you have a high priority server problem as backends are experiencing 5xx errors and clients are not being served successfully.