### PR TITLE
MongoDB Ops Agent Alerts

### DIFF
--- a/alerts/mongodb/README.md
+++ b/alerts/mongodb/README.md
@@ -30,7 +30,7 @@ i.e.
 
 #### Notification Channels
 
-The ID of the notification channel to be notifed.
+The ID of the notification channel to be notified.
 
 ```json
     "notificationChannels": [

--- a/alerts/mongodb/README.md
+++ b/alerts/mongodb/README.md
@@ -1,0 +1,39 @@
+# Alerts for MongoDB in Ops Agent
+
+## Connections Near Max
+
+If connections are approaching the limit, then new connections cannot be established. By default the mongod rejects connections at around 52000. Applications may stop functioning if connections cannot be established.
+
+## High CPU Utilization
+
+If CPU utilization is above 90%, then the MongoDB instance is probably due to be scaled up or needs further investigation.
+
+## High Disk Utilization
+
+If Disk Utilization is above 80%, then it is time to look deeper into adding more storage or cleaning up old docs.
+
+### Creating notification Channels and User Labels
+
+Whether these alert policies are being used as standalones or base templates for a deployment strategy like terraform, one thing that should be utilized is notification channels and user labels.
+
+### User Labels
+
+Supplying user labels could give extra identification information about the firing alert:
+
+i.e.
+
+```json
+    "userLabels": {
+        "datacenter": "central"
+    }
+```
+
+#### Notification Channels
+
+The ID of the notification channel to be notifed.
+
+```json
+    "notificationChannels": [
+        "projects/project-id/notificationChannels/1234567
+    ]
+```

--- a/alerts/mongodb/connection-near-max.json
+++ b/alerts/mongodb/connection-near-max.json
@@ -1,0 +1,34 @@
+{
+    "displayName": "MongoDB - Connection Utilization Near Max",
+    "documentation": {
+        "content": "If connections are approaching the limit, then new connections cannot be established. By default the mongod rejects connections at around 52000. Applications may stop functioning if connections cannot be established.",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "MongoDB - Connections Near Limit",
+            "conditionThreshold": {
+                "aggregations": [
+                    {
+                        "alignmentPeriod": "300s",
+                        "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                ],
+                "comparison": "COMPARISON_GT",
+                "duration": "0s",
+                "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/mongodb.connection.count\" AND metric.labels.type = \"current\"",
+                "thresholdValue": 50000,
+                "trigger": {
+                    "count": 1
+                }
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "3600s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}

--- a/alerts/mongodb/high-cpu-utilization.json
+++ b/alerts/mongodb/high-cpu-utilization.json
@@ -9,8 +9,7 @@
         {
             "displayName": "MongoDB - High CPU Utilization",
             "conditionMonitoringQueryLanguage": {
-                "duration": "1m",
-                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
+                "duration": "0s",
                 "trigger": {
                     "count": 1
                 },

--- a/alerts/mongodb/high-cpu-utilization.json
+++ b/alerts/mongodb/high-cpu-utilization.json
@@ -1,0 +1,27 @@
+{
+    "displayName": "MongoDB - High CPU Utilization",
+    "documentation": {
+        "content": "If CPU utilization is above 90%, then the MongoDB instance is probably due to be scaled up or needs further investigation.",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "MongoDB - High CPU Utilization",
+            "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
+            "conditionMonitoringQueryLanguage": {
+                "duration": "0s",
+                "trigger": {
+                    "count": 1
+                },
+                "query": "def top_5_cpu_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/cpu/utilization'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n@top_5_cpu_filtered_by_metric\n  'workload.googleapis.com/mongodb.memory.usage'\n| condition val() > 90'%'"
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "3600s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}

--- a/alerts/mongodb/high-cpu-utilization.json
+++ b/alerts/mongodb/high-cpu-utilization.json
@@ -8,9 +8,9 @@
     "conditions": [
         {
             "displayName": "MongoDB - High CPU Utilization",
-            "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
             "conditionMonitoringQueryLanguage": {
-                "duration": "0s",
+                "duration": "1m",
+                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
                 "trigger": {
                     "count": 1
                 },

--- a/alerts/mongodb/high-disk-utilization.json
+++ b/alerts/mongodb/high-disk-utilization.json
@@ -1,0 +1,27 @@
+{
+    "displayName": "MongoDB - High Disk Utilization",
+    "documentation": {
+      "content": "If Disk Utilization is above 80%, then it is time to look deeper into adding more storage or cleaning up old docs.",
+      "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+      {
+        "displayName": "New condition",
+        "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
+        "conditionMonitoringQueryLanguage": {
+          "duration": "0s",
+          "trigger": {
+            "count": 1
+          },
+          "query": "def top_5_disk_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/disk/percent_used'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | every 1m;\n\n@top_5_disk_filtered_by_metric\n  'workload.googleapis.com/mongodb.memory.usage'\n| condition val() > 80'%'"
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "3600s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+  }

--- a/alerts/mongodb/high-disk-utilization.json
+++ b/alerts/mongodb/high-disk-utilization.json
@@ -9,7 +9,7 @@
       {
         "displayName": "New condition",
         "conditionMonitoringQueryLanguage": {
-          "duration": "1m",
+          "duration": "60s",
           "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
           "trigger": {
             "count": 1

--- a/alerts/mongodb/high-disk-utilization.json
+++ b/alerts/mongodb/high-disk-utilization.json
@@ -8,9 +8,9 @@
     "conditions": [
       {
         "displayName": "New condition",
-        "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
         "conditionMonitoringQueryLanguage": {
-          "duration": "0s",
+          "duration": "1m",
+          "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
           "trigger": {
             "count": 1
           },


### PR DESCRIPTION
Proposing these alerts for MongoDB while using it in the Ops Agent

These are MongoDB instances run on single GCE VMs. 

# Alerts for MongoDB in Ops Agent

## Connections Near Max

If connections are approaching the limit, then new connections cannot be established. By default the mongod rejects connections at around 52000. Applications may stop functioning if connections cannot be established.

## High CPU Utilization

If CPU utilization is above 90%, then the MongoDB instance is probably due to be scaled up or needs further investigation.

## High Disk Utilization

If Disk Utilization is above 80%, then it is time to look deeper into adding more storage or cleaning up old docs.