### PR TITLE
Add Memcached Alerts

### DIFF
--- a/alerts/memcached/README.md
+++ b/alerts/memcached/README.md
@@ -31,7 +31,7 @@ i.e.
 
 #### Notification Channels
 
-The ID of the notification channel to be notifed.
+The ID of the notification channel to be notified.
 
 ```json
     "notificationChannels": [

--- a/alerts/memcached/README.md
+++ b/alerts/memcached/README.md
@@ -1,0 +1,40 @@
+
+# Alerts for Memcached in the Ops Agent
+
+## High CPU Usage
+
+if `memcached.cpu.usage` is higher than what is anticipated it could show that the Server us overloaded and efforts to improve performance may be necessary. Subjective to environment, configure threshold knowingly.
+
+## High Evictions
+
+if `memcached.evictions` increase above `0` that shows that items are being evicted due to high memory usage and should be a cause for concern.
+
+## No Connections
+
+if `memcached.connections.current` reaches `0` that should be cause for concern because memcached should always have at least 1 connection.
+
+### Creating notification Channels and User Labels
+
+Whether these alert policies are being used as standalones or base templates for a deployment strategy like terraform, one thing that should be utilized is notification channels and user labels.
+
+### User Labels
+
+Supplying user labels could give extra identification information about the firing alert:
+
+i.e.
+
+```json
+    "userLabels": {
+        "datacenter": "central"
+    }
+```
+
+#### Notification Channels
+
+The ID of the notification channel to be notifed.
+
+```json
+    "notificationChannels": [
+        "projects/project-id/notificationChannels/1234567
+    ]
+```

--- a/alerts/memcached/README.md
+++ b/alerts/memcached/README.md
@@ -3,7 +3,7 @@
 
 ## High CPU Usage
 
-if `memcached.cpu.usage` is higher than what is anticipated it could show that the Server us overloaded and efforts to improve performance may be necessary. Subjective to environment, configure threshold knowingly.
+if `memcached.cpu.usage` is higher than what is anticipated, default is `0.9`, it could show that the Server is overloaded and efforts to improve performance may be necessary. Subjective to environment, configure threshold knowingly.
 
 ## High Evictions
 

--- a/alerts/memcached/high-cpu-usage.json
+++ b/alerts/memcached/high-cpu-usage.json
@@ -1,6 +1,9 @@
 {
   "displayName": "Memcached - High CPU Usage",
-  "documentation": {},
+  "documentation": {
+    "content": "if `memcached.cpu.usage` is higher than what is anticipated it could show that the Server us overloaded and efforts to improve performance may be necessary. Subjective to environment, configure threshold knowingly.",
+    "mimeType": "text/markdown"
+  },
   "userLabels": {},
   "conditions": [
     {

--- a/alerts/memcached/high-cpu-usage.json
+++ b/alerts/memcached/high-cpu-usage.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Memcached - High CPU Usage",
   "documentation": {
-    "content": "if `memcached.cpu.usage` is higher than what is anticipated it could show that the Server us overloaded and efforts to improve performance may be necessary. Subjective to environment, configure threshold knowingly.",
+    "content": "If `memcached.cpu.usage` is higher than what is anticipated, default is `0.9`, it could show that the Server is overloaded and efforts to improve performance may be necessary. Subjective to environment, configure threshold knowingly.",
     "mimeType": "text/markdown"
   },
   "userLabels": {},
@@ -18,7 +18,7 @@
         "comparison": "COMPARISON_GT",
         "duration": "0s",
         "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/memcached.cpu.usage\"",
-        "thresholdValue": 0.1,
+        "thresholdValue": 0.9,
         "trigger": {
           "count": 1
         }

--- a/alerts/memcached/high-cpu-usage.json
+++ b/alerts/memcached/high-cpu-usage.json
@@ -1,0 +1,31 @@
+{
+  "displayName": "Memcached - High CPU Usage",
+  "documentation": {},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/memcached.cpu.usage",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "60s",
+            "perSeriesAligner": "ALIGN_RATE"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/memcached.cpu.usage\"",
+        "thresholdValue": 0.1,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/memcached/high-evictions.json
+++ b/alerts/memcached/high-evictions.json
@@ -1,6 +1,9 @@
 {
   "displayName": "Memcached - High Evictions",
-  "documentation": {},
+  "documentation": {
+    "content": "if `memcached.evictions` increase above `0` that shows that items are being evicted due to high memory usage and should be a cause for concern.",
+    "mimeType": "text/markdown"
+  },
   "userLabels": {},
   "conditions": [
     {

--- a/alerts/memcached/high-evictions.json
+++ b/alerts/memcached/high-evictions.json
@@ -1,0 +1,31 @@
+{
+  "displayName": "Memcached - High Evictions",
+  "documentation": {},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/memcached.evictions",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_RATE"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/memcached.evictions\"",
+        "thresholdValue": 0,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/memcached/high-evictions.json
+++ b/alerts/memcached/high-evictions.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Memcached - High Evictions",
   "documentation": {
-    "content": "if `memcached.evictions` increase above `0` that shows that items are being evicted due to high memory usage and should be a cause for concern.",
+    "content": "If `memcached.evictions` increase above `0` that shows that items are being evicted due to high memory usage and should be a cause for concern.",
     "mimeType": "text/markdown"
   },
   "userLabels": {},

--- a/alerts/memcached/no-connections.json
+++ b/alerts/memcached/no-connections.json
@@ -1,0 +1,31 @@
+{
+  "displayName": "Memcached - No Connections ",
+  "documentation": {},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/memcached.connections.current",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_MEAN"
+          }
+        ],
+        "comparison": "COMPARISON_LT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/memcached.connections.current\"",
+        "thresholdValue": 1,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/memcached/no-connections.json
+++ b/alerts/memcached/no-connections.json
@@ -1,6 +1,9 @@
 {
   "displayName": "Memcached - No Connections ",
-  "documentation": {},
+  "documentation": {
+    "content": "if `memcached.connections.current` reaches `0` that should be cause for concern because memcached should always have at least 1 connection.",
+    "mimeType": "text/markdown"
+  },
   "userLabels": {},
   "conditions": [
     {

--- a/alerts/memcached/no-connections.json
+++ b/alerts/memcached/no-connections.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Memcached - No Connections ",
   "documentation": {
-    "content": "if `memcached.connections.current` reaches `0` that should be cause for concern because memcached should always have at least 1 connection.",
+    "content": "If `memcached.connections.current` reaches `0` that should be cause for concern because memcached should always have at least 1 connection.",
     "mimeType": "text/markdown"
   },
   "userLabels": {},


### PR DESCRIPTION
Alerts to be added:
## High CPU Usage

if `memcached.cpu.usage` is higher than what is anticipated it could show that the Server us overloaded and efforts to improve performance may be necessary. Subjective to environment, configure threshold knowingly.

## High Evictions

if `memcached.evictions` increase above `0` that shows that items are being evicted due to high memory usage and should be a cause for concern.

## No Connections

if `memcached.connections.current` reaches `0` that should be cause for concern because memcached should always have at least 1 connection.
