### PR TITLE
Add Solr Alerts

### DIFF
--- a/alerts/solr/README.md
+++ b/alerts/solr/README.md
@@ -6,11 +6,11 @@ If `solr.request.error.count` is high there should be cause for concern as your 
 
 ## High Cache Evictions
 
-If `solr.cache.eviction.count` is high, Solr is having trouble keeping up. Either the cache eviction time should be increased or improvements in performance should be looked for.
+If `solr.cache.eviction.count` is high (default: `5 evictions`), Solr is having trouble keeping up. Either the cache eviction time should be increased or performance improvements are needed.
 
 ## High Request Count
 
-If `solr.request.count` is above a threshold that should be determined based on your server, it could show there is a security issue.
+If `solr.request.count` is above a threshold that should be determined based on your server, it shows that the server is experiencing higher load than expected. This means resources should be expanded to support the load or that there is a security issue with the server.
 
 ### Creating notification Channels and User Labels
 

--- a/alerts/solr/README.md
+++ b/alerts/solr/README.md
@@ -1,0 +1,39 @@
+# Alerts for Solr in the Ops Agent
+
+## High Request Errors
+
+If `solr.request.error.count` is high there should be cause for concern as your server could be having issue executing queries. 
+
+## High Cache Evictions
+
+If `solr.cache.eviction.count` is high, Solr is having trouble keeping up. Either the cache eviction time should be increased or improvements in performance should be looked for.
+
+## High Request Count
+
+If `solr.request.count` is above a threshold that should be determined based on your server, it could show there is a security issue.
+
+### Creating notification Channels and User Labels
+
+Whether these alert policies are being used as standalones or base templates for a deployment strategy like terraform, one thing that should be utilized is notification channels and user labels.
+
+### User Labels
+
+Supplying user labels could give extra identification information about the firing alert:
+
+i.e.
+
+```json
+    "userLabels": {
+        "datacenter": "central"
+    }
+```
+
+#### Notification Channels
+
+The ID of the notification channel to be notified.
+
+```json
+    "notificationChannels": [
+        "projects/project-id/notificationChannels/1234567
+    ]
+```

--- a/alerts/solr/high-cache-evictions.json
+++ b/alerts/solr/high-cache-evictions.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Solr - High Cache Evictions ",
   "documentation": {
-    "content": "If `solr.cache.eviction.count` is high, Solr is having trouble keeping up. Either the cache eviction time should be increased or improvements in performance should be looked for.",
+    "content": "If `solr.cache.eviction.count` is high (default: `5 evictions`), Solr is having trouble keeping up. Either the cache eviction time should be increased or performance improvements are needed.",
     "mimeType": "text/markdown"
   },
   "userLabels": {},

--- a/alerts/solr/high-cache-evictions.json
+++ b/alerts/solr/high-cache-evictions.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "Solr - High Cache Evictions ",
+  "documentation": {
+    "content": "If `solr.cache.eviction.count` is high, Solr is having trouble keeping up. Either the cache eviction time should be increased or improvements in performance should be looked for.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/solr.cache.eviction.count",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_RATE"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/solr.cache.eviction.count\"",
+        "thresholdValue": 5,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/solr/high-request-count.json
+++ b/alerts/solr/high-request-count.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "Solr - High Request Count",
+  "documentation": {
+    "content": "If `solr.request.count` is above a threshold that should be determined based on your server, it could show there is a security issue.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/solr.request.count",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "60s",
+            "perSeriesAligner": "ALIGN_RATE"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/solr.request.count\"",
+        "thresholdValue": 10,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/solr/high-request-errors.json
+++ b/alerts/solr/high-request-errors.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "Solr - High Request Errors ",
+  "documentation": {
+    "content": "If `solr.request.error.count` is high there should be cause for concern as your server could be having issue executing queries.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/solr.request.error.count",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_RATE"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/solr.request.error.count\"",
+        "thresholdValue": 5,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}


### PR DESCRIPTION
Alerts to be added: 

## High Request Errors

If `solr.request.error.count` is high there should be cause for concern as your server could be having issue executing queries. 

## High Cache Evictions

If `solr.cache.eviction.count` is high, Solr is having trouble keeping up. Either the cache eviction time should be increased or improvements in performance should be looked for.

## High Request Count

If `solr.request.count` is above a threshold that should be determined based on your server, it could show there is a security issue.

