### PR TITLE
Add Ops agent ActiveMQ alert polices

### DIFF
--- a/alerts/activemq/README.md
+++ b/alerts/activemq/README.md
@@ -15,10 +15,10 @@ User labels can be used for these policies by modifying the userLabels fields of
 ```
 
 ## High disk storage alert
-When the broker's disk storage is near it's limit, then the producer flow control may cause producers to stop sending messages.
+When the broker's disk storage is near its limit, then the producer flow control may cause producers to stop sending messages.
 
 ## High temp storage alert
-When the broker's non-persistent storage is near it's limit, messages are moved to a temp file system. If that temp file system fills up, then producers will stop sending messages until storage space is freed.
+When the broker's non-persistent storage is near its limit, messages are moved to a temp file system. If that temp file system fills up, then producers will stop sending messages until storage space is freed.
 
 ## Dropped connection alert
 When the connection count is zero, then there are networking problems and clients cannot connect to the ActiveMQ server.

--- a/alerts/activemq/README.md
+++ b/alerts/activemq/README.md
@@ -1,0 +1,24 @@
+# ActiveMQ Alerts for Ops Agent
+
+### Notification Channels
+For all alerts, a notification channel needs to be set up or the alert will fire silently.
+
+### User Labels
+User labels can be used for these policies by modifying the userLabels fields of the policies. i.e.
+
+```json
+{ 
+  "userLabels": {
+    "datacenter": "central"
+  }
+}
+```
+
+## High disk storage alert
+When the broker's disk storage is near it's limit, then the producer flow control may cause producers to stop sending messages.
+
+## High temp storage alert
+When the broker's non-persistent storage is near it's limit, messages are moved to a temp file system. If that temp file system fills up, then producers will stop sending messages until storage space is freed.
+
+## Dropped connection alert
+When the connection count is zero, then there are networking problems and clients cannot connect to the ActiveMQ server.

--- a/alerts/activemq/README.md
+++ b/alerts/activemq/README.md
@@ -1,5 +1,14 @@
 # ActiveMQ Alerts for Ops Agent
 
+## High disk storage alert
+When the broker's disk storage is near its limit(90%), then the producer flow control may cause producers to stop sending messages.
+
+## High temp storage alert
+When the broker's non-persistent storage is near its limit(90%), messages are moved to a temp file system. If that temp file system fills up, then producers will stop sending messages until storage space is freed.
+
+## Dropped connection alert
+When the connection count is zero, then there are networking problems and clients cannot connect to the ActiveMQ server.
+
 ### Notification Channels
 For all alerts, a notification channel needs to be set up or the alert will fire silently.
 
@@ -13,12 +22,3 @@ User labels can be used for these policies by modifying the userLabels fields of
   }
 }
 ```
-
-## High disk storage alert
-When the broker's disk storage is near its limit, then the producer flow control may cause producers to stop sending messages.
-
-## High temp storage alert
-When the broker's non-persistent storage is near its limit, messages are moved to a temp file system. If that temp file system fills up, then producers will stop sending messages until storage space is freed.
-
-## Dropped connection alert
-When the connection count is zero, then there are networking problems and clients cannot connect to the ActiveMQ server.

--- a/alerts/activemq/activemq-dropped-connection.json
+++ b/alerts/activemq/activemq-dropped-connection.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "Activemq - dropped connection",
+  "documentation": {
+    "content": "When the connection count is zero, then there are networking problems and clients cannot connect to the ActiveMQ server.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/activemq.connection.count",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_MEAN"
+          }
+        ],
+        "comparison": "COMPARISON_LT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/activemq.connection.count\"",
+        "thresholdValue": 1,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/activemq/activemq-high-disk-storage.json
+++ b/alerts/activemq/activemq-high-disk-storage.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Activemq - High disk storage",
   "documentation": {
-    "content": "When the broker's disk storage is near it's limit, then the producer flow control may cause producers to stop sending messages.",
+    "content": "When the broker's disk storage is near its limit, then the producer flow control may cause producers to stop sending messages.",
     "mimeType": "text/markdown"
   },
   "userLabels": {},

--- a/alerts/activemq/activemq-high-disk-storage.json
+++ b/alerts/activemq/activemq-high-disk-storage.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "Activemq - High disk storage",
+  "documentation": {
+    "content": "When the broker's disk storage is near it's limit, then the producer flow control may cause producers to stop sending messages.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/activemq.disk.store_usage",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_MEAN"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/activemq.disk.store_usage\"",
+        "thresholdValue": 0.9,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/activemq/activemq-high-disk-storage.json
+++ b/alerts/activemq/activemq-high-disk-storage.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Activemq - High disk storage",
   "documentation": {
-    "content": "When the broker's disk storage is near its limit, then the producer flow control may cause producers to stop sending messages.",
+    "content": "When the broker's disk storage is near its limit(90%), then the producer flow control may cause producers to stop sending messages.",
     "mimeType": "text/markdown"
   },
   "userLabels": {},

--- a/alerts/activemq/activemq-high-temp-storage.json
+++ b/alerts/activemq/activemq-high-temp-storage.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "Activemq - High temp storage",
+  "documentation": {
+    "content": "When the broker's non-persistent storage is near it's limit, messages are moved to a temp file system. If that temp file system fills up, then producers will stop sending messages until storage space is freed.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/activemq.disk.temp_usage",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_MEAN"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/activemq.disk.temp_usage\"",
+        "thresholdValue": 0.9,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/activemq/activemq-high-temp-storage.json
+++ b/alerts/activemq/activemq-high-temp-storage.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Activemq - High temp storage",
   "documentation": {
-    "content": "When the broker's non-persistent storage is near its limit, messages are moved to a temp file system. If that temp file system fills up, then producers will stop sending messages until storage space is freed.",
+    "content": "When the broker's non-persistent storage is near its limit(90%), messages are moved to a temp file system. If that temp file system fills up, then producers will stop sending messages until storage space is freed.",
     "mimeType": "text/markdown"
   },
   "userLabels": {},

--- a/alerts/activemq/activemq-high-temp-storage.json
+++ b/alerts/activemq/activemq-high-temp-storage.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Activemq - High temp storage",
   "documentation": {
-    "content": "When the broker's non-persistent storage is near it's limit, messages are moved to a temp file system. If that temp file system fills up, then producers will stop sending messages until storage space is freed.",
+    "content": "When the broker's non-persistent storage is near its limit, messages are moved to a temp file system. If that temp file system fills up, then producers will stop sending messages until storage space is freed.",
     "mimeType": "text/markdown"
   },
   "userLabels": {},


### PR DESCRIPTION
Intending to add these alerts:

## High disk storage alert
When the broker's disk storage is near its limit, then the producer flow control may cause producers to stop sending messages.

## High temp storage alert
When the broker's non-persistent storage is near its limit, messages are moved to a temp file system. If that temp file system fills up, then producers will stop sending messages until storage space is freed.

## Dropped connection alert
When the connection count is zero, then there are networking problems and clients cannot connect to the ActiveMQ server.