### PR TITLE
Apache HBase Alert Policies

### DIFF
--- a/alerts/hbase/README.md
+++ b/alerts/hbase/README.md
@@ -2,15 +2,15 @@
 
 ## Slow Operations
 
-Slow operations can be an indication that the HDFS may be in an unhealthy state.
+Slow operations are defined as operations that took over `1000ms` to complete. Slow operations can be an indication that the HDFS may be in an unhealthy state. This alert is configured to fire if `10` slow operations are recorded.
 
 ## HBase Server Stopped
 
-If the HBase has unexpected downtime, this alert will help teams discern that the server is stopped and unable to function in their environment.
+If the HBase has unexpected downtime, this alert will help teams discern that the server is stopped and unable to function in their environment. The alert is currently configured for 5 minutes of downtime may be considered lenient for certain environments, so feel free to tighten or loosen the `duration` if desired.
 
 Required Log Query:
 
-```sh
+```
 logName="projects/<project_id>/logs/hbase_system"
 jsonPayload.message="regionserver.HeapMemoryManager: Stopping"
 ```
@@ -19,9 +19,9 @@ Replace <project_id> with your Project ID
 
 ## Authentication Errors
 
-Authentication errors could indicate that clients do not have correct credentials or somebody is maliciously trying to access the HBase system.
+Authentication errors could indicate that clients do not have correct credentials or somebody is maliciously trying to access the HBase system. The alert is configured to fire if 5 authentication errors are happening over a minute. Feel free to modify to fit use cases.
 
-### Creating notification Channels and User Labels
+### Creating Notification Channels and User Labels
 
 Whether these alert policies are being used as standalones or base templates for a deployment strategy like terraform, one thing that should be utilized is notification channels and user labels.
 

--- a/alerts/hbase/README.md
+++ b/alerts/hbase/README.md
@@ -1,0 +1,48 @@
+# Alert Policies for Apache HBase in the Ops Agent
+
+## Slow Operations
+
+Slow operations can be an indication that the HDFS may be in an unhealthy state.
+
+## HBase Server Stopped
+
+If the HBase has unexpected downtime, this alert will help teams discern that the server is stopped and unable to function in their environment.
+
+Required Log Query:
+
+```sh
+logName="projects/<project_id>/logs/hbase_system"
+jsonPayload.message="regionserver.HeapMemoryManager: Stopping"
+```
+
+Replace <project_id> with your Project ID
+
+## Authentication Errors
+
+Authentication errors could indicate that clients do not have correct credentials or somebody is maliciously trying to access the HBase system.
+
+### Creating notification Channels and User Labels
+
+Whether these alert policies are being used as standalones or base templates for a deployment strategy like terraform, one thing that should be utilized is notification channels and user labels.
+
+### User Labels
+
+Supplying user labels could give extra identification information about the firing alert:
+
+i.e.
+
+```json
+    "userLabels": {
+        "datacenter": "central"
+    }
+```
+
+#### Notification Channels
+
+The ID of the notification channel to be notified.
+
+```json
+    "notificationChannels": [
+        "projects/project-id/notificationChannels/1234567
+    ]
+```

--- a/alerts/hbase/authentication-errors.json
+++ b/alerts/hbase/authentication-errors.json
@@ -1,7 +1,7 @@
 {
     "displayName": "HBase - Authentication Errors",
     "documentation": {
-        "content": "Authentication errors could indicate that clients do not have correct credentials or somebody is maliciously trying to access the HBase system.",
+        "content": "Authentication errors could indicate that clients do not have correct credentials or somebody is maliciously trying to access the HBase system. The alert is configured to fire if 5 authentication errors are happening over a minute. Feel free to modify to fit use cases.",
         "mimeType": "text/markdown"
     },
     "userLabels": {},

--- a/alerts/hbase/authentication-errors.json
+++ b/alerts/hbase/authentication-errors.json
@@ -1,0 +1,27 @@
+{
+    "displayName": "HBase - Authentication Errors",
+    "documentation": {
+        "content": "Authentication errors could indicate that clients do not have correct credentials or somebody is maliciously trying to access the HBase system.",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "HBase Authentication Errors",
+            "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
+            "conditionMonitoringQueryLanguage": {
+                "duration": "0s",
+                "trigger": {
+                    "count": 1
+                },
+                "query": "fetch gce_instance\n| metric 'workload.googleapis.com/hbase.region_server.authentication.count'\n| filter (metric.state == \"failures\")\n| group_by 1m, [value_count_mean: mean(value.count)]\n| every 1m\n| condition val() > 5"
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "3600s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}

--- a/alerts/hbase/authentication-errors.json
+++ b/alerts/hbase/authentication-errors.json
@@ -10,7 +10,6 @@
             "displayName": "HBase Authentication Errors",
             "conditionMonitoringQueryLanguage": {
                 "duration": "0s",
-                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
                 "trigger": {
                     "count": 1
                 },

--- a/alerts/hbase/authentication-errors.json
+++ b/alerts/hbase/authentication-errors.json
@@ -8,9 +8,9 @@
     "conditions": [
         {
             "displayName": "HBase Authentication Errors",
-            "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
             "conditionMonitoringQueryLanguage": {
                 "duration": "0s",
+                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
                 "trigger": {
                     "count": 1
                 },

--- a/alerts/hbase/server-down.json
+++ b/alerts/hbase/server-down.json
@@ -1,0 +1,36 @@
+{
+    "displayName": "HBase - Server is Down",
+    "documentation": {
+        "content": "If the HBase has unexpected downtime, this alert will help teams discern that the server is stopped and unable to function in their environment.\n\nRequired Log Query:\n\n```sh\nlogName=\"projects/<project_id>/logs/hbase_system\"\njsonPayload.message=\"regionserver.HeapMemoryManager: Stopping\"\n```\n\nReplace <project_id> with your Project ID",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "HBase Server Down",
+            "conditionThreshold": {
+                "filter": "resource.type = \"gce_instance\" AND metric.type = \"logging.googleapis.com/user/HBase-Server-Stopping\"",
+                "aggregations": [
+                    {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                ],
+                "comparison": "COMPARISON_GT",
+                "duration": "600s",
+                "trigger": {
+                    "count": 1
+                },
+                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
+                "thresholdValue": 1
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "3600s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}

--- a/alerts/hbase/server-down.json
+++ b/alerts/hbase/server-down.json
@@ -1,7 +1,7 @@
 {
     "displayName": "HBase - Server is Down",
     "documentation": {
-        "content": "If the HBase has unexpected downtime, this alert will help teams discern that the server is stopped and unable to function in their environment.\n\nRequired Log Query:\n\n```sh\nlogName=\"projects/<project_id>/logs/hbase_system\"\njsonPayload.message=\"regionserver.HeapMemoryManager: Stopping\"\n```\n\nReplace <project_id> with your Project ID",
+        "content": "If the HBase has unexpected downtime, this alert will help teams discern that the server is stopped and unable to function in their environment. The alert is currently configured for 5 minutes of downtime may be considered lenient for certain environments, so feel free to tighten or loosen the `duration` if desired.\n\nRequired Log Query:\n\n```\nlogName=\"projects/<project_id>/logs/hbase_system\"\njsonPayload.message=\"regionserver.HeapMemoryManager: Stopping\"\n```\n\nReplace <project_id> with your Project ID",
         "mimeType": "text/markdown"
     },
     "userLabels": {},
@@ -18,7 +18,7 @@
                     }
                 ],
                 "comparison": "COMPARISON_GT",
-                "duration": "600s",
+                "duration": "300s",
                 "trigger": {
                     "count": 1
                 },

--- a/alerts/hbase/slow-operations.json
+++ b/alerts/hbase/slow-operations.json
@@ -1,7 +1,7 @@
 {
     "displayName": "HBase - Slow Operations",
     "documentation": {
-        "content": "Slow operations can be an indication that the HDFS may be in an unhealthy state. ",
+        "content": "Slow operations are defined as operations that took over `1000ms` to complete. Slow operations can be an indication that the HDFS may be in an unhealthy state. This alert is configured to fire if `10` slow operations are recorded.",
         "mimeType": "text/markdown"
     },
     "userLabels": {},

--- a/alerts/hbase/slow-operations.json
+++ b/alerts/hbase/slow-operations.json
@@ -1,0 +1,35 @@
+{
+    "displayName": "HBase - Slow Operations",
+    "documentation": {
+        "content": "Slow operations can be an indication that the HDFS may be in an unhealthy state. ",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "VM Instance - workload/hbase.region_server.operations.slow",
+            "conditionThreshold": {
+                "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/hbase.region_server.operations.slow\"",
+                "aggregations": [
+                    {
+                        "alignmentPeriod": "300s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                ],
+                "comparison": "COMPARISON_GT",
+                "duration": "0s",
+                "trigger": {
+                    "count": 1
+                },
+                "thresholdValue": 10
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}


### PR DESCRIPTION
# Alert Policies for Apache HBase in the Ops Agent

## Slow Operations

Slow operations can be an indication that the HDFS may be in an unhealthy state.

## HBase Server Stopped

If the HBase has unexpected downtime, this alert will help teams discern that the server is stopped and unable to function in their environment.

Required Log Query:

```sh
logName="projects/<project_id>/logs/hbase_system"
jsonPayload.message="regionserver.HeapMemoryManager: Stopping"
```

Replace <project_id> with your Project ID

## Authentication Errors

Authentication errors could indicate that clients do not have correct credentials or somebody is maliciously trying to access the HBase system.
