### PR TITLE
Add Zookeeper Alerts

### DIFF
--- a/alerts/zookeeper/README.md
+++ b/alerts/zookeeper/README.md
@@ -2,15 +2,15 @@
 
 ## High Average Latency
 
-if `zookeeper.latency.avg` is 100ms or higher, it shows that the server can't keep up with demand and performance improvements should be sought after.
+If `zookeeper.latency.avg` is 100ms or higher, it shows that the server can't keep up with demand and performance improvements should be sought after.
 
 ## High fsync Duration
 
-if `zookeeper.fsync.exceeded_threshold.count` is above an amount dependent on your environment it could show either the fsync duration  threshold set is too low or there is an issue writing to files.
+If `zookeeper.fsync.exceeded_threshold.count` is above an amount dependent on your environment it could show either the fsync duration  threshold set is too low or there is an issue writing to files.
 
 ## Low Open File Descriptors
 
-if `workload.googleapis.com/zookeeper.file_descriptor.open` is about to hit `workload.googleapis.com/zookeeper.file_descriptor.limit` zookeeper will not be able to handle any new requests and will fail to connect new clients.
+If `workload.googleapis.com/zookeeper.file_descriptor.open` is about to hit `workload.googleapis.com/zookeeper.file_descriptor.limit` zookeeper will not be able to handle any new requests and will fail to connect new clients.
 
 ### Creating notification Channels and User Labels
 

--- a/alerts/zookeeper/README.md
+++ b/alerts/zookeeper/README.md
@@ -1,0 +1,39 @@
+# Alerts for Zookeeper in the Ops Agent
+
+## High Average Latency
+
+if `zookeeper.latency.avg` is 100ms or higher, it shows that the server can't keep up with demand and performance improvements should be sought after.
+
+## High fsync Duration
+
+if `zookeeper.fsync.exceeded_threshold.count` is above an amount dependent on your environment it could show either the fsync duration  threshold set is too low or there is an issue writing to files.
+
+## Low Open File Descriptors
+
+if `workload.googleapis.com/zookeeper.file_descriptor.open` is about to hit `workload.googleapis.com/zookeeper.file_descriptor.limit` zookeeper will not be able to handle any new requests and will fail to connect new clients.
+
+### Creating notification Channels and User Labels
+
+Whether these alert policies are being used as standalones or base templates for a deployment strategy like terraform, one thing that should be utilized is notification channels and user labels.
+
+### User Labels
+
+Supplying user labels could give extra identification information about the firing alert:
+
+i.e.
+
+```json
+    "userLabels": {
+        "datacenter": "central"
+    }
+```
+
+#### Notification Channels
+
+The ID of the notification channel to be notified.
+
+```json
+    "notificationChannels": [
+        "projects/project-id/notificationChannels/1234567
+    ]
+```

--- a/alerts/zookeeper/high-average-latency.json
+++ b/alerts/zookeeper/high-average-latency.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Zookeeper - High Average Latency",
   "documentation": {
-    "content": "if `zookeeper.latency.avg` is 100ms or higher, it shows that the server can't keep up with demand and performance improvements should be sought after.",
+    "content": "If `zookeeper.latency.avg` is 100ms or higher, it shows that the server can't keep up with demand and performance improvements should be sought after.",
     "mimeType": "text/markdown"
   },
   "userLabels": {},

--- a/alerts/zookeeper/high-average-latency.json
+++ b/alerts/zookeeper/high-average-latency.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "Zookeeper - High Average Latency",
+  "documentation": {
+    "content": "if `zookeeper.latency.avg` is 100ms or higher, it shows that the server can't keep up with demand and performance improvements should be sought after.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/zookeeper.latency.avg",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_MEAN"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/zookeeper.latency.avg\"",
+        "thresholdValue": 100,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/zookeeper/high-fsync-duration.json
+++ b/alerts/zookeeper/high-fsync-duration.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Zookeeper - High fsync Duration",
   "documentation": {
-    "content": "if `zookeeper.fsync.exceeded_threshold.count` is above an amount dependent on your environment it could show either the fsync duration  threshold set is too low or there is an issue writing to files.",
+    "content": "If `zookeeper.fsync.exceeded_threshold.count` is above an amount dependent on your environment it could show either the fsync duration  threshold set is too low or there is an issue writing to files.",
     "mimeType": "text/markdown"
   },
   "userLabels": {},

--- a/alerts/zookeeper/high-fsync-duration.json
+++ b/alerts/zookeeper/high-fsync-duration.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "Zookeeper - High fsync Duration",
+  "documentation": {
+    "content": "if `zookeeper.fsync.exceeded_threshold.count` is above an amount dependent on your environment it could show either the fsync duration  threshold set is too low or there is an issue writing to files.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/zookeeper.fsync.exceeded_threshold.count",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_RATE"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/zookeeper.fsync.exceeded_threshold.count\"",
+        "thresholdValue": 5,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/zookeeper/low-open-file-descriptors.json
+++ b/alerts/zookeeper/low-open-file-descriptors.json
@@ -1,0 +1,26 @@
+{
+  "displayName": "Zookeeper - Low Open File Descriptors",
+  "documentation": {
+    "content": "if `workload.googleapis.com/zookeeper.file_descriptor.open` is about to hit `workload.googleapis.com/zookeeper.file_descriptor.limit` zookeeper will not be able to handle any new requests and will fail to connect new clients. ",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "New condition",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "0s",
+        "query": " fetch gce_instance\n| { metric 'workload.googleapis.com/zookeeper.file_descriptor.limit'\n; metric 'workload.googleapis.com/zookeeper.file_descriptor.open' }\n| outer_join 0\n| group_by 1m\n| sub\n| condition val() < 1000",
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/zookeeper/low-open-file-descriptors.json
+++ b/alerts/zookeeper/low-open-file-descriptors.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Zookeeper - Low Open File Descriptors",
   "documentation": {
-    "content": "if `workload.googleapis.com/zookeeper.file_descriptor.open` is about to hit `workload.googleapis.com/zookeeper.file_descriptor.limit` zookeeper will not be able to handle any new requests and will fail to connect new clients. ",
+    "content": "If `workload.googleapis.com/zookeeper.file_descriptor.open` is about to hit `workload.googleapis.com/zookeeper.file_descriptor.limit` zookeeper will not be able to handle any new requests and will fail to connect new clients. ",
     "mimeType": "text/markdown"
   },
   "userLabels": {},


### PR DESCRIPTION
Alerts to be added:

## High Average Latency

if `zookeeper.latency.avg` is 100ms or higher, it shows that the server can't keep up with demand and performance improvements should be sought after.

## High fsync Duration

if `zookeeper.fsync.exceeded_threshold.count` is above an amount dependent on your environment it could show either the fsync duration  threshold set is too low or there is an issue writing to files.

## Low Open File Descriptors

if `workload.googleapis.com/zookeeper.file_descriptor.open` is about to hit `workload.googleapis.com/zookeeper.file_descriptor.limit` zookeeper will not be able to handle any new requests and will fail to connect new clients.