### PR TITLE
Add Ops agent MySQL alert polices

### DIFF
--- a/alerts/mysql/README.md
+++ b/alerts/mysql/README.md
@@ -1,19 +1,5 @@
 # MySQL Alerts for Ops Agent
 
-### Notification Channels
-For all alerts, a notification channel needs to be set up or the alert will fire silently.
-
-### User Labels
-User labels can be used for these policies by modifying the userLabels fields of the policies. i.e.
-
-```json
-{ 
-  "userLabels": {
-    "datacenter": "central"
-  }
-}
-```
-
 ## High number of log warnings alert
 Log warnings are a count of logs collected from mysql_error logs with a warning level per 5 minute window. The default condition of warnings per 5 minute window is 20.
 
@@ -52,4 +38,18 @@ The filter for the metric should be:
 logName:"mysql_slow"
 jsonPayload.message:("SELECT" OR "INSERT" OR "UPDATE" OR "CREATE" OR "DELETE")
 jsonPayload.queryTime>1
+```
+
+### Notification Channels
+For all alerts, a notification channel needs to be set up or the alert will fire silently.
+
+### User Labels
+User labels can be used for these policies by modifying the userLabels fields of the policies. i.e.
+
+```json
+{ 
+  "userLabels": {
+    "datacenter": "central"
+  }
+}
 ```

--- a/alerts/mysql/README.md
+++ b/alerts/mysql/README.md
@@ -1,0 +1,55 @@
+# MySQL Alerts for Ops Agent
+
+### Notification Channels
+For all alerts, a notification channel needs to be set up or the alert will fire silently.
+
+### User Labels
+User labels can be used for these policies by modifying the userLabels fields of the policies. i.e.
+
+```json
+{ 
+  "userLabels": {
+    "datacenter": "central"
+  }
+}
+```
+
+## High number of log warnings alert
+Log warnings are a count of logs collected from mysql_error logs with a warning level per 5 minute window. The default condition of warnings per 5 minute window is 20.
+
+### Prerequisites
+The name of the metric should be:
+`mysql.warning.count`
+
+The filter for the metric should be:
+```
+logName:"mysql_error"
+jsonPayload.level="Warning"
+```
+
+## High number of log errors alert
+Log error are a count of logs collected from mysql_error logs with an error level per 5 minute window. The default condition of error per 5 minute window is 5.
+
+### Prerequisites
+The name of the metric should be:
+`mysql.error.count`
+
+The filter for the metric should be:
+```
+logName:"mysql_error"
+jsonPayload.level="Error"
+```
+
+## High slow queries rate
+The slow queries are collected from mysql_slow logs. More specific queries can be filtered using the `jasonPayload.message` field shown in the filter below. Additionally, different max query times can also be filtered using `jsonPayload.queryTime` field.
+
+### Prerequisites
+The name of the metric should be:
+`mysql.slow_queries.count`
+
+The filter for the metric should be:
+```
+logName:"mysql_slow"
+jsonPayload.message:("SELECT" OR "INSERT" OR "UPDATE" OR "CREATE" OR "DELETE")
+jsonPayload.queryTime>1
+```

--- a/alerts/mysql/mysql-high-number-of-log-errors.json
+++ b/alerts/mysql/mysql-high-number-of-log-errors.json
@@ -1,0 +1,26 @@
+{
+  "displayName": "MySQL - High number of log errors",
+  "documentation": {
+    "content": "Log error are a count of logs collected from mysql_error logs with an error level per 5 minute window. The default condition of error per 5 minute window is 5.",
+    "mimeType": "text/markdown"
+},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "logging/user/mysql.error.count",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "0s",
+        "query": "fetch gce_instance\n| metric 'logging.googleapis.com/user/mysql.error.count'\n| window 5m \n| condition val() > 5\n",
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/mysql/mysql-high-number-of-log-warnings.json
+++ b/alerts/mysql/mysql-high-number-of-log-warnings.json
@@ -1,0 +1,26 @@
+{
+  "displayName": "MySQL - High number of log warnings",
+  "documentation": {
+    "content": "Log warnings are a count of logs collected from mysql_error logs with a warning level per 5 minute window. The default condition of warnings per 5 minute window is 20.",
+    "mimeType": "text/markdown"
+},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "logging/user/mysql.warning.count",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "0s",
+        "query": "fetch gce_instance\n| metric 'logging.googleapis.com/user/mysql.warning.count'\n| window 5m \n| condition val() > 20\n",
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/mysql/mysql-high-slow-queries-rate.json
+++ b/alerts/mysql/mysql-high-slow-queries-rate.json
@@ -17,7 +17,7 @@
         ],
         "comparison": "COMPARISON_GT",
         "duration": "0s",
-        "filter": "metric.type=\"logging.googleapis.com/user/mysql.slow_queries.count\"",
+        "filter": "resource.type = \"gce_instance\" AND metric.type=\"logging.googleapis.com/user/mysql.slow_queries.count\"",
         "thresholdValue": 0.5,
         "trigger": {
           "count": 1

--- a/alerts/mysql/mysql-high-slow-queries-rate.json
+++ b/alerts/mysql/mysql-high-slow-queries-rate.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "MySQL - high slow queries rate",
+  "documentation": {
+    "content": "The slow queries are collected from mysql_slow logs. More specific queries can be filtered using the `jasonPayload.message` field shown in the filter below. Additionally, different max query times can also be filtered using `jsonPayload.queryTime` field.",
+    "mimeType": "text/markdown"
+},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "New condition",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_RATE"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "metric.type=\"logging.googleapis.com/user/mysql.slow_queries.count\"",
+        "thresholdValue": 0.5,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}


### PR DESCRIPTION
Intending to add these alerts:

## High number of log warnings alert
Log warnings are a count of logs collected from mysql_error logs with a warning level per 5 minute window. The default condition of warnings per 5 minute window is 20.

### Prerequisites
The name of the metric should be:
`mysql.warning.count`

The filter for the metric should be:
```
logName:"mysql_error"
jsonPayload.level="Warning"
```

## High number of log errors alert
Log error are a count of logs collected from mysql_error logs with an error level per 5 minute window. The default condition of error per 5 minute window is 5.

### Prerequisites
The name of the metric should be:
`mysql.error.count`

The filter for the metric should be:
```
logName:"mysql_error"
jsonPayload.level="Error"
```

## High slow queries rate
The slow queries are collected from mysql_slow logs. More specific queries can be filtered using the `jasonPayload.message` field shown in the filter below. Additionally, different max query times can also be filtered using `jsonPayload.queryTime` field.

### Prerequisites
The name of the metric should be:
`mysql.slow_queries.count`

The filter for the metric should be:
```
logName:"mysql_slow"
jsonPayload.message:("SELECT" OR "INSERT" OR "UPDATE" OR "CREATE" OR "DELETE")
jsonPayload.queryTime>1
```