### PR TITLE
Active Directory Ops Agent Alerts

### DIFF
--- a/alerts/active-directory/README.md
+++ b/alerts/active-directory/README.md
@@ -1,0 +1,31 @@
+# Alerts for Active Directory Ops Agent
+
+## LDAP Connections Higher than Recommended
+
+It is recommended to keep LDAP connections below 8000. If this value is exceeding then there may be real performance impacts.
+
+### Creating notification Channels and User Labels
+
+Whether these alert policies are being used as standalones or base templates for a deployment strategy like terraform, one thing that should be utilized is notification channels and user labels.
+
+### User Labels
+
+Supplying user labels could give extra identification information about the firing alert:
+
+i.e.
+
+```json
+    "userLabels": {
+        "datacenter": "central"
+    }
+```
+
+#### Notification Channels
+
+The ID of the notification channel to be notifed.
+
+```json
+    "notificationChannels": [
+        "projects/project-id/notificationChannels/1234567"
+    ]
+```

--- a/alerts/active-directory/README.md
+++ b/alerts/active-directory/README.md
@@ -4,6 +4,10 @@
 
 It is recommended to keep LDAP connections below 8000. If this value is exceeding then there may be real performance impacts.
 
+## Long Replications
+
+Alert configured for if a replication takes longer than 30 minutes, feel free to modify this window to fit your environment. This could be an indication that replication is taking longer than expected.
+
 ### Creating notification Channels and User Labels
 
 Whether these alert policies are being used as standalones or base templates for a deployment strategy like terraform, one thing that should be utilized is notification channels and user labels.

--- a/alerts/active-directory/ldap-connections.json
+++ b/alerts/active-directory/ldap-connections.json
@@ -1,0 +1,36 @@
+{
+    "displayName": "Active Directory - LDAP Connections Higher than Recommended",
+    "documentation": {
+        "content": "It is recommended to keep LDAP connections below 8000. If this value is exceeding then there may be real performance impacts.",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "Active Directory - LDAP Connections Above Recommendation",
+            "conditionThreshold": {
+                "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/active_directory.ds.ldap.client.session.count\"",
+                "aggregations": [
+                    {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                ],
+                "comparison": "COMPARISON_GT",
+                "duration": "60s",
+                "trigger": {
+                    "count": 1
+                },
+                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
+                "thresholdValue": 8000
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "3600s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}

--- a/alerts/active-directory/long-replication.json
+++ b/alerts/active-directory/long-replication.json
@@ -1,0 +1,36 @@
+{
+    "displayName": "Active Directory - Long Replication",
+    "documentation": {
+        "content": "Alert configured for if a replication takes longer than 30 minutes, feel free to modify this window to fit your environment. This could be an indication that replication is taking longer than expected.",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "Active Directory - Long Replications",
+            "conditionThreshold": {
+                "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/active_directory.ds.replication.operation.pending\"",
+                "aggregations": [
+                    {
+                        "alignmentPeriod": "900s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                ],
+                "comparison": "COMPARISON_GT",
+                "duration": "60s",
+                "trigger": {
+                    "count": 1
+                },
+                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
+                "thresholdValue": 1
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "3600s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}


### PR DESCRIPTION
## LDAP Connections Higher than Recommended

It is recommended to keep LDAP connections below 8000. If this value is exceeding then there may be real performance impacts.


## Long Replications

Alert configured for if a replication takes longer than 30 minutes, feel free to modify this window to fit your environment. This could be an indication that replication is taking longer than expected.