### PR TITLE
Add Ops agent Sap Hana alert polices

### DIFF
--- a/alerts/saphana/README.md
+++ b/alerts/saphana/README.md
@@ -1,5 +1,14 @@
 # Sap Hana Alerts for Ops Agent
 
+# High priority alert
+High priority alert occurs when `saphana.alert.count` produces a rating 5 alert for critical error messages.
+
+# Old backups alert
+If `backup.latest` is older than 24 hours there can be an issue with creating new backups.
+
+### Server down alert
+When the `saphana.uptime` metric is absent, an alert is triggered indicating server downtime.
+
 ### Notification Channels
 For all alerts, a notification channel needs to be set up or the alert will fire silently.
 
@@ -13,12 +22,3 @@ User labels can be used for these policies by modifying the userLabels fields of
   }
 }
 ```
-
-# High priority alert
-High priority alert occurs when `saphana.alert.count` produces a rating 5 alert for critical error messages.
-
-# Old backups alert
-If `backup.latest` is older than 24 hours there can be an issue with creating new backups.
-
-### Server down alert
-When the `saphana.uptime` metric is absent, an alert is triggered indicating server downtime.

--- a/alerts/saphana/README.md
+++ b/alerts/saphana/README.md
@@ -1,0 +1,24 @@
+# Sap Hana Alerts for Ops Agent
+
+### Notification Channels
+For all alerts, a notification channel needs to be set up or the alert will fire silently.
+
+### User Labels
+User labels can be used for these policies by modifying the userLabels fields of the policies. i.e.
+
+```json
+{ 
+  "userLabels": {
+    "datacenter": "central"
+  }
+}
+```
+
+# High priority alert
+High priority alert occurs when `saphana.alert.count` produces a rating 5 alert for critical error messages.
+
+# Old backups alert
+If `backup.latest` is older than 24 hours there can be an issue with creating new backups.
+
+### Server down alert
+When the `saphana.uptime` metric is absent, an alert is triggered indicating server downtime.

--- a/alerts/saphana/saphana-high-priority-alert.json
+++ b/alerts/saphana/saphana-high-priority-alert.json
@@ -1,0 +1,34 @@
+  {
+  "displayName": "Sap Hana - High priority alert",
+  "documentation": {
+    "content": "High priority alert occurs when `saphana.alert.count` produces a rating 5 alert for critical error messages.",
+    "mimeType": "text/markdown"
+},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Generic Node - saphana.alert.count",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_COUNT"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"generic_node\" AND metric.type = \"custom.googleapis.com/saphana.alert.count\" AND metric.labels.rating = \"5\"",
+        "thresholdValue": 5,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/saphana/saphana-old-backups-alert.json
+++ b/alerts/saphana/saphana-old-backups-alert.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "Sap Hana - Old backups alert",
+  "documentation": {
+    "content": "If `backup.latest` is older than 24 hours there can be an issue with creating new backups.",
+    "mimeType": "text/markdown"
+},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Generic Node - saphana.backup.latest",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_MEAN"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"generic_node\" AND metric.type = \"custom.googleapis.com/saphana.backup.latest\"",
+        "thresholdValue": 86400,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/saphana/saphana-server-down.json
+++ b/alerts/saphana/saphana-server-down.json
@@ -1,0 +1,32 @@
+{
+  "displayName": "Sap Hana - server down",
+  "documentation": {
+    "content": "When the `saphana.uptime` metric is absent, an alert is triggered indicating server downtime.",
+    "mimeType": "text/markdown"
+},
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Generic Node - saphana.uptime",
+      "conditionAbsent": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_COUNT"
+          }
+        ],
+        "duration": "300s",
+        "filter": "resource.type = \"generic_node\" AND metric.type = \"custom.googleapis.com/saphana.uptime\"",
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}


### PR DESCRIPTION
Intending to add these alerts:

# High priority alert
High priority alert occurs when `saphana.alert.count` produces a rating 5 alert for critical error messages.

# Old backups alert
If `backup.latest` is older than 24 hours there can be an issue with creating new backups.

### Server down alert
When the `saphana.uptime` metric is absent, an alert is triggered indicating server downtime.
