### PR TITLE
Update log link query for mongodb

### DIFF
--- a/dashboards/mongodb/mongodb-gce-overview.json
+++ b/dashboards/mongodb/mongodb-gce-overview.json
@@ -1,4 +1,5 @@
 {
+  "category": "CUSTOM",
   "displayName": "MongoDB Overview",
   "mosaicLayout": {
     "columns": 12,
@@ -216,7 +217,7 @@
         "height": 3,
         "widget": {
           "text": {
-            "content": "[How to configure MongoDB Monitoring](https://cloud.google.com/monitoring/agent/ops-agent/third-party/mongodb)\n\n[View MongoDB Access Logs](https://console.cloud.google.com/logs/query;query=logName:\"mongodb_default\"%0Aresource.type%3D\"gce_instance\"%0AjsonPayload.component%3D\"ACCESS\")\n\n[View MongoDB General Logs](https://console.cloud.google.com/logs/query;query=logName:\"mongodb_default\"%0Aresource.type%3D\"gce_instance\"%0AjsonPayload.component!%3D\"ACCESS\")",
+            "content": "[How to configure MongoDB Monitoring](https://cloud.google.com/monitoring/agent/ops-agent/third-party/mongodb)\n\n[View MongoDB Logs](https://console.cloud.google.com/logs/query;query=resource.type%3D%22gce_instance%22%0AlogName:%22mongodb%22)\n",
             "format": "MARKDOWN"
           },
           "title": "MongoDB Monitoring Links"
@@ -242,7 +243,6 @@
                 }
               }
             ],
-            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
               "label": "y1Axis",
@@ -280,7 +280,6 @@
                 }
               }
             ],
-            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
               "label": "y1Axis",
@@ -309,7 +308,6 @@
                 }
               }
             ],
-            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
               "label": "y1Axis",
@@ -338,7 +336,6 @@
                 }
               }
             ],
-            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
               "label": "y1Axis",


### PR DESCRIPTION
The current markdown links to the markdown logs widget were incorrect. The new changes are set to the correct log name, `mongodb` as in the [ops agent](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/apps/mongodb.go#L96)
```
resource.type="gce_instance"
logName:"mongodb"
```