### PR TITLE
Postgresql: change log link to postgresql_general

### DIFF
--- a/dashboards/postgresql/postgresql-gce-overview.json
+++ b/dashboards/postgresql/postgresql-gce-overview.json
@@ -18,14 +18,17 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "apiSource": "DEFAULT_CLOUD",
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_NONE",
                       "perSeriesAligner": "ALIGN_RATE"
                     },
                     "filter": "metric.type=\"workload.googleapis.com/postgresql.blocks_read\"",
                     "secondaryAggregation": {
                       "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_NONE",
                       "perSeriesAligner": "ALIGN_MEAN"
                     }
                   }
@@ -58,14 +61,17 @@
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "apiSource": "DEFAULT_CLOUD",
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_NONE",
                       "perSeriesAligner": "ALIGN_RATE"
                     },
                     "filter": "metric.type=\"workload.googleapis.com/postgresql.commits\"",
                     "secondaryAggregation": {
                       "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_NONE",
                       "perSeriesAligner": "ALIGN_MEAN"
                     }
                   }
@@ -77,9 +83,11 @@
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "apiSource": "DEFAULT_CLOUD",
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_NONE",
                       "perSeriesAligner": "ALIGN_MEAN"
                     },
                     "filter": "metric.type=\"workload.googleapis.com/postgresql.rollbacks\" resource.type=\"gce_instance\""
@@ -95,7 +103,8 @@
           }
         },
         "width": 4,
-        "xPos": 4
+        "xPos": 4,
+        "yPos": 0
       },
       {
         "height": 4,
@@ -112,9 +121,11 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "apiSource": "DEFAULT_CLOUD",
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_NONE",
                       "perSeriesAligner": "ALIGN_MEAN"
                     },
                     "filter": "metric.type=\"workload.googleapis.com/postgresql.db_size\""
@@ -131,7 +142,8 @@
           }
         },
         "width": 4,
-        "xPos": 8
+        "xPos": 8,
+        "yPos": 0
       },
       {
         "height": 4,
@@ -148,9 +160,11 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "apiSource": "DEFAULT_CLOUD",
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_NONE",
                       "perSeriesAligner": "ALIGN_MEAN"
                     },
                     "filter": "metric.type=\"workload.googleapis.com/postgresql.backends\""
@@ -165,7 +179,9 @@
             }
           }
         },
-        "width": 4
+        "width": 4,
+        "xPos": 0,
+        "yPos": 0
       },
       {
         "height": 4,
@@ -182,15 +198,14 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "apiSource": "DEFAULT_CLOUD",
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_NONE",
                       "perSeriesAligner": "ALIGN_MEAN"
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/postgresql.rows\"",
-                    "secondaryAggregation": {
-                      "alignmentPeriod": "60s"
-                    }
+                    "filter": "metric.type=\"workload.googleapis.com/postgresql.rows\""
                   }
                 }
               }
@@ -203,6 +218,7 @@
           }
         },
         "width": 6,
+        "xPos": 0,
         "yPos": 4
       },
       {
@@ -220,14 +236,17 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "apiSource": "DEFAULT_CLOUD",
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_NONE",
                       "perSeriesAligner": "ALIGN_RATE"
                     },
                     "filter": "metric.type=\"workload.googleapis.com/postgresql.operations\"",
                     "secondaryAggregation": {
                       "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_NONE",
                       "perSeriesAligner": "ALIGN_MEAN"
                     }
                   }
@@ -242,6 +261,7 @@
           }
         },
         "width": 12,
+        "xPos": 0,
         "yPos": 8
       },
       {
@@ -270,6 +290,7 @@
           }
         },
         "width": 4,
+        "xPos": 0,
         "yPos": 12
       },
       {
@@ -290,7 +311,6 @@
                 }
               }
             ],
-            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
               "label": "y1Axis",
@@ -335,12 +355,13 @@
         "height": 2,
         "widget": {
           "text": {
-            "content": "[How to configure PostgreSQL Monitoring](https://cloud.google.com/monitoring/agent/ops-agent/third-party/postgresql)\n\n[View PostgreSQL Error Log](https://console.cloud.google.com/logs/query?query=logName:%22postgresql_error%22%0Aresource.type%3D%22gce_instance%22)",
+            "content": "[How to configure PostgreSQL Monitoring](https://cloud.google.com/monitoring/agent/ops-agent/third-party/postgresql)\n\n[View PostgreSQL General Log](https://console.cloud.google.com/logs/query;query=resource.type%3D%22gce_instance%22%0AlogName:postgresql_general)",
             "format": "MARKDOWN"
           },
           "title": "PostgreSQL Monitoring Links"
         },
         "width": 12,
+        "xPos": 0,
         "yPos": 16
       }
     ]


### PR DESCRIPTION
The current markdown links to the markdown logs widget were incorrect. The new changes are set to the correct log name, postgresql_general as in the [ops agent](https://github.com/GoogleCloudPlatform/ops-agent/blob/master/apps/postgresql.go#L92)

```
resource.type="gce_instance"
logName:postgresql_general
```