### PR TITLE
Add Vault Alerts

### DIFF
--- a/alerts/vault/README.md
+++ b/alerts/vault/README.md
@@ -1,0 +1,39 @@
+# Alerts for Vault in the Ops Agent
+
+## Token Renew/Revoke Alert
+
+This alert will be triggered when it is taking longer than one second to renew or revoke tokens. This alert will help notify users when there is a potential problem with backend token storage.
+
+## Token Creation Alert
+
+This alert will be triggered when tokens are being created at a rate considered abnormally high for the user.\nThis alert will help notify users if an application is under stress or abnormal usage. The threshold for this alert will need to be adjusted on a per user basis.
+
+## Audit Failure Alert
+
+This alert will be triggered whenever an audit request or audit response failure is greater than 0. This alert will help notify users when their audit device is potentially blocked. If it is blocked, Vault will become unresponsive.
+
+### Creating notification Channels and User Labels
+
+Whether these alert policies are being used as standalones or base templates for a deployment strategy like terraform, one thing that should be utilized is notification channels and user labels.
+
+### User Labels
+
+Supplying user labels could give extra identification information about the firing alert:
+
+i.e.
+
+```json
+    "userLabels": {
+        "datacenter": "central"
+    }
+```
+
+#### Notification Channels
+
+The ID of the notification channel to be notified.
+
+```json
+    "notificationChannels": [
+        "projects/project-id/notificationChannels/1234567"
+    ]
+```

--- a/alerts/vault/Vault - Audit Failure Alert.json
+++ b/alerts/vault/Vault - Audit Failure Alert.json
@@ -1,0 +1,26 @@
+{
+  "displayName": "Vault - Audit Failure Alert",
+  "documentation": {
+    "content": "This alert will be triggered whenever an audit request or audit response failure is greater than 0. This alert will help notify users when their audit device is potentially blocked. If it is blocked, Vault will become unresponsive.\n",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "New condition",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "0s",
+        "query": "fetch gce_instance\n| { metric 'workload.googleapis.com/vault.audit.response.failed'\n; metric 'workload.googleapis.com/vault.audit.request.failed' }\n| outer_join 0\n| group_by 1m\n| condition val(0) > 0 || val(1) > 0",
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/vault/Vault - Token Creation Alert.json
+++ b/alerts/vault/Vault - Token Creation Alert.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "Vault - Token Creation Alert",
+  "documentation": {
+    "content": "This alert will be triggered when tokens are being created at a rate considered abnormally high for the user.\nThis alert will help notify users if an application is under stress or abnormal usage. The threshold for this alert will need to be adjusted on a per user basis.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - workload/vault.token.count",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_MEAN"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/vault.token.count\"",
+        "thresholdValue": 20,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/vault/Vault - Token Renew_Revoke Alert.json
+++ b/alerts/vault/Vault - Token Renew_Revoke Alert.json
@@ -1,0 +1,26 @@
+{
+  "displayName": "Vault - Token Renew/Revoke Alert",
+  "documentation": {
+    "content": "This alert will be triggered when it is taking longer than one second to renew or revoke tokens. This alert will help notify users when there is a potential problem with backend token storage.\n\n",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "New condition",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "0s",
+        "query": "fetch gce_instance\n| { metric 'workload.googleapis.com/vault.token.renew.time'\n; metric 'workload.googleapis.com/vault.token.revoke.time' }\n| outer_join 0\n| group_by 1m\n| condition val(0) > 1000 || val(1) > 1000",
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}


### PR DESCRIPTION
Alerts to be added: 

## Token Renew/Revoke Alert

This alert will be triggered when it is taking longer than one second to renew or revoke tokens. This alert will help notify users when there is a potential problem with backend token storage.

## Token Creation Alert

This alert will be triggered when tokens are being created at a rate considered abnormally high for the user.\nThis alert will help notify users if an application is under stress or abnormal usage. The threshold for this alert will need to be adjusted on a per user basis.

## Audit Failure Alert

This alert will be triggered whenever an audit request or audit response failure is greater than 0. This alert will help notify users when their audit device is potentially blocked. If it is blocked, Vault will become unresponsive.
