### PR TITLE
Add google-cloud-alerting to /alerts

### DIFF
--- a/alerts/google-cloud-alerting/README.md
+++ b/alerts/google-cloud-alerting/README.md
@@ -1,0 +1,3 @@
+# Alert Policy Templates for the Cloud Alerting Team
+
+Templates in this directory are managed by the Cloud Alerting Eng team and for development/testing/debugging purposes.

--- a/alerts/google-cloud-alerting/README.md
+++ b/alerts/google-cloud-alerting/README.md
@@ -1,3 +1,3 @@
 # Alert Policy Templates for the Cloud Alerting Team
 
-Templates in this directory are managed by the Cloud Alerting Eng team and for development/testing/debugging purposes.
+Templates in this directory are managed by the Cloud Alerting Eng team and for development purposes.

--- a/alerts/google-cloud-alerting/log-match-condition.v1.json
+++ b/alerts/google-cloud-alerting/log-match-condition.v1.json
@@ -1,0 +1,21 @@
+{
+  "displayName": "OiC Sample Log-Based Alert Policy",
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Log match condition",
+      "conditionMatchedLog": {
+        "filter": "logName=\"projects/cloud-alerting-test/logs/alerting-summit-log\""
+      }
+    }
+  ],
+  "alertStrategy": {
+    "notificationRateLimit": {
+      "period": "300s"
+    },
+    "autoClose": "1800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/google-cloud-alerting/metadata.yaml
+++ b/alerts/google-cloud-alerting/metadata.yaml
@@ -1,0 +1,16 @@
+alert_policy_templates:
+-
+  id: log-match-condition
+  display_name: log match condition
+  description: "Match alerting-summit-log"
+  version: 1
+-
+  id: utilization-too-high
+  display_name: utilization too high
+  description: "MBA with threshold 1"
+  version: 1
+-
+  id: utilization-too-high
+  display_name: utilization too high
+  description: "MBA with threshold 2"
+  version: 2

--- a/alerts/google-cloud-alerting/metadata.yaml
+++ b/alerts/google-cloud-alerting/metadata.yaml
@@ -9,8 +9,3 @@ alert_policy_templates:
   display_name: utilization too high
   description: "MBA with threshold 1"
   version: 1
--
-  id: utilization-too-high
-  display_name: utilization too high
-  description: "MBA with threshold 2"
-  version: 2

--- a/alerts/google-cloud-alerting/utilization-too-high.v1.json
+++ b/alerts/google-cloud-alerting/utilization-too-high.v1.json
@@ -1,0 +1,29 @@
+{
+  "displayName": "OiC Sample Metric-Based Alert Policy",
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - CPU usage",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_MEAN"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"compute.googleapis.com/instance/cpu/usage_time\"",
+        "thresholdValue": 1,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true
+}


### PR DESCRIPTION
Sets up the google-cloud-alerting folder in /alerts for development/testing.