### PR TITLE
fix: MSSQL alerts: Remove evaluationMissingData field

### DIFF
--- a/alerts/mssql-server/connections-near-limit.v1.json
+++ b/alerts/mssql-server/connections-near-limit.v1.json
@@ -19,7 +19,6 @@
                 ],
                 "comparison": "COMPARISON_GT",
                 "duration": "0s",
-                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
                 "trigger": {
                     "count": 1
                 },

--- a/alerts/mssql-server/high-lock-wait-rates.v1.json
+++ b/alerts/mssql-server/high-lock-wait-rates.v1.json
@@ -19,7 +19,6 @@
                 ],
                 "comparison": "COMPARISON_GT",
                 "duration": "0s",
-                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
                 "trigger": {
                     "count": 1
                 },

--- a/alerts/mssql-server/high-page-split-rate.v1.json
+++ b/alerts/mssql-server/high-page-split-rate.v1.json
@@ -19,7 +19,6 @@
                 ],
                 "comparison": "COMPARISON_GT",
                 "duration": "0s",
-                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
                 "trigger": {
                     "count": 1
                 },


### PR DESCRIPTION
The presence of this field causes the policy to fail to import with the following error:
```
Field alert_policy.conditions[0].condition_threshold.evaluation_missing_data had an invalid value of "3": Conditions setting evaluation_missing_data must have a non-zero duration.
```

If `duration` is `0s`, this field is not allowed.