### PR TITLE
Ops Agent Alerts for PostgreSQL

### DIFF
--- a/alerts/postgresql/README.md
+++ b/alerts/postgresql/README.md
@@ -1,0 +1,17 @@
+# Alerts for Postgres in Ops Agent
+
+## High CPU Utilization
+
+Alerts whenever the CPU utilization goes above 80% which usually indicates the instance's performance is heavily degraded and likely is going to impact applications reliant on postgres.
+
+## Connections Near Limit
+
+Connections are a limiting factor in postgres and once the instance cannot accept any more connections, then applications reliant on the postgres instance cannot function.
+
+## High Database Size
+
+Alert fires when the database size is growing greater than expected (this value will be subject to instance size and utilization); defaulted to 93 GB but will be subject to instance size as well as connected storage.
+
+## Reached Max Written Buffers
+
+Alert fires when the background writer attains 3 maxwritten errors i.e. it cannot flush buffers because it has written too many. This is an indication that if an outage were to occur, then any bytes pending may be subject to be lost.

--- a/alerts/postgresql/connections.json
+++ b/alerts/postgresql/connections.json
@@ -1,0 +1,26 @@
+{
+    "displayName": "Postgresql - High Connection Utilization",
+    "documentation": {
+        "content": "Alert fires when active connections are near a threshold of 90. Around this point is where the instance may run into connection issues and may start refusing connections.",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "Connections near system max",
+            "conditionMonitoringQueryLanguage": {
+                "duration": "0s",
+                "trigger": {
+                    "count": 1
+                },
+                "query": "{\n     t_0: fetch gce_instance::workload.googleapis.com/postgresql.connection.max ;\n     t_1: fetch gce_instance::workload.googleapis.com/postgresql.backends\n}\n| group_by [resource.instance_id]\n| outer_join 0\n| window 1m\n| condition val(0) * .9 < val(1)\n"
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}

--- a/alerts/postgresql/high_cpu_utilization.json
+++ b/alerts/postgresql/high_cpu_utilization.json
@@ -1,0 +1,27 @@
+{
+    "displayName": "Postgres - High CPU Utilization",
+    "documentation": {
+        "content": "Alerts whenever the CPU utilization goes above 80% which usually indicates the instance's performance is heavily degraded and likely is going to impact applications reliant on postgres.",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "Postgres CPU > 90%",
+            "conditionMonitoringQueryLanguage": {
+                "duration": "0s",
+                "trigger": {
+                    "count": 1
+                },
+                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
+                "query": "def top_cpu_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_cpu: metric 'compute.googleapis.com/instance/cpu/utilization'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value t_cpu.value.utilization\n  | group_by [resource.project_id, resource.zone, metric.instance_name], 1m,\n      [value_utilization_mean: mean(t_cpu.value.utilization)]\n  | every 1m;\n\n@top_cpu_filtered_by_metric 'workload.googleapis.com/postgresql.operations'\n| condition val() > .9"
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "1800s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}

--- a/alerts/postgresql/high_db_size.json
+++ b/alerts/postgresql/high_db_size.json
@@ -1,0 +1,26 @@
+{
+    "displayName": "Postgresql - High Database Size",
+    "documentation": {
+        "content": "Alert fires when the database size is growing greater than expected (this value will be subject to instance size and utilization); defaulted to 93 GB but will be subject to instance size as well as connected storage.",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "Database Size Large for Environment",
+            "conditionMonitoringQueryLanguage": {
+                "duration": "0s",
+                "trigger": {
+                    "count": 1
+                },
+                "query": "fetch gce_instance\n| metric 'workload.googleapis.com/postgresql.db_size'\n| group_by 1m, [value_db_size_mean: mean(value.db_size)]\n| every 1m\n| cast_units \"By\"\n| condition val() > 1e+11 \"By\""
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}

--- a/alerts/postgresql/max_writes.json
+++ b/alerts/postgresql/max_writes.json
@@ -1,0 +1,35 @@
+{
+    "displayName": "Postgresql - Reached Max Written Buffers",
+    "documentation": {
+        "content": "Alert fires when the background writer attains 3 maxwritten errors i.e. it cannot flush buffers because it has written too many. This is an indication that if an outage were to occur, then any bytes pending may be subject to be lost.",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "Experiencing Max Written Pauses",
+            "conditionThreshold": {
+                "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/postgresql.bgwriter.maxwritten\"",
+                "aggregations": [
+                    {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_RATE"
+                    }
+                ],
+                "comparison": "COMPARISON_GT",
+                "duration": "0s",
+                "trigger": {
+                    "count": 1
+                },
+                "thresholdValue": 3
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}


### PR DESCRIPTION
Alerts proposed:

## High CPU Utilization

Alerts whenever the CPU utilization goes above 80% which usually indicates the instance's performance is heavily degraded and likely is going to impact applications reliant on postgres.

## Connections Near Limit

Connections are a limiting factor in postgres and once the instance cannot accept any more connections, then applications reliant on the postgres instance cannot function.

## High Database Size

Alert fires when the database size is growing greater than expected (this value will be subject to instance size and utilization); defaulted to 93 GB but will be subject to instance size as well as connected storage.

## Reached Max Written Buffers

Alert fires when the background writer attains 3 maxwritten errors i.e. it cannot flush buffers because it has written too many. This is an indication that if an outage were to occur, then any bytes pending may be subject to be lost.


Submitting in draft until metric additions get merged :) 