### PR TITLE
Second batch of GKE alerts

### DIFF
--- a/alerts/airflow-gke/README.md
+++ b/alerts/airflow-gke/README.md
@@ -1,0 +1,31 @@
+# Apache Airflow Scheduler Alerts for GKE
+
+## DAG import errors alert
+When a DAG file fails to import, the DAG will not be able to run.
+
+
+### Creating Notification Channels and User Labels
+
+It is strongly recommended to add notification channels and user labels to the alert policies. The notification channel will set the notification destination if the alert policy is triggered. User labels are used for categorization, and can be used to indicate the severity level.
+
+### User Labels
+
+Supplying user labels could give extra identification information about the firing alert:
+
+i.e.
+
+```json
+    "userLabels": {
+        "Severity": "Warning"
+    }
+```
+
+### Notification Channels
+
+The ID of the notification channel to be notified.
+
+```json
+    "notificationChannels": [
+        "projects/project-id/notificationChannels/1234567"
+    ]
+```

--- a/alerts/airflow-gke/dag-import-errors.v1.json
+++ b/alerts/airflow-gke/dag-import-errors.v1.json
@@ -1,0 +1,33 @@
+{
+    "displayName": "Apache Airflow Scheduler - Prometheus - DAG Import Errors",
+    "documentation": {
+      "content": "When a DAG file fails to import, the DAG will not be able to run.",
+      "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+      {
+        "displayName": "Prometheus Target - prometheus/airflow_dag_processing_import_errors/gauge",
+        "conditionThreshold": {
+          "aggregations": [
+            {
+              "alignmentPeriod": "300s",
+              "perSeriesAligner": "ALIGN_MEAN"
+            }
+          ],
+          "comparison": "COMPARISON_GT",
+          "duration": "0s",
+          "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/airflow_dag_processing_import_errors/gauge\"",
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+  }

--- a/alerts/airflow-gke/metadata.yaml
+++ b/alerts/airflow-gke/metadata.yaml
@@ -1,0 +1,5 @@
+alert_policy_templates:
+  - id: "dag-import-errors"
+    display_name: "Apache Airflow Scheduler - Prometheus - DAG Import Errors"
+    description: "When a DAG file fails to import, the DAG will not be able to run."
+    version: 1

--- a/alerts/argo-server-gke/README.md
+++ b/alerts/argo-server-gke/README.md
@@ -1,0 +1,31 @@
+# Argo Server Alerts for GKE
+
+## Workflow errors alert
+This alert triggers when a workflow fails to run successfully. See the `cause` label on the triggering time-series for the cause of the error.
+
+
+### Creating Notification Channels and User Labels
+
+It is strongly recommended to add notification channels and user labels to the alert policies. The notification channel will set the notification destination if the alert policy is triggered. User labels are used for categorization, and can be used to indicate the severity level.
+
+### User Labels
+
+Supplying user labels could give extra identification information about the firing alert:
+
+i.e.
+
+```json
+    "userLabels": {
+        "Severity": "Warning"
+    }
+```
+
+### Notification Channels
+
+The ID of the notification channel to be notified.
+
+```json
+    "notificationChannels": [
+        "projects/project-id/notificationChannels/1234567"
+    ]
+```

--- a/alerts/argo-server-gke/metadata.yaml
+++ b/alerts/argo-server-gke/metadata.yaml
@@ -1,0 +1,5 @@
+alert_policy_templates:
+  - id: "workflow-errors"
+    display_name: "Argo Server - Prometheus - Workflow Errors"
+    description: "This alert triggers when a workflow fails to run successfully. See the `cause` label on the triggering time-series for the cause of the error."
+    version: 1

--- a/alerts/argo-server-gke/workflow-errors.v1.json
+++ b/alerts/argo-server-gke/workflow-errors.v1.json
@@ -1,0 +1,33 @@
+{
+    "displayName": "Argo Server - Prometheus - Workflow Errors",
+    "documentation": {
+      "content": "This alert triggers when a workflow fails to run successfully. See the `cause` label on the triggering time-series for the cause of the error.",
+      "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+      {
+        "displayName": "Prometheus Target - prometheus/argo_workflows_error_count/counter",
+        "conditionThreshold": {
+          "aggregations": [
+            {
+              "alignmentPeriod": "300s",
+              "perSeriesAligner": "ALIGN_RATE"
+            }
+          ],
+          "comparison": "COMPARISON_GT",
+          "duration": "0s",
+          "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/argo_workflows_error_count/counter\"",
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+  }

--- a/alerts/etcd-gke/README.md
+++ b/alerts/etcd-gke/README.md
@@ -1,0 +1,33 @@
+# etcd Alerts for GKE
+
+## Long fsync duration alert
+When the WAL (Write-Ahead Logging) fsync time is too long, performance is degrading, often due to disk issues. This could cause cluster instability, or high latency for client requests.
+
+## Rapid leader changes alert
+When the leader of the cluster changes often, it indicates that the leader is unstable, often due to network issues or high load.
+
+### Creating Notification Channels and User Labels
+
+It is strongly recommended to add notification channels and user labels to the alert policies. The notification channel will set the notification destination if the alert policy is triggered. User labels are used for categorization, and can be used to indicate the severity level.
+
+### User Labels
+
+Supplying user labels could give extra identification information about the firing alert:
+
+i.e.
+
+```json
+    "userLabels": {
+        "Severity": "Warning"
+    }
+```
+
+### Notification Channels
+
+The ID of the notification channel to be notified.
+
+```json
+    "notificationChannels": [
+        "projects/project-id/notificationChannels/1234567"
+    ]
+```

--- a/alerts/etcd-gke/README.md
+++ b/alerts/etcd-gke/README.md
@@ -1,7 +1,7 @@
 # etcd Alerts for GKE
 
 ## Long fsync duration alert
-When the WAL (Write-Ahead Logging) fsync time is too long, performance is degrading, often due to disk issues. This could cause cluster instability, or high latency for client requests.
+When the WAL (Write-Ahead Logging) fsync time is too long, performance is degrading, often due to disk issues. This could cause cluster instability or high latency for client requests.
 
 ## Rapid leader changes alert
 When the leader of the cluster changes often, it indicates that the leader is unstable, often due to network issues or high load.

--- a/alerts/etcd-gke/long-fsync-duration.v1.json
+++ b/alerts/etcd-gke/long-fsync-duration.v1.json
@@ -1,7 +1,7 @@
 {
     "displayName": "etcd - Prometheus - Long Fsync Duration",
     "documentation": {
-      "content": "When the WAL (Write-Ahead Logging) fsync time is too long, performance is degrading, often due to disk issues. This could cause cluster instability, or high latency for client requests.",
+      "content": "When the WAL (Write-Ahead Logging) fsync time is too long, performance is degrading, often due to disk issues. This could cause cluster instability or high latency for client requests.",
       "mimeType": "text/markdown"
     },
     "userLabels": {},

--- a/alerts/etcd-gke/long-fsync-duration.v1.json
+++ b/alerts/etcd-gke/long-fsync-duration.v1.json
@@ -1,0 +1,35 @@
+{
+    "displayName": "etcd - Prometheus - Long Fsync Duration",
+    "documentation": {
+      "content": "When the WAL (Write-Ahead Logging) fsync time is too long, performance is degrading, often due to disk issues. This could cause cluster instability, or high latency for client requests.",
+      "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+      {
+        "displayName": "Prometheus Target - prometheus/etcd_disk_wal_fsync_duration_seconds/histogram",
+        "conditionThreshold": {
+          "aggregations": [
+            {
+              "alignmentPeriod": "300s",
+              "crossSeriesReducer": "REDUCE_MEAN",
+              "perSeriesAligner": "ALIGN_DELTA"
+            }
+          ],
+          "comparison": "COMPARISON_GT",
+          "duration": "0s",
+          "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/etcd_disk_wal_fsync_duration_seconds/histogram\"",
+          "thresholdValue": 0.1,
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+  }

--- a/alerts/etcd-gke/metadata.yaml
+++ b/alerts/etcd-gke/metadata.yaml
@@ -1,7 +1,7 @@
 alert_policy_templates:
   - id: "long-fsync-duration"
     display_name: "etcd - Prometheus - Long Fsync Duration"
-    description: "When the WAL (Write-Ahead Logging) fsync time is too long, performance is degrading, often due to disk issues. This could cause cluster instability, or high latency for client requests."
+    description: "When the WAL (Write-Ahead Logging) fsync time is too long, performance is degrading, often due to disk issues. This could cause cluster instability or high latency for client requests."
     version: 1
   - id: "rapid-leader-changes"
     display_name: "etcd - Prometheus - Rapid Leader Changes"

--- a/alerts/etcd-gke/metadata.yaml
+++ b/alerts/etcd-gke/metadata.yaml
@@ -1,0 +1,9 @@
+alert_policy_templates:
+  - id: "long-fsync-duration"
+    display_name: "etcd - Prometheus - Long Fsync Duration"
+    description: "When the WAL (Write-Ahead Logging) fsync time is too long, performance is degrading, often due to disk issues. This could cause cluster instability, or high latency for client requests."
+    version: 1
+  - id: "rapid-leader-changes"
+    display_name: "etcd - Prometheus - Rapid Leader Changes"
+    description: "When the leader of the cluster changes often, it indicates that the leader is unstable, often due to network issues or high load."
+    version: 1

--- a/alerts/etcd-gke/rapid-leader-changes.v1.json
+++ b/alerts/etcd-gke/rapid-leader-changes.v1.json
@@ -1,0 +1,34 @@
+{
+    "displayName": "etcd - Prometheus - Rapid Leader Changes",
+    "documentation": {
+      "content": "When the leader of the cluster changes often, it indicates that the leader is unstable, often due to network issues or high load.",
+      "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+      {
+        "displayName": "Prometheus Target - prometheus/etcd_server_leader_changes_seen_total/counter",
+        "conditionThreshold": {
+          "aggregations": [
+            {
+              "alignmentPeriod": "60s",
+              "perSeriesAligner": "ALIGN_RATE"
+            }
+          ],
+          "comparison": "COMPARISON_GT",
+          "duration": "0s",
+          "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/etcd_server_leader_changes_seen_total/counter\"",
+          "thresholdValue": 0.05,
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+  }

--- a/alerts/haproxy-gke/README.md
+++ b/alerts/haproxy-gke/README.md
@@ -1,0 +1,34 @@
+# HAProxy Alerts for GKE
+
+## Frontend sessions near limit alert
+When the session limit is reached, any new incoming connections will be rejected. This is typically caused by a sudden influx of traffic, and may indicate the configured max number of sessions needs to be adjusted.
+
+
+## Server down alert
+When the server is down, it means that it cannot accept any requests due to degraded health.
+
+### Creating Notification Channels and User Labels
+
+It is strongly recommended to add notification channels and user labels to the alert policies. The notification channel will set the notification destination if the alert policy is triggered. User labels are used for categorization, and can be used to indicate the severity level.
+
+### User Labels
+
+Supplying user labels could give extra identification information about the firing alert:
+
+i.e.
+
+```json
+    "userLabels": {
+        "Severity": "Warning"
+    }
+```
+
+### Notification Channels
+
+The ID of the notification channel to be notified.
+
+```json
+    "notificationChannels": [
+        "projects/project-id/notificationChannels/1234567"
+    ]
+```

--- a/alerts/haproxy-gke/frontend-sessions-near-limit.v1.json
+++ b/alerts/haproxy-gke/frontend-sessions-near-limit.v1.json
@@ -1,0 +1,26 @@
+{
+    "displayName": "HAProxy - Prometheus - Frontend Sessions Reaching Limit",
+    "documentation": {
+        "content": "When the session limit is reached, any new incoming connections will be rejected. This is typically caused by a sudden influx of traffic, and may indicate the configured max number of sessions needs to be adjusted.",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "Prometheus Target - prometheus/haproxy_backend_limit_sessions/gauge",
+            "conditionMonitoringQueryLanguage": {
+                "duration": "0s",
+                "query": "fetch prometheus_target\n| { t_0:\n      metric prometheus.googleapis.com/haproxy_frontend_current_sessions/gauge\n  ; t_1:\n      metric prometheus.googleapis.com/haproxy_frontend_limit_sessions/gauge }\n| outer_join 0\n| value\n    t_0.value.haproxy_frontend_current_sessions\n    / t_1.value.haproxy_frontend_limit_sessions\n| condition val() > 0.9\n| every 5m\n| window 5m",
+                "trigger": {
+                    "count": 1
+                }
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}

--- a/alerts/haproxy-gke/metadata.yaml
+++ b/alerts/haproxy-gke/metadata.yaml
@@ -1,0 +1,9 @@
+alert_policy_templates:
+  - id: "frontend-sessions-near-limit"
+    display_name: "HAProxy - Prometheus - Frontend Sessions Reaching Limit"
+    description: "When the session limit is reached, any new incoming connections will be rejected. This is typically caused by a sudden influx of traffic, and may indicate the configured max number of sessions needs to be adjusted."
+    version: 1
+  - id: "server-down"
+    display_name: "HAProxy - Prometheus - Server Down"
+    description: "When the server is down, it means that it cannot accept any requests due to degraded health."
+    version: 1

--- a/alerts/haproxy-gke/server-down.v1.json
+++ b/alerts/haproxy-gke/server-down.v1.json
@@ -1,0 +1,34 @@
+{
+    "displayName": "HAProxy - Prometheus - Server Down",
+    "documentation": {
+        "content": "When the server is down, it means that it cannot accept any requests due to degraded health.",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "Prometheus Target - prometheus/haproxy_server_up/gauge",
+            "conditionThreshold": {
+                "aggregations": [
+                    {
+                        "alignmentPeriod": "300s",
+                        "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                ],
+                "comparison": "COMPARISON_LT",
+                "duration": "0s",
+                "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/haproxy_server_up/gauge\"",
+                "thresholdValue": 1,
+                "trigger": {
+                    "count": 1
+                }
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}

--- a/alerts/istio-proxy-gke/README.md
+++ b/alerts/istio-proxy-gke/README.md
@@ -1,0 +1,33 @@
+# Istio Proxy Alerts for GKE
+
+## Degraded endpoint alert
+When an endpoint is degraded, the endpoint can still receive traffic, but is de-prioritized. This indicates that a host may have performance issues that need to be remediated for the endpoint to be considered healthy again.
+
+## High request duration alert
+When the request duration is high, it indicates performance issues with deployed Envoy proxies, network issues, or slow application response times.
+
+### Creating Notification Channels and User Labels
+
+It is strongly recommended to add notification channels and user labels to the alert policies. The notification channel will set the notification destination if the alert policy is triggered. User labels are used for categorization, and can be used to indicate the severity level.
+
+### User Labels
+
+Supplying user labels could give extra identification information about the firing alert:
+
+i.e.
+
+```json
+    "userLabels": {
+        "Severity": "Warning"
+    }
+```
+
+### Notification Channels
+
+The ID of the notification channel to be notified.
+
+```json
+    "notificationChannels": [
+        "projects/project-id/notificationChannels/1234567"
+    ]
+```

--- a/alerts/istio-proxy-gke/degraded-endpoint.v1.json
+++ b/alerts/istio-proxy-gke/degraded-endpoint.v1.json
@@ -1,0 +1,34 @@
+{
+    "displayName": "Istio Proxy - Prometheus - Degraded Endpoint",
+    "documentation": {
+        "content": "When an endpoint is degraded, the endpoint can still receive traffic, but is de-prioritized. This indicates that a host may have performance issues that need to be remediated for the endpoint to be considered healthy again.",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "Prometheus Target - prometheus/envoy_cluster_membership_degraded/gauge",
+            "conditionThreshold": {
+                "aggregations": [
+                    {
+                        "alignmentPeriod": "300s",
+                        "crossSeriesReducer": "REDUCE_MEAN",
+                        "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                ],
+                "comparison": "COMPARISON_GT",
+                "duration": "0s",
+                "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/envoy_cluster_membership_degraded/gauge\"",
+                "trigger": {
+                    "count": 1
+                }
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}

--- a/alerts/istio-proxy-gke/high-request-duration.v1.json
+++ b/alerts/istio-proxy-gke/high-request-duration.v1.json
@@ -1,0 +1,26 @@
+{
+    "displayName": "Istio Proxy - Prometheus - High Request Duration",
+    "documentation": {
+      "content": "When the request duration is high, it indicates performance issues with deployed Envoy proxies, network issues, or slow application response times.",
+      "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+      {
+        "displayName": "Prometheus Target - prometheus/istio_request_duration_milliseconds/histogram - 95th percentile",
+        "conditionMonitoringQueryLanguage": {
+          "duration": "0s",
+          "query": "fetch prometheus_target\n| metric\n    'prometheus.googleapis.com/istio_request_duration_milliseconds/histogram'\n| percentile_from(95)\n| cast_units('ms')\n| every 5m\n| window 5m\n| condition val() > 500 'ms'",
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": false,
+    "notificationChannels": []
+  }

--- a/alerts/istio-proxy-gke/metadata.yaml
+++ b/alerts/istio-proxy-gke/metadata.yaml
@@ -1,0 +1,9 @@
+alert_policy_templates:
+  - id: "degraded-endpoint"
+    display_name: "Istio Proxy - Prometheus - Degraded Endpoint"
+    description: "When an endpoint is degraded, the endpoint can still receive traffic, but is de-prioritized. This indicates that a host may have performance issues that need to be remediated for the endpoint to be considered healthy again."
+    version: 1
+  - id: "high-request-duration"
+    display_name: "Istio Proxy - Prometheus - High Request Duration"
+    description: "When the request duration is high, it indicates performance issues with deployed Envoy proxies, network issues, or slow application response times."
+    version: 1

--- a/alerts/jenkins-gke/README.md
+++ b/alerts/jenkins-gke/README.md
@@ -1,0 +1,33 @@
+# Jenkins Alerts for GKE
+
+## Health score below 1 alert
+If the Jenkins health score is below 1, then at least one health check has failed. To view which health checks have failed, see `${JENKINS_URL}/metrics/currentUser/healthcheck?pretty=true`.
+
+## Plugin failure alert
+A plugin failure indicates that a plugin has failed to start. Usually, this can be resolved by explicitly disabling the failing plugin, or by resolving dependency issues with the plugin. See the Jenkins logs to determine the exact cause of the plugin failure.
+
+### Creating Notification Channels and User Labels
+
+It is strongly recommended to add notification channels and user labels to the alert policies. The notification channel will set the notification destination if the alert policy is triggered. User labels are used for categorization, and can be used to indicate the severity level.
+
+### User Labels
+
+Supplying user labels could give extra identification information about the firing alert:
+
+i.e.
+
+```json
+    "userLabels": {
+        "Severity": "Warning"
+    }
+```
+
+### Notification Channels
+
+The ID of the notification channel to be notified.
+
+```json
+    "notificationChannels": [
+        "projects/project-id/notificationChannels/1234567"
+    ]
+```

--- a/alerts/jenkins-gke/health-score-below-1.v1.json
+++ b/alerts/jenkins-gke/health-score-below-1.v1.json
@@ -1,0 +1,34 @@
+{
+    "displayName": "Jenkins - Prometheus - Health Score Below 1",
+    "documentation": {
+      "content": "If the Jenkins health score is below 1, then at least one health check has failed. To view which health checks have failed, see `${JENKINS_URL}/metrics/currentUser/healthcheck?pretty=true`.",
+      "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+      {
+        "displayName": "Prometheus Target - prometheus/jenkins_health_check_score/gauge",
+        "conditionThreshold": {
+          "aggregations": [
+            {
+              "alignmentPeriod": "300s",
+              "perSeriesAligner": "ALIGN_MEAN"
+            }
+          ],
+          "comparison": "COMPARISON_LT",
+          "duration": "0s",
+          "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/jenkins_health_check_score/gauge\"",
+          "thresholdValue": 1,
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": false,
+    "notificationChannels": []
+  }

--- a/alerts/jenkins-gke/metadata.yaml
+++ b/alerts/jenkins-gke/metadata.yaml
@@ -1,0 +1,9 @@
+alert_policy_templates:
+  - id: "health-score-below-1"
+    display_name: "Jenkins - Prometheus - Health Score Below 1"
+    description: "If the Jenkins health score is below 1, then at least one health check has failed. To view which health checks have failed, see `${JENKINS_URL}/metrics/currentUser/healthcheck?pretty=true`."
+    version: 1
+  - id: "plugin-failure"
+    display_name: "Jenkins - Prometheus - Plugin Failure"
+    description: "A plugin failure indicates that a plugin has failed to start. Usually, this can be resolved by explicitly disabling the failing plugin, or by resolving dependency issues with the plugin. See the Jenkins logs to determine the exact cause of the plugin failure."
+    version: 1

--- a/alerts/jenkins-gke/plugin-failure.v1.json
+++ b/alerts/jenkins-gke/plugin-failure.v1.json
@@ -1,0 +1,33 @@
+{
+    "displayName": "Jenkins - Prometheus - Plugin Failure",
+    "documentation": {
+      "content": "A plugin failure indicates that a plugin has failed to start. Usually, this can be resolved by explicitly disabling the failing plugin, or by resolving dependency issues with the plugin. See the Jenkins logs to determine the exact cause of the plugin failure.",
+      "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+      {
+        "displayName": "Prometheus Target - prometheus/jenkins_plugins_failed/gauge",
+        "conditionThreshold": {
+          "aggregations": [
+            {
+              "alignmentPeriod": "300s",
+              "perSeriesAligner": "ALIGN_MEAN"
+            }
+          ],
+          "comparison": "COMPARISON_GT",
+          "duration": "0s",
+          "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/jenkins_plugins_failed/gauge\"",
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": false,
+    "notificationChannels": []
+  }

--- a/alerts/kibana-gke/README.md
+++ b/alerts/kibana-gke/README.md
@@ -1,0 +1,33 @@
+# Kibana Alerts for GKE
+
+## High memory usage alert
+This alert triggers when there is a high amount of memory in use. Memory pressure can cause excessive garbage collection, leading to performance degradation.
+
+## High cpu usage alert
+This alert triggers when there is a high amount of CPU usage. High CPU usage indicates that Kibana is running out of compute resources, and performance may degrade.
+
+### Creating Notification Channels and User Labels
+
+It is strongly recommended to add notification channels and user labels to the alert policies. The notification channel will set the notification destination if the alert policy is triggered. User labels are used for categorization, and can be used to indicate the severity level.
+
+### User Labels
+
+Supplying user labels could give extra identification information about the firing alert:
+
+i.e.
+
+```json
+    "userLabels": {
+        "Severity": "Warning"
+    }
+```
+
+### Notification Channels
+
+The ID of the notification channel to be notified.
+
+```json
+    "notificationChannels": [
+        "projects/project-id/notificationChannels/1234567"
+    ]
+```

--- a/alerts/kibana-gke/high-cpu-usage.v1.json
+++ b/alerts/kibana-gke/high-cpu-usage.v1.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "Kibana - Prometheus - High CPU Usage",
+  "documentation": {
+    "content": "This alert triggers when there is a high amount of CPU usage. High CPU usage indicates that Kibana is running out of compute resources, and performance may degrade.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Prometheus Target - prometheus/kibana_os_load5/gauge",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "perSeriesAligner": "ALIGN_MEAN"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/kibana_os_load5/gauge\"",
+        "thresholdValue": 90,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": false,
+  "notificationChannels": []
+}

--- a/alerts/kibana-gke/high-memory-usage.v1.json
+++ b/alerts/kibana-gke/high-memory-usage.v1.json
@@ -1,0 +1,27 @@
+{
+    "displayName": "Kibana - Prometheus - High Memory Usage",
+    "documentation": {
+      "content": "This alert triggers when there is a high amount of memory in use. Memory pressure can cause excessive garbage collection, leading to performance degradation.",
+      "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+      {
+        "displayName": "Prometheus Target - prometheus/kibana_os_mem_bytes_free/gauge",
+        "conditionMonitoringQueryLanguage": {
+          "duration": "300s",
+          "evaluationMissingData": "EVALUATION_MISSING_DATA_ACTIVE",
+          "query": "fetch prometheus_target\n| { t_0: metric 'prometheus.googleapis.com/kibana_os_mem_bytes_used/gauge'\n  ; t_1: metric prometheus.googleapis.com/kibana_os_mem_bytes_total/gauge }\n| ratio\n| group_by sliding(5m), mean(val())\n| condition val() > 0.9",
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+  }

--- a/alerts/kibana-gke/metadata.yaml
+++ b/alerts/kibana-gke/metadata.yaml
@@ -1,0 +1,10 @@
+alert_policy_templates:
+  - id: "high-memory-usage"
+    display_name: "Kibana - Prometheus - High Memory Usage"
+    description: "This alert triggers when there is a high amount of memory in use. Memory pressure can cause excessive garbage collection, leading to performance degradation."
+    version: 1
+  - id: "high-cpu-usage"
+    display_name: "Kibana - Prometheus - High CPU Usage"
+    description: "This alert triggers when there is a high amount of CPU usage. High CPU usage indicates that Kibana is running out of compute resources, and performance may degrade."
+    version: 1
+  

--- a/alerts/kube-state-gke/README.md
+++ b/alerts/kube-state-gke/README.md
@@ -1,0 +1,36 @@
+# Kube State Alerts for GKE
+
+## Job failure alert
+A Job failure indicates that the Job did not run successfully.
+
+## Pod disruption budget exceeded alert
+When the pod disruption budget is exceeded, the configured minimum availability is not being respected, typically due to an application failure.
+
+## Volume reaching capacity alert
+This alert triggers when a volume is beginning to reach its capacity. When a volume reaches capacity, it cannot store any more data, which can cause applications to stop working.
+
+### Creating Notification Channels and User Labels
+
+It is strongly recommended to add notification channels and user labels to the alert policies. The notification channel will set the notification destination if the alert policy is triggered. User labels are used for categorization, and can be used to indicate the severity level.
+
+### User Labels
+
+Supplying user labels could give extra identification information about the firing alert:
+
+i.e.
+
+```json
+    "userLabels": {
+        "Severity": "Warning"
+    }
+```
+
+### Notification Channels
+
+The ID of the notification channel to be notified.
+
+```json
+    "notificationChannels": [
+        "projects/project-id/notificationChannels/1234567"
+    ]
+```

--- a/alerts/kube-state-gke/job-failure.v1.json
+++ b/alerts/kube-state-gke/job-failure.v1.json
@@ -1,0 +1,33 @@
+{
+    "displayName": "Kube State - Prometheus - Job Failure",
+    "documentation": {
+      "content": "A Job failure indicates that the Job did not run successfully.",
+      "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+      {
+        "displayName": "Prometheus Target - prometheus/kube_job_status_failed/gauge",
+        "conditionThreshold": {
+          "aggregations": [
+            {
+              "alignmentPeriod": "300s",
+              "perSeriesAligner": "ALIGN_MEAN"
+            }
+          ],
+          "comparison": "COMPARISON_GT",
+          "duration": "0s",
+          "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/kube_job_status_failed/gauge\"",
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+  }

--- a/alerts/kube-state-gke/metadata.yaml
+++ b/alerts/kube-state-gke/metadata.yaml
@@ -1,0 +1,13 @@
+alert_policy_templates:
+  - id: "job-failure"
+    display_name: "Kube State - Prometheus - Job Failure"
+    description: "A Job failure indicates that the Job did not run successfully."
+    version: 1
+  - id: "pod-disruption-budget-exceeded"
+    display_name: "Kube State - Prometheus - Pod Disruption Budget Exceeded"
+    description: "When the pod disruption budget is exceeded, the configured minimum availability is not being respected, typically due to an application failure."
+    version: 1
+  - id: "volume-reaching-capacity"
+    display_name: "Kube State - Prometheus - Volume Reaching Capacity"
+    description: "This alert triggers when a volume is beginning to reach its capacity. When a volume reaches capacity, it cannot store any more data, which can cause applications to stop working."
+    version: 1

--- a/alerts/kube-state-gke/pod-disruption-budget-exceeded.v1.json
+++ b/alerts/kube-state-gke/pod-disruption-budget-exceeded.v1.json
@@ -1,0 +1,26 @@
+{
+    "displayName": "Kube State - Prometheus - Pod Disruption Budget Exceeded",
+    "documentation": {
+      "content": "When the pod disruption budget is exceeded, the configured minimum availability is not being respected, typically due to an application failure.",
+      "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+      {
+        "displayName": "Allowed Pod Disruptions Remaining",
+        "conditionMonitoringQueryLanguage": {
+          "duration": "0s",
+          "query": "fetch prometheus_target\n| { metric\n      prometheus.googleapis.com/kube_poddisruptionbudget_status_current_healthy/gauge\n  ; metric\n      prometheus.googleapis.com/kube_poddisruptionbudget_status_desired_healthy/gauge }\n| outer_join 0\n| sub\n| every 5m\n| window 5m\n| condition val() < 0",
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": false,
+    "notificationChannels": []
+  }

--- a/alerts/kube-state-gke/volume-reaching-capacity.v1.json
+++ b/alerts/kube-state-gke/volume-reaching-capacity.v1.json
@@ -1,0 +1,26 @@
+{
+    "displayName": "Kube State - Prometheus - Volume Reaching Capacity",
+    "documentation": {
+      "content": "This alert triggers when a volume is beginning to reach its capacity. When a volume reaches capacity, it cannot store any more data, which can cause applications to stop working.",
+      "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+      {
+        "displayName": "Volume Usage Ratio",
+        "conditionMonitoringQueryLanguage": {
+          "duration": "0s",
+          "query": "fetch prometheus_target\n| {\n    t_0: metric prometheus.googleapis.com/kubelet_volume_stats_used_bytes/gauge;\n    t_1: metric prometheus.googleapis.com/kubelet_volume_stats_capacity_bytes/gauge\n}\n| ratio\n| condition val() > 0.9\n| every 5m\n| window 5m",
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+  }

--- a/alerts/nginx-ingress-gke/README.md
+++ b/alerts/nginx-ingress-gke/README.md
@@ -1,0 +1,40 @@
+# NGINX Ingress Controller Alerts for GKE
+
+## Connections dropped alert
+The connections dropped value is derived from the connections accepted minus the connections handled. This value should be near 0. When this value is rising, it means you may have a resource saturation problem.
+
+## High request rate alert
+The request rate is derived from the requests metrics taken as a rate over a 5 minute interval. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When the request rate is above this threshold, then that means there is a large spike in traffic, which may be diagnosed by viewing the access logs.
+
+The "thresholdValue" can be adjusted depending on what is considered to be a high request rate.
+
+## Low request rate alert
+The request rate is derived from the requests metrics taken as a rate over a 5 minute interval. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When the request rate is below this threshold, then that means there may be an environment problem that is limiting the request rate.
+
+The "thresholdValue" can be adjusted depending on what is considered to be a low request rate.
+
+### Creating Notification Channels and User Labels
+
+It is strongly recommended to add notification channels and user labels to the alert policies. The notification channel will set the notification destination if the alert policy is triggered. User labels are used for categorization, and can be used to indicate the severity level.
+
+### User Labels
+
+Supplying user labels could give extra identification information about the firing alert:
+
+i.e.
+
+```json
+    "userLabels": {
+        "Severity": "Warning"
+    }
+```
+
+#### Notification Channels
+
+The ID of the notification channel to be notified.
+
+```json
+    "notificationChannels": [
+        "projects/project-id/notificationChannels/1234567"
+    ]
+```

--- a/alerts/nginx-ingress-gke/connections-dropped.v1.json
+++ b/alerts/nginx-ingress-gke/connections-dropped.v1.json
@@ -1,0 +1,26 @@
+{
+    "displayName": "NGINX Ingress Controller - Prometheus - Connections Dropped",
+    "documentation": {
+      "content": "The connections dropped value is derived from the connections accepted minus the connections handled. This value should be near 0. When this value is rising, it means you may have a resource saturation problem.",
+      "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+      {
+        "displayName": "Dropped Connections",
+        "conditionMonitoringQueryLanguage": {
+          "duration": "0s",
+          "query": "fetch prometheus_target\n| { t_0:\n      metric\n        'prometheus.googleapis.com/nginx_ingress_controller_nginx_process_connections_total/counter'\n      | filter state = \"accepted\"\n      | map drop[metric.state]\n  ; t_1:\n      metric\n        'prometheus.googleapis.com/nginx_ingress_controller_nginx_process_connections_total/counter'\n      | filter state = \"handled\"\n      | map drop[metric.state] }\n| outer_join 0\n| sub\n| align rate(5m)\n| every 5m\n| condition val() > 0",
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+  }

--- a/alerts/nginx-ingress-gke/high-request-rate.v1.json
+++ b/alerts/nginx-ingress-gke/high-request-rate.v1.json
@@ -1,0 +1,38 @@
+{
+    "displayName": "NGINX Ingress Controller - Prometheus - High Request Rate",
+    "documentation": {
+      "content": "The request rate is derived from the requests metrics taken as a rate over a 5 minute interval. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When the request rate is above this threshold, then that means there is a large spike in traffic for a particular controller pod.",
+      "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+      {
+        "displayName": "Prometheus Target - prometheus/nginx_ingress_controller_requests/counter",
+        "conditionThreshold": {
+          "aggregations": [
+            {
+              "alignmentPeriod": "300s",
+              "crossSeriesReducer": "REDUCE_SUM",
+              "groupByFields": [
+                "metric.label.controller_pod"
+              ],
+              "perSeriesAligner": "ALIGN_RATE"
+            }
+          ],
+          "comparison": "COMPARISON_GT",
+          "duration": "0s",
+          "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/nginx_ingress_controller_requests/counter\"",
+          "thresholdValue": 100,
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+  }

--- a/alerts/nginx-ingress-gke/low-request-rate.v1.json
+++ b/alerts/nginx-ingress-gke/low-request-rate.v1.json
@@ -1,0 +1,38 @@
+{
+    "displayName": "NGINX Ingress Controller - Prometheus - Low Request Rate",
+    "documentation": {
+      "content": "The request rate is derived from the requests metrics taken as a rate over a 5 minute interval. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When the request rate is below this threshold, then that means there may be an environment problem that is limiting the request rate.",
+      "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+      {
+        "displayName": "Prometheus Target - prometheus/nginx_ingress_controller_requests/counter",
+        "conditionThreshold": {
+          "aggregations": [
+            {
+              "alignmentPeriod": "300s",
+              "crossSeriesReducer": "REDUCE_SUM",
+              "groupByFields": [
+                "metric.label.controller_pod"
+              ],
+              "perSeriesAligner": "ALIGN_RATE"
+            }
+          ],
+          "comparison": "COMPARISON_LT",
+          "duration": "0s",
+          "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/nginx_ingress_controller_requests/counter\"",
+          "thresholdValue": 10,
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+  }

--- a/alerts/nginx-ingress-gke/metadata.yaml
+++ b/alerts/nginx-ingress-gke/metadata.yaml
@@ -1,0 +1,13 @@
+alert_policy_templates:
+  - id: "connections-dropped"
+    display_name: "NGINX Ingress Controller - Prometheus - Connections Dropped"
+    description: "The connections dropped value is derived from the connections accepted minus the connections handled. This value should be near 0. When this value is rising, it means you may have a resource saturation problem."
+    version: 1
+  - id: "high-request-rate"
+    display_name: "NGINX Ingress Controller - Prometheus - High Request Rate"
+    description: "The request rate is derived from the requests metrics taken as a rate over a 5 minute interval. This value should be monitored beforehand to understand what qualifies as a normal request rate so a threshold can be established. When the request rate is above this threshold, then that means there is a large spike in traffic for a particular controller pod."
+    version: 1
+  - id: "low-request-rate"
+    display_name: "NGINX Ingress Controller - Prometheus - Low Request Rate"
+    description: "The connections dropped value is derived from the connections accepted minus the connections handled. This value should be near 0. When this value is rising, it means you may have a resource saturation problem."
+    version: 1

--- a/alerts/node-exporter-gke/README.md
+++ b/alerts/node-exporter-gke/README.md
@@ -1,0 +1,36 @@
+# Node Exporter Alerts for GKE
+
+## High CPU Usage alert
+This alert triggers when CPU Usage is high. This indicates that the node may degrade in performance due to too many workloads.
+
+## Low available memory alert
+This alert triggers when the amount of memory available is low. When memory is low, GKE may be unable to assign any more pods to the node.
+
+## Low filesystem space alert
+This alert triggers when the amount of space for the affected filesystem is low. When filesystem space is low, GKE may be unable to assign any more pods to the node.
+
+### Creating Notification Channels and User Labels
+
+It is strongly recommended to add notification channels and user labels to the alert policies. The notification channel will set the notification destination if the alert policy is triggered. User labels are used for categorization, and can be used to indicate the severity level.
+
+### User Labels
+
+Supplying user labels could give extra identification information about the firing alert:
+
+i.e.
+
+```json
+    "userLabels": {
+        "Severity": "Warning"
+    }
+```
+
+#### Notification Channels
+
+The ID of the notification channel to be notified.
+
+```json
+    "notificationChannels": [
+        "projects/project-id/notificationChannels/1234567"
+    ]
+```

--- a/alerts/node-exporter-gke/high-cpu-usage.v1.json
+++ b/alerts/node-exporter-gke/high-cpu-usage.v1.json
@@ -1,0 +1,34 @@
+{
+    "displayName": "Node Exporter - Prometheus - High CPU Usage",
+    "documentation": {
+        "content": "This alert triggers when CPU Usage is high. This indicates that the node may degrade in performance due to too many workloads.",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "Prometheus Target - prometheus/node_load5/gauge",
+            "conditionThreshold": {
+                "aggregations": [
+                    {
+                        "alignmentPeriod": "300s",
+                        "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                ],
+                "comparison": "COMPARISON_GT",
+                "duration": "0s",
+                "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/node_load5/gauge\"",
+                "thresholdValue": 90,
+                "trigger": {
+                    "count": 1
+                }
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": false,
+    "notificationChannels": []
+}

--- a/alerts/node-exporter-gke/low-available-memory.v1.json
+++ b/alerts/node-exporter-gke/low-available-memory.v1.json
@@ -1,0 +1,26 @@
+{
+    "displayName": "Node Exporter - Prometheus - Low Available Memory",
+    "documentation": {
+      "content": "This alert triggers when the amount of memory available is low. When memory is low, GKE may be unable to assign any more pods to the node.",
+      "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+      {
+        "displayName": "Memory Available < 10%",
+        "conditionMonitoringQueryLanguage": {
+          "duration": "0s",
+          "query": "fetch prometheus_target\n| {\n    t_0: metric prometheus.googleapis.com/node_memory_MemAvailable_bytes/gauge;\n    t_1: metric prometheus.googleapis.com/node_memory_MemTotal_bytes/gauge\n}\n| ratio\n| every 5m\n| window 5m\n| condition val() < 0.1",
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": false,
+    "notificationChannels": []
+  }

--- a/alerts/node-exporter-gke/low-filesystem-space.v1.json
+++ b/alerts/node-exporter-gke/low-filesystem-space.v1.json
@@ -1,0 +1,26 @@
+{
+    "displayName": "Node Exporter - Prometheus - Low Filesystem Space",
+    "documentation": {
+        "content": "This alert triggers when the amount of space for the affected filesystem is low. When filesystem space is low, GKE may be unable to assign any more pods to the node.",
+        "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+        {
+            "displayName": "Filesystem Space Available < 10%",
+            "conditionMonitoringQueryLanguage": {
+                "duration": "0s",
+                "query": "fetch prometheus_target\n| { t_0: metric prometheus.googleapis.com/node_filesystem_avail_bytes/gauge\n  ; t_1: metric prometheus.googleapis.com/node_filesystem_size_bytes/gauge }\n| ratio\n| every 5m\n| window 5m\n| condition val() < 0.1",
+                "trigger": {
+                    "count": 1
+                }
+            }
+        }
+    ],
+    "alertStrategy": {
+        "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+}

--- a/alerts/node-exporter-gke/metadata.yaml
+++ b/alerts/node-exporter-gke/metadata.yaml
@@ -1,0 +1,13 @@
+alert_policy_templates:
+  - id: "high-cpu-usage"
+    display_name: "Node Exporter - Prometheus - High CPU Usage"
+    description: "This alert triggers when CPU Usage is high. This indicates that the node may degrade in performance due to too many workloads."
+    version: 1
+  - id: "low-available-memory"
+    display_name: "Node Exporter - Prometheus - Low Available Memory"
+    description: "This alert triggers when the amount of memory available is low. When memory is low, GKE may be unable to assign any more pods to the node."
+    version: 1
+  - id: "low-filesystem-space"
+    display_name: "Node Exporter - Prometheus - Low Filesystem Space"
+    description: "This alert triggers when the amount of space for the affected filesystem is low. When filesystem space is low, GKE may be unable to assign any more pods to the node."
+    version: 1

--- a/alerts/scylla-gke/README.md
+++ b/alerts/scylla-gke/README.md
@@ -1,0 +1,33 @@
+# ScyllaDB Alerts for GKE
+
+## High compaction load alert
+High compaction load can interfere with system behavior. If compaction load remains high, you may need to set the compaction share to a static level.
+
+## High prepared statement eviction rate alert
+If the prepared statement cache is being continuously evicted, it indicates an error in application prepared-statement usage logic. This can cause performance to degrade.
+
+### Creating Notification Channels and User Labels
+
+It is strongly recommended to add notification channels and user labels to the alert policies. The notification channel will set the notification destination if the alert policy is triggered. User labels are used for categorization, and can be used to indicate the severity level.
+
+### User Labels
+
+Supplying user labels could give extra identification information about the firing alert:
+
+i.e.
+
+```json
+    "userLabels": {
+        "Severity": "Warning"
+    }
+```
+
+#### Notification Channels
+
+The ID of the notification channel to be notified.
+
+```json
+    "notificationChannels": [
+        "projects/project-id/notificationChannels/1234567"
+    ]
+```

--- a/alerts/scylla-gke/high-compaction-load.v1.json
+++ b/alerts/scylla-gke/high-compaction-load.v1.json
@@ -1,0 +1,34 @@
+{
+    "displayName": "ScyllaDB - Prometheus - High Compaction Load",
+    "documentation": {
+      "content": "High compaction load can interfere with system behavior. If compaction load remains high, you may need to set the compaction share to a static level.",
+      "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+      {
+        "displayName": "Prometheus Target - prometheus/scylla_scheduler_shares/gauge",
+        "conditionThreshold": {
+          "aggregations": [
+            {
+              "alignmentPeriod": "300s",
+              "perSeriesAligner": "ALIGN_MEAN"
+            }
+          ],
+          "comparison": "COMPARISON_GT",
+          "duration": "0s",
+          "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/scylla_scheduler_shares/gauge\" AND metric.labels.group = \"compaction\"",
+          "thresholdValue": 1000,
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": false,
+    "notificationChannels": []
+  }

--- a/alerts/scylla-gke/high-prepared-statement-eviction-rate.v1.json
+++ b/alerts/scylla-gke/high-prepared-statement-eviction-rate.v1.json
@@ -1,0 +1,26 @@
+{
+    "displayName": "ScyllaDB - Prometheus - High Prepared Statement Eviction Rate",
+    "documentation": {
+      "content": "If the prepared statement cache is being continuously evicted, it indicates an error in application prepared-statement usage logic. This can cause performance to degrade.",
+      "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+      {
+        "displayName": "Prometheus Target - prometheus/scylla_cql_prepared_cache_evictions/counter",
+        "conditionMonitoringQueryLanguage": {
+          "duration": "0s",
+          "query": "fetch prometheus_target\n| { t_0: metric 'prometheus.googleapis.com/scylla_cql_prepared_cache_evictions/counter';\n    t_1: metric 'prometheus.googleapis.com/scylla_cql_authorized_prepared_statements_cache_evictions/counter'\n}\n| outer_join 0, 0\n| add\n| align rate(5m)\n| every 5m\n| condition val() > 100\n",
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": false,
+    "notificationChannels": []
+  }

--- a/alerts/scylla-gke/metadata.yaml
+++ b/alerts/scylla-gke/metadata.yaml
@@ -1,0 +1,9 @@
+alert_policy_templates:
+  - id: "high-compaction-load"
+    display_name: "ScyllaDB - Prometheus - High Compaction Load"
+    description: "High compaction load can interfere with system behavior. If compaction load remains high, you may need to set the compaction share to a static level."
+    version: 1
+  - id: "high-prepared-statement-eviction-rate"
+    display_name: "ScyllaDB - Prometheus - High Prepared Statement Eviction Rate"
+    description: "If the prepared statement cache is being continuously evicted, it indicates an error in application prepared-statement usage logic. This can cause performance to degrade."
+    version: 1

--- a/alerts/velero-gke/README.md
+++ b/alerts/velero-gke/README.md
@@ -1,0 +1,36 @@
+# Velero Alerts for GKE
+
+## Backup failure alert
+This alert triggers when a backup fails. If this occurs, then a backup failed, and data will be missing. Inspect the logs for Velero in order to further determine the cause.
+
+## Partial backup failure alert
+This alert triggers when a backup partially fails. This indicates that a full backup could not be made, and the resulting backup only partially describes the cluster. Inspect the logs for Velero in order to further determine the cause.
+
+## Restore failure alert
+This alert triggers when a restore operation fails. Inspect the logs for Velero in order to further determine the cause.
+
+### Creating Notification Channels and User Labels
+
+It is strongly recommended to add notification channels and user labels to the alert policies. The notification channel will set the notification destination if the alert policy is triggered. User labels are used for categorization, and can be used to indicate the severity level.
+
+### User Labels
+
+Supplying user labels could give extra identification information about the firing alert:
+
+i.e.
+
+```json
+    "userLabels": {
+        "Severity": "Warning"
+    }
+```
+
+#### Notification Channels
+
+The ID of the notification channel to be notified.
+
+```json
+    "notificationChannels": [
+        "projects/project-id/notificationChannels/1234567"
+    ]
+```

--- a/alerts/velero-gke/backup-failure.v1.json
+++ b/alerts/velero-gke/backup-failure.v1.json
@@ -1,0 +1,33 @@
+{
+    "displayName": "Velero - Prometheus - Backup Failure",
+    "documentation": {
+      "content": "This alert triggers when a backup fails. If this occurs, then a backup failed, and data will be missing. Inspect the logs for Velero in order to further determine the cause.",
+      "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+      {
+        "displayName": "Prometheus Target - prometheus/velero_backup_failure_total/counter",
+        "conditionThreshold": {
+          "aggregations": [
+            {
+              "alignmentPeriod": "300s",
+              "perSeriesAligner": "ALIGN_RATE"
+            }
+          ],
+          "comparison": "COMPARISON_GT",
+          "duration": "0s",
+          "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/velero_backup_failure_total/counter\"",
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+  }

--- a/alerts/velero-gke/metadata.yaml
+++ b/alerts/velero-gke/metadata.yaml
@@ -1,0 +1,13 @@
+alert_policy_templates:
+  - id: "backup-failure"
+    display_name: "Velero - Prometheus - Backup Failure"
+    description: "This alert triggers when a backup fails. If this occurs, then a backup failed, and data will be missing. Inspect the logs for Velero in order to further determine the cause."
+    version: 1
+  - id: "partial-backup-failure"
+    display_name: "Velero - Prometheus - Partial Backup Failure"
+    description: "This alert triggers when a backup partially fails. This indicates that a full backup could not be made, and the resulting backup only partially describes the cluster. Inspect the logs for Velero in order to further determine the cause."
+    version: 1
+  - id: "restore-failure"
+    display_name: "Velero - Prometheus - Restore Failure"
+    description: "This alert triggers when a restore operation fails. Inspect the logs for Velero in order to further determine the cause."
+    version: 1

--- a/alerts/velero-gke/partial-backup-failure.v1.json
+++ b/alerts/velero-gke/partial-backup-failure.v1.json
@@ -1,0 +1,34 @@
+{
+    "displayName": "Velero - Prometheus - Partial Backup Failure",
+    "documentation": {
+      "content": "This alert triggers when a backup partially fails. This indicates that a full backup could not be made, and the resulting backup only partially describes the cluster. Inspect the logs for Velero in order to further determine the cause.",
+      "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+      {
+        "displayName": "Prometheus Target - prometheus/velero_backup_partial_failure_total/counter",
+        "conditionThreshold": {
+          "aggregations": [
+            {
+              "alignmentPeriod": "300s",
+              "perSeriesAligner": "ALIGN_RATE"
+            }
+          ],
+          "comparison": "COMPARISON_GT",
+          "duration": "0s",
+          "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/velero_backup_partial_failure_total/counter\"",
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+  }
+  

--- a/alerts/velero-gke/restore-failure.v1.json
+++ b/alerts/velero-gke/restore-failure.v1.json
@@ -1,0 +1,33 @@
+{
+    "displayName": "Velero - Prometheus - Restore Failure",
+    "documentation": {
+      "content": "This alert triggers when a restore operation fails. Inspect the logs for Velero in order to further determine the cause.",
+      "mimeType": "text/markdown"
+    },
+    "userLabels": {},
+    "conditions": [
+      {
+        "displayName": "Prometheus Target - prometheus/velero_restore_failed_total/counter",
+        "conditionThreshold": {
+          "aggregations": [
+            {
+              "alignmentPeriod": "300s",
+              "perSeriesAligner": "ALIGN_RATE"
+            }
+          ],
+          "comparison": "COMPARISON_GT",
+          "duration": "0s",
+          "filter": "resource.type = \"prometheus_target\" AND metric.type = \"prometheus.googleapis.com/velero_restore_failed_total/counter\"",
+          "trigger": {
+            "count": 1
+          }
+        }
+      }
+    ],
+    "alertStrategy": {
+      "autoClose": "604800s"
+    },
+    "combiner": "OR",
+    "enabled": true,
+    "notificationChannels": []
+  }


### PR DESCRIPTION
This PR contains the second batch of alerting policies for GKE.

The alerting policies included here are for the following technologies:
- Apache Airflow Scheduler
- Argo Server
- Consul
- etcd
- HAProxy
- Istio Proxy
- Jenkins
- Kibana
- Kube State Metrics
- NGINX Ingress Controller
- Node Exporter
- ScyllaDB
- Velero