### PR TITLE
Initialize quotas alert policy folder with exceeded template

### DIFF
--- a/alerts/google-quotas/README.md
+++ b/alerts/google-quotas/README.md
@@ -1,0 +1,1 @@
+ # Alert policies for quotas

--- a/alerts/google-quotas/exceeded-quota.v1.json
+++ b/alerts/google-quotas/exceeded-quota.v1.json
@@ -1,0 +1,27 @@
+{
+  "displayName": "Quota Exceeded Alert Policy",
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Quota Exceeded",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "60s",
+            "perSeriesAligner": "ALIGN_COUNT_TRUE",
+            "crossSeriesReducer": "REDUCE_SUM"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "filter": "resource.type=\"consumer_quota\" AND metric.type=\"serviceruntime.googleapis.com/quota/exceeded\" AND resource.label.project_id=\"${PROJECT}\" AND resource.label.service=\"${SERVICE}\" AND metric.label.quota_metric=\"${METRIC}\" AND metric.label.limit_name=\"${LIMIT}\"",
+        "thresholdValue": 1,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "combiner": "OR",
+  "enabled": true
+}

--- a/alerts/google-quotas/metadata.yaml
+++ b/alerts/google-quotas/metadata.yaml
@@ -1,0 +1,7 @@
+alert_policy_templates:
+-
+  id: exceeded-quota
+  display_name: Quota Exceeded Alert Policy
+  description: "Alert policy for exceeding quota limit"
+  version: 1
+


### PR DESCRIPTION
Initializing the quotas alert policy folder and added a alert policy template for exceeded quota alerts.

<img width="1334" alt="Screen Shot 2022-09-14 at 6 05 25 PM" src="https://user-images.githubusercontent.com/113474262/190272348-8ba2440f-53af-49de-9f33-bd2cb7464f01.png">

Validated the template with the placeholders replaced with valid values.