### PR TITLE
Add Prometheus GMP documentation

### DIFF
--- a/dashboards/redis/documentation.yaml
+++ b/dashboards/redis/documentation.yaml
@@ -1,0 +1,62 @@
+exporter_type: sidecar
+app_name_short: Redis
+app_name: {{app_name_short}}
+app_site_name: Redis
+app_site_url: https://www.redis.com/
+exporter_name: Redis
+exporter_pkg_name: redis_exporter
+exporter_repo_url: https://github.com/oliver006/redis_exporter
+dashboard_available: true
+minimum_exporter_version: v1.43.1
+multiple_dashboards: false
+dashboard_display_name: {{app_name_short}} Prometheus Overview
+config_mods: |
+  apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    name: redis
+  spec:
+    serviceName: redis
+    selector:
+      matchLabels:
+  +     app.kubernetes.io/name: redis
+    template:
+      metadata:
+        labels:
+  +       app.kubernetes.io/name: redis
+      spec:
+        containers:
+        - name: redis
+          image: "redis:6.2"
+          ports:
+          - containerPort: 6379
+  +     - name: redis-exporter
+  +       image: oliver006/redis_exporter:v1.43.1
+  +       args: [--include-system-metrics]
+  +       resources:
+  +         requests:
+  +           cpu: 100m
+  +           memory: 100Mi
+  +       ports:
+  +       - containerPort: 9121
+  +         name: prometheus
+podmonitoring_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: PodMonitoring
+  metadata:
+    name: redis
+    labels:
+      app.kubernetes.io/name: redis
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    endpoints:
+    - port: prometheus
+      scheme: http
+      interval: 60s
+      path: /metrics
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: redis
+alerts_config: {% includecode content_path="stackdriver/docs/managed-prometheus/exporters/configs/redis_alerts.yaml" %}
+additional_alert_info: You can adjust the alert thresholds to suit your application.
+sample_promql_query: up{job="redis", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}

--- a/dashboards/redis/documentation.yaml
+++ b/dashboards/redis/documentation.yaml
@@ -3,7 +3,7 @@ app_name_short: Redis
 app_name: {{app_name_short}}
 app_site_name: Redis
 app_site_url: https://www.redis.com/
-exporter_name: Redis
+exporter_name: the Redis exporter
 exporter_pkg_name: redis_exporter
 exporter_repo_url: https://github.com/oliver006/redis_exporter
 dashboard_available: true
@@ -40,6 +40,16 @@ config_mods: |
   +       ports:
   +       - containerPort: 9121
   +         name: prometheus
+additional_install_info: |
+  These instructions assume you already have a working {{app_name_short}}
+  installation and want to modify it to include an exporter. If you need to
+  also set up {{app_name_short}}, you can configure and apply the
+  [Bitnami Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/redis){:class=external}.
+  Pass in the following configuration values:
+  <ul>
+    <li><code>metrics.enabled = true</code></li>
+    <li><code>metrics.podLabels = {app.kubernetes.io/name: redis}</code></li>
+  </ul>
 podmonitoring_config: |
   apiVersion: monitoring.googleapis.com/v1
   kind: PodMonitoring

--- a/dashboards/redis/documentation.yaml
+++ b/dashboards/redis/documentation.yaml
@@ -57,6 +57,6 @@ podmonitoring_config: |
     selector:
       matchLabels:
         app.kubernetes.io/name: redis
-alerts_config: {% includecode content_path="stackdriver/docs/managed-prometheus/exporters/configs/redis_alerts.yaml" %}
-additional_alert_info: You can adjust the alert thresholds to suit your application.
+#alerts_config: {% includecode content_path="stackdriver/docs/managed-prometheus/exporters/configs/redis_alerts.yaml" %}
+#additional_alert_info: You can adjust the alert thresholds to suit your application.
 sample_promql_query: up{job="redis", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}

--- a/dashboards/redis/prometheus_metadata.yaml
+++ b/dashboards/redis/prometheus_metadata.yaml
@@ -29,4 +29,4 @@ platforms:
         prometheus_name: redis_net_output_bytes_total
         kind: CUMULATIVE
         value_type: DOUBLE
-    install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters
+    install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/redis

--- a/dashboards/redis/prometheus_metadata.yaml
+++ b/dashboards/redis/prometheus_metadata.yaml
@@ -1,0 +1,32 @@
+platforms:
+  - type: GKE
+    detections:
+      - characteristic_metric:
+          metric_type: prometheus.googleapis.com/redis_uptime_in_seconds/gauge
+    launch_stage: GA
+    exporter_metadata:
+      name: Redis Prometheus Exporter
+      doc_url: https://github.com/oliver006/redis_exporter
+      minimum_supported_version: v1.43.1
+    default_metrics:
+      - name: prometheus.googleapis.com/redis_commands_total/counter
+        prometheus_name: redis_commands_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/redis_connected_clients/gauge
+        prometheus_name: redis_connected_clients
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/redis_db_keys/gauge
+        prometheus_name: redis_db_keys
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/redis_memory_used_bytes/gauge
+        prometheus_name: redis_memory_used_bytes
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/redis_net_output_bytes_total/counter
+        prometheus_name: redis_net_output_bytes_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+    install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters


### PR DESCRIPTION
This PR adds documentation configuration for the Redis GMP integration.

- Added redis documentation.yaml
- Added redis prometheus_metadata.yaml

Alerting has not been implemented yet. The alerting fields have been commented for now. Follow up PRs will include alert configuration and documentation.