### PR TITLE
Add related integrations to Elasticsearch alert metadata

### DIFF
--- a/alerts/elasticsearch-gke/metadata.yaml
+++ b/alerts/elasticsearch-gke/metadata.yaml
@@ -3,11 +3,20 @@ alert_policy_templates:
     display_name: "Elasticsearch - Prometheus - High JVM Memory Usage"
     description: "When the ratio of heap used to max heap becomes high, then application's performance may start to degrade."
     version: 1
+    related_integrations:
+      - id: elasticsearch
+        platform: GKE
   - id: "red-cluster-status"
     display_name: "Elasticsearch - Prometheus - Red Cluster Status"
     description: 'When the cluster has a "red" status, at least one primary shard is missing, and data is missing.'
     version: 1
+    related_integrations:
+      - id: elasticsearch
+        platform: GKE
   - id: "yellow-cluster-status"
     display_name: "Elasticsearch - Prometheus - Yellow Cluster Status"
     description: 'When the cluster has a "yellow" status, at least one replica shard is unallocated or missing.'
     version: 1
+    related_integrations:
+      - id: elasticsearch
+        platform: GKE

--- a/alerts/elasticsearch/metadata.yaml
+++ b/alerts/elasticsearch/metadata.yaml
@@ -5,15 +5,24 @@ alert_policy_templates:
   description: "When red cluster status duration exceeds 5 minute, at least one replica
     shard is unallocated or missing."
   version: 1
+  related_integrations:
+    - id: elasticsearch
+      platform: GCE
 -
   id: elasticsearch-high-jvm-memory-usage
   display_name: Elasticsearch - high jvm memory usage
   description: "When the JVM heap ratio of heap used over max heap exceeds a threshold,
     then application's performance may start to degrade."
   version: 1
+  related_integrations:
+    - id: elasticsearch
+      platform: GCE
 -
   id: elasticsearch-red-cluster-status
   display_name: Elasticsearch - red cluster status
   description: "When red cluster status duration is exceeds 1 minute, at least one
     primary shard is missing, and data is missing."
   version: 1
+  related_integrations:
+    - id: elasticsearch
+      platform: GCE


### PR DESCRIPTION
Created this PR in addition to the existing activemq so that I can test against the case where there are GKE and GCE alert policy templates, since they, unlike sample dashboards, live in different directories.