### PR TITLE
Fix chart position on elasticsearch clusters dash

### DIFF
--- a/dashboards/elasticsearch/elasticsearch-cluster-gce-overview.json
+++ b/dashboards/elasticsearch/elasticsearch-cluster-gce-overview.json
@@ -1,4 +1,5 @@
 {
+  "category": "CUSTOM",
   "displayName": "Elasticsearch Cluster GCE Overview",
   "mosaicLayout": {
     "columns": 12,
@@ -175,12 +176,14 @@
             "sparkChartView": {
               "sparkChartType": "SPARK_LINE"
             },
+            "thresholds": [],
             "timeSeriesQuery": {
               "apiSource": "DEFAULT_CLOUD",
               "timeSeriesFilter": {
                 "aggregation": {
                   "alignmentPeriod": "60s",
                   "crossSeriesReducer": "REDUCE_MEAN",
+                  "groupByFields": [],
                   "perSeriesAligner": "ALIGN_MEAN"
                 },
                 "filter": "metric.type=\"workload.googleapis.com/elasticsearch.cluster.shards\" resource.type=\"gce_instance\" metric.label.\"state\"=\"initializing\""
@@ -244,208 +247,218 @@
         "yPos": 2
       },
       {
-          "height": 4,
-          "widget": {
-            "title": "Published Cluster States",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "perSeriesAligner": "ALIGN_MEAN"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/elasticsearch.cluster.published_states.full\" resource.type=\"gce_instance\""
-                    }
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "label": "y1Axis",
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 6,
-          "xPos": 0,
-          "yPos": 6
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Published Clusters State Differences",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "STACKED_AREA",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "perSeriesAligner": "ALIGN_MEAN"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/elasticsearch.cluster.published_states.differences\" resource.type=\"gce_instance\""
-                    }
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "label": "y1Axis",
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 6,
-          "xPos": 6,
-          "yPos": 6
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Queued States",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "perSeriesAligner": "ALIGN_MEAN"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/elasticsearch.cluster.state_queue\" resource.type=\"gce_instance\""
-                    }
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "label": "y1Axis",
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 0,
-          "yPos": 10
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Update State Time",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "perSeriesAligner": "ALIGN_RATE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/elasticsearch.cluster.state_update.time\" resource.type=\"gce_instance\""
-                    }
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "label": "y1Axis",
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 4,
-          "yPos": 10
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Attempted State Updates",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "perSeriesAligner": "ALIGN_RATE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/elasticsearch.cluster.state_update.count\" resource.type=\"gce_instance\""
-                    }
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "label": "y1Axis",
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 8,
-          "yPos": 10
-        },
-        {
-          "height": 4,
-          "widget": {
-              "logsPanel": {
-              "filter": "(\n  labels.\"logging.googleapis.com/instrumentation_source\"=\"agent.googleapis.com/elasticsearch_json\"\n  OR log_id(\"elasticsearch_json\")\n)\nresource.type=\"gce_instance\""
+        "height": 4,
+        "widget": {
+          "title": "Published Cluster States",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
             },
-            "title": "Elasticsearch_json Logs"
-          },
-          "width": 6,
-          "xPos": 0,
-          "yPos": 12
-        },{
-          "height": 4,
-          "widget": {
-              "logsPanel": {
-              "filter": "(\n  labels.\"logging.googleapis.com/instrumentation_source\"=\"agent.googleapis.com/elasticsearch_gc\"\n  OR log_id(\"elasticsearch_gc\")\n)\nresource.type=\"gce_instance\""
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "apiSource": "DEFAULT_CLOUD",
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_NONE",
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/elasticsearch.cluster.published_states.full\" resource.type=\"gce_instance\""
+                  }
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 0,
+        "yPos": 4
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Published Clusters State Differences",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
             },
-            "title": "Elasticsearch_gc Logs"
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "apiSource": "DEFAULT_CLOUD",
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_NONE",
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/elasticsearch.cluster.published_states.differences\" resource.type=\"gce_instance\""
+                  }
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 4
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Queued States",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "apiSource": "DEFAULT_CLOUD",
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_NONE",
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/elasticsearch.cluster.state_queue\" resource.type=\"gce_instance\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 4,
+        "xPos": 0,
+        "yPos": 8
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Update State Time",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "apiSource": "DEFAULT_CLOUD",
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_NONE",
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/elasticsearch.cluster.state_update.time\" resource.type=\"gce_instance\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 4,
+        "xPos": 4,
+        "yPos": 8
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Attempted State Updates",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "apiSource": "DEFAULT_CLOUD",
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_NONE",
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/elasticsearch.cluster.state_update.count\" resource.type=\"gce_instance\""
+                  }
+                }
+              }
+            ],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 4,
+        "xPos": 8,
+        "yPos": 8
+      },
+      {
+        "height": 4,
+        "widget": {
+          "logsPanel": {
+            "filter": "(\n  labels.\"logging.googleapis.com/instrumentation_source\"=\"agent.googleapis.com/elasticsearch_json\"\n  OR log_id(\"elasticsearch_json\")\n)\nresource.type=\"gce_instance\"",
+            "resourceNames": []
           },
-          "width": 6,
-          "xPos": 6,
-          "yPos": 12
-        }
+          "title": "Elasticsearch_json Logs"
+        },
+        "width": 6,
+        "xPos": 0,
+        "yPos": 12
+      },
+      {
+        "height": 4,
+        "widget": {
+          "logsPanel": {
+            "filter": "(\n  labels.\"logging.googleapis.com/instrumentation_source\"=\"agent.googleapis.com/elasticsearch_gc\"\n  OR log_id(\"elasticsearch_gc\")\n)\nresource.type=\"gce_instance\"",
+            "resourceNames": []
+          },
+          "title": "Elasticsearch_gc Logs"
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 12
+      }
     ]
   }
 }


### PR DESCRIPTION
Charts were overlapping, resulting in the template failing validation.

Formatting change + missing default fields added by dashboard builder, recommend reviewing with whitespace changes hidden: https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/pull/348/files?w=1
