### PR TITLE
Update google-quotas templates for grouping in the query and url params in the documentation link

### DIFF
--- a/alerts/google-quotas/single-allocation-quota.v1.json
+++ b/alerts/google-quotas/single-allocation-quota.v1.json
@@ -1,7 +1,7 @@
 {
   "displayName": "High allocation quota utilization - ${LIMIT_DISPLAY_NAME}",
   "documentation": {
-    "content": "Alerts when usage reaches 80%. [View quotas](https://console.cloud.google.com/iam-admin/quotas",
+    "content": "Alerts when usage reaches 80%. [View and edit quotas](https://console.cloud.google.com/iam-admin/quotas?${URL_PARAMS})",
     "mimeType": "text/markdown"
   },
   "userLabels": {},
@@ -9,7 +9,7 @@
     {
       "displayName": "Usage nearing allocation quota limit",
       "conditionMonitoringQueryLanguage": {
-        "query": "fetch ${MONITORED_RESOURCE}| filter ${OUTER_FILTER}| {metric ${METRIC_USAGE_TYPE}| filter ${QUOTA_USAGE_FILTER}| align next_older(1d)| group_by [], .max; metric ${METRIC_LIMIT_TYPE}| filter ${QUOTA_LIMIT_FILTER}| align next_older(1d)| group_by [], .min}| ratio| every 1m| condition gt(val(), 0.8 '1')",
+        "query": "fetch ${MONITORED_RESOURCE}| filter ${OUTER_FILTER}| {metric ${METRIC_USAGE_TYPE}| filter ${QUOTA_USAGE_FILTER}${OPTIONAL_USAGE_QUERY}| align next_older(1d)| group_by [${GROUPING}], .max; metric ${METRIC_LIMIT_TYPE}| filter ${QUOTA_LIMIT_FILTER}| align next_older(1d)| group_by [${GROUPING}], .min}| ratio| every 1m| condition gt(val(), 0.8 '1')",
         "duration": "60s",
         "trigger": {
           "count": 1

--- a/alerts/google-quotas/single-daily-rate-quota.v1.json
+++ b/alerts/google-quotas/single-daily-rate-quota.v1.json
@@ -1,15 +1,15 @@
 {
   "displayName": "High daily rate quota utilization - ${LIMIT_DISPLAY_NAME}",
   "documentation": {
-    "content": "Alerts when usage reaches 80% for 1 day. [View quotas](https://console.cloud.google.com/iam-admin/quotas",
+    "content": "Alerts when usage reaches 80%. [View and edit quotas](https://console.cloud.google.com/iam-admin/quotas?${URL_PARAMS})",
     "mimeType": "text/markdown"
   },
   "userLabels": {},
   "conditions": [
     {
-      "displayName": "Usage nearing dailiy rate quota limit",
+      "displayName": "Usage nearing daily rate quota limit",
       "conditionMonitoringQueryLanguage": {
-        "query": "fetch ${MONITORED_RESOURCE}| filter ${OUTER_FILTER}| {metric ${METRIC_USAGE_TYPE}| filter ${QUOTA_USAGE_FILTER}|map add [day: end().timestamp_to_string('%Y%m%d', 'America/Los_Angeles').string_to_int64]| group_by 1d, .sum| map add [current_day: end().timestamp_to_string('%Y%m%d', 'America/Los_Angeles').string_to_int64]| (current_day == day)| group_by []; metric ${METRIC_LIMIT_TYPE}| filter ${QUOTA_LIMIT_FILTER}| group_by [], .min}| ratio| window 1d| every 1m| condition gt(val(), 0.8 '1')",
+        "query": "fetch ${MONITORED_RESOURCE}| filter ${OUTER_FILTER}| {metric ${METRIC_USAGE_TYPE}| filter ${QUOTA_USAGE_FILTER}${OPTIONAL_USAGE_QUERY}|map add [day: end().timestamp_to_string('%Y%m%d', 'America/Los_Angeles').string_to_int64]| group_by 1d, .sum| map add [current_day: end().timestamp_to_string('%Y%m%d', 'America/Los_Angeles').string_to_int64]| (current_day == day)| group_by [${GROUPING}]; metric ${METRIC_LIMIT_TYPE}| filter ${QUOTA_LIMIT_FILTER}| group_by [${GROUPING}], .min}| ratio| window 1d| every 1m| condition gt(val(), 0.8 '1')",
         "duration": "60s",
         "trigger": {
           "count": 1

--- a/alerts/google-quotas/single-per-minute-rate-quota.v1.json
+++ b/alerts/google-quotas/single-per-minute-rate-quota.v1.json
@@ -1,7 +1,7 @@
 {
   "displayName": "High per-minute rate quota utilization - ${LIMIT_DISPLAY_NAME}",
   "documentation": {
-    "content": "Alerts when usage reaches 80% for 1 minute. [View quotas](https://console.cloud.google.com/iam-admin/quotas",
+    "content": "Alerts when usage reaches 80%. [View and edit quotas](https://console.cloud.google.com/iam-admin/quotas?${URL_PARAMS})",
     "mimeType": "text/markdown"
   },
   "userLabels": {},
@@ -9,7 +9,7 @@
     {
       "displayName": "Usage nearing per-minute rate quota limit",
       "conditionMonitoringQueryLanguage": {
-        "query": "fetch ${MONITORED_RESOURCE}| filter ${OUTER_FILTER}| {metric ${METRIC_USAGE_TYPE}| filter ${QUOTA_USAGE_FILTER}| align delta_gauge(1m)| group_by [], sum(value.net_usage); metric ${METRIC_LIMIT_TYPE}| filter ${QUOTA_LIMIT_FILTER} | group_by [],sliding(1m), .min}| ratio| every 1m| condition gt(val(), 0.8 '1')",
+        "query": "fetch ${MONITORED_RESOURCE}| filter ${OUTER_FILTER}| {metric ${METRIC_USAGE_TYPE}| filter ${QUOTA_USAGE_FILTER}${OPTIONAL_USAGE_QUERY}| align delta_gauge(1m)| group_by [${GROUPING}], sum(value.net_usage); metric ${METRIC_LIMIT_TYPE}| filter ${QUOTA_LIMIT_FILTER} | group_by [${GROUPING}],sliding(1m), .min}| ratio| every 1m| condition gt(val(), 0.8 '1')",
         "duration": "60s",
         "trigger": {
           "count": 1

--- a/alerts/google-quotas/single-per-second-rate-quota.v1.json
+++ b/alerts/google-quotas/single-per-second-rate-quota.v1.json
@@ -1,7 +1,7 @@
 {
   "displayName": "High per-second rate quota utilization - ${LIMIT_DISPLAY_NAME}",
   "documentation": {
-    "content": "Alerts when usage reaches 80% for 1 second. [View quotas](https://console.cloud.google.com/iam-admin/quotas",
+    "content": "Alerts when usage reaches 80%. [View and edit quotas](https://console.cloud.google.com/iam-admin/quotas?${URL_PARAMS})",
     "mimeType": "text/markdown"
   },
   "userLabels": {},
@@ -9,7 +9,7 @@
     {
       "displayName": "Usage nearing per-second rate quota limit",
       "conditionMonitoringQueryLanguage": {
-        "query": "fetch ${MONITORED_RESOURCE}| filter ${OUTER_FILTER}| {metric ${METRIC_USAGE_TYPE}| filter ${QUOTA_USAGE_FILTER}| align delta_gauge(1s)| group_by [], sum(value.net_usage)| within 1d; metric ${METRIC_LIMIT_TYPE}| filter ${QUOTA_LIMIT_FILTER}| group_by [],sliding(1s), .min}| ratio| every 1s| condition gt(val(), 0.8 '1')",
+        "query": "fetch ${MONITORED_RESOURCE}| filter ${OUTER_FILTER}| {metric ${METRIC_USAGE_TYPE}| filter ${QUOTA_USAGE_FILTER}${OPTIONAL_USAGE_QUERY}| align delta_gauge(1s)| group_by [${GROUPING}], sum(value.net_usage)| within 1d; metric ${METRIC_LIMIT_TYPE}| filter ${QUOTA_LIMIT_FILTER}| group_by [${GROUPING}],sliding(1s), .min}| ratio| every 1s| condition gt(val(), 0.8 '1')",
         "duration": "60s",
         "trigger": {
           "count": 1


### PR DESCRIPTION
- Added GROUPING placeholder to group quota usage metric and quota limit metric.
- Added OPTIONAL_USAGE_QUERY to add new column for limit_name for certain usage metrics, i.e. `| map add [metric.limit_name: "LimitName"]`
- Added URL_PARAMS placeholder to documentation link for adding metric params i.e. `service=${resource.label.service}&limit=${metric.label.limit_name}`
- Fixed some typos.