### PR TITLE
Fix some typos in elasticsearch alert templates

### DIFF
--- a/alerts/elasticsearch/metadata.yaml
+++ b/alerts/elasticsearch/metadata.yaml
@@ -2,7 +2,7 @@ alert_policy_templates:
 -
   id: elasticsearch-yellow-cluster-status
   display_name: Elasticsearch - yellow cluster status
-  description: "When red cluster status duration exceeds 5 minute, at least one replica
+  description: "When yellow cluster status duration exceeds 5 minutes, at least one replica
     shard is unallocated or missing."
   version: 1
 -
@@ -14,6 +14,6 @@ alert_policy_templates:
 -
   id: elasticsearch-red-cluster-status
   display_name: Elasticsearch - red cluster status
-  description: "When red cluster status duration is exceeds 1 minute, at least one
+  description: "When red cluster status duration exceeds 1 minute, at least one
     primary shard is missing, and data is missing."
   version: 1


### PR DESCRIPTION
Don't know enough about elasticsearch to know if the "yellow" correction is correct, but the ID mentions "yellow" and the description mentions "red"--seems like a CnP error