### PR TITLE
GMP Alerts: HAProxy

### DIFF
--- a/integrations/haproxy/documentation.yaml
+++ b/integrations/haproxy/documentation.yaml
@@ -83,3 +83,5 @@ podmonitoring_config: |
       matchLabels:
         app.kubernetes.io/name: haproxy
 sample_promql_query: up{job="haproxy", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}
+alerts_config: {% includecode content_path="stackdriver/docs/managed-prometheus/exporters/configs/haproxy_alerts.yaml" %}
+additional_alert_info: You can adjust the alert thresholds to suit your application.

--- a/integrations/haproxy/documentation.yaml
+++ b/integrations/haproxy/documentation.yaml
@@ -83,5 +83,40 @@ podmonitoring_config: |
       matchLabels:
         app.kubernetes.io/name: haproxy
 sample_promql_query: up{job="haproxy", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}
-alerts_config: {% includecode content_path="stackdriver/docs/managed-prometheus/exporters/configs/haproxy_alerts.yaml" %}
+alerts_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: Rules
+  metadata:
+    name: haproxy-rules
+    labels:
+      app.kubernetes.io/component: rules
+      app.kubernetes.io/name: haproxy-rules
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    groups:
+    - name: haproxy
+      interval: 30s
+      rules:
+      - alert: HAProxyDown
+        annotations:
+          description: |-
+            HAProxy instance is down 
+              VALUE = {{ $value }}
+              LABELS: {{ $labels }}
+          summary: HAProxy down (instance {{ $labels.instance }})
+        expr: haproxy_server_up{job="haproxy"} == 0
+        for: 5m
+        labels:
+          severity: critical
+      - alert: HAProxyTooManyConnections
+        annotations:
+          description: |-
+            HAProxy instance has too many connections
+              VALUE = {{ $value }}
+              LABELS: {{ $labels }}
+          summary: HAProxy too many connections (instance {{ $labels.instance }})
+        expr: haproxy_frontend_current_sessions{job="haproxy"} / haproxy_frontend_limit_sessions{job="haproxy"} * 100 > 90
+        for: 5m
+        labels:
+          severity: warning
 additional_alert_info: You can adjust the alert thresholds to suit your application.

--- a/integrations/haproxy/haproxy_alerts.yaml
+++ b/integrations/haproxy/haproxy_alerts.yaml
@@ -1,0 +1,35 @@
+apiVersion: monitoring.googleapis.com/v1
+kind: Rules
+metadata:
+  name: rabbitmq-rules
+  labels:
+    app.kubernetes.io/component: rules
+    app.kubernetes.io/name: rabbitmq-rules
+    app.kubernetes.io/part-of: google-cloud-managed-prometheus
+spec:
+  groups:
+  - name: rabbitmq
+    interval: 30s
+    rules:
+    - alert: RedisDown
+      annotations:
+        description: |-
+          HAProxy instance is down 
+            VALUE = {{ $value }}
+            LABELS: {{ $labels }}
+        summary: HAProxy down (instance {{ $labels.instance }})
+      expr: haproxy_server_up{job="haproxy"} == 0
+      for: 5m
+      labels:
+        severity: critical
+    - alert: HAProxyTooManyConnections
+      annotations:
+        description: |-
+          HAProxy instance has too many connections
+            VALUE = {{ $value }}
+            LABELS: {{ $labels }}
+        summary: HAProxy too many connections (instance {{ $labels.instance }})
+      expr: haproxy_frontend_current_sessions{job="haproxy"} / haproxy_frontend_limit_sessions{job="haproxy"} * 100 > 90
+      for: 5m
+      labels:
+        severity: critical

--- a/integrations/haproxy/haproxy_alerts.yaml
+++ b/integrations/haproxy/haproxy_alerts.yaml
@@ -32,4 +32,4 @@ spec:
       expr: haproxy_frontend_current_sessions{job="haproxy"} / haproxy_frontend_limit_sessions{job="haproxy"} * 100 > 90
       for: 5m
       labels:
-        severity: critical
+        severity: warning

--- a/integrations/haproxy/haproxy_alerts.yaml
+++ b/integrations/haproxy/haproxy_alerts.yaml
@@ -11,7 +11,7 @@ spec:
   - name: haproxy
     interval: 30s
     rules:
-    - alert: RedisDown
+    - alert: HAProxyDown
       annotations:
         description: |-
           HAProxy instance is down 

--- a/integrations/haproxy/haproxy_alerts.yaml
+++ b/integrations/haproxy/haproxy_alerts.yaml
@@ -1,14 +1,14 @@
 apiVersion: monitoring.googleapis.com/v1
 kind: Rules
 metadata:
-  name: rabbitmq-rules
+  name: haproxy-rules
   labels:
     app.kubernetes.io/component: rules
-    app.kubernetes.io/name: rabbitmq-rules
+    app.kubernetes.io/name: haproxy-rules
     app.kubernetes.io/part-of: google-cloud-managed-prometheus
 spec:
   groups:
-  - name: rabbitmq
+  - name: haproxy
     interval: 30s
     rules:
     - alert: RedisDown


### PR DESCRIPTION
Ported alerts from [cloud monitoring](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/tree/master/alerts/haproxy-gke) to monitoring.googleapis.com/v1 Rules.

- Added alerts configuration for HAProxy
- Updated HAProxy documentation.yaml to point to new alerts configuration

Let me know if `haproxy_alerts.yaml` should exist in a different directory. For now, I have kept it with the GMP metadata yamls.