### PR TITLE
Assorted documentation cleanup

### DIFF
--- a/integrations/activemq/documentation.yaml
+++ b/integrations/activemq/documentation.yaml
@@ -70,14 +70,14 @@ config_mods: |
         containers:
         - name: activemq
           image: rmohr/activemq:5.15.9-alpine
-  +     ports:
-  +       - containerPort: 1099
-  +         name: jmx
-  +     env:
-  +       - name: ACTIVEMQ_JMX
-  +         value: "1099"
-  +       - name: ACTIVEMQ_OPTS
-  +         value: "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=1099 -Dcom.sun.management.jmxremote.rmi.port=1099 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+  +       ports:
+  +         - containerPort: 1099
+  +           name: jmx
+  +       env:
+  +         - name: ACTIVEMQ_JMX
+  +           value: "1099"
+  +         - name: ACTIVEMQ_OPTS
+  +           value: "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=1099 -Dcom.sun.management.jmxremote.rmi.port=1099 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
   +     - name: exporter
   +       image: bitnami/jmx-exporter:0.17.0
   +       command:
@@ -113,7 +113,7 @@ podmonitoring_config: |
     endpoints:
     - port: prometheus
       scheme: http
-      interval: 60s
+      interval: 30s
       path: /metrics
     selector:
       matchLabels:

--- a/integrations/aerospike/documentation.yaml
+++ b/integrations/aerospike/documentation.yaml
@@ -45,21 +45,21 @@ config_mods: |
   +           value: "3000"
 additional_install_info: |
   These instructions assume you already have a working {{app_name_short}}
-  installation and want to modify it to include an exporter. If you need to
-  also set up {{app_name_short}}, you can reference the
+  installation and want to modify it to include an exporter. For information
+  about setting up {{app_name_short}}, see the
   [Aerospike operator documentation](https://docs.aerospike.com/cloud/kubernetes/operator){:class=external}.
 podmonitoring_config: |
   apiVersion: monitoring.googleapis.com/v1
   kind: PodMonitoring
   metadata:
-    name: redis
+    name: aerospike
     labels:
-      app.kubernetes.io/name: redis
+      app.kubernetes.io/name: aerospike
       app.kubernetes.io/part-of: google-cloud-managed-prometheus
   spec:
     endpoints:
     - port: prometheus
-      interval: 60s
+      interval: 30s
     selector:
       matchLabels:
        app.kubernetes.io/name: aerospike

--- a/integrations/couchdb/documentation.yaml
+++ b/integrations/couchdb/documentation.yaml
@@ -69,7 +69,7 @@ podmonitoring_config: |
     endpoints:
     - port: prometheus
       scheme: http
-      interval: 60s
+      interval: 30s
       path: /metrics
       params:
         format: 

--- a/integrations/haproxy/documentation.yaml
+++ b/integrations/haproxy/documentation.yaml
@@ -22,7 +22,7 @@ config_mods: |
   +     bind *:8404
   +     stats enable
   +     stats uri /stats
-  \-\-\-
+  ---
   apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -61,10 +61,9 @@ config_mods: |
             - key: haproxy.cfg
               path: haproxy.cfg
 additional_install_info: |
-  The recommended changes in haproxy.cfg defines a frontend with the "stats enable" directive 
+  The recommended changes in <code>haproxy.cfg</code> defines a frontend with the "stats enable" directive 
   and enables the {{app_name_short}} stats page. This frontend can be scraped by {{exporter_pkg_name}}.
-  See [this official blog](https://www.haproxy.com/blog/exploring-the-haproxy-stats-page/){:class=external}
-  for more information.
+  For more information, see [Exploring the HAProxy Stats page](https://www.haproxy.com/blog/exploring-the-haproxy-stats-page/){:class=external}.
 podmonitoring_config: |
   apiVersion: monitoring.googleapis.com/v1
   kind: PodMonitoring
@@ -77,7 +76,7 @@ podmonitoring_config: |
     endpoints:
     - port: prometheus
       scheme: http
-      interval: 60s
+      interval: 30s
       path: /metrics
     selector:
       matchLabels:

--- a/integrations/postgresql/documentation.yaml
+++ b/integrations/postgresql/documentation.yaml
@@ -55,7 +55,7 @@ podmonitoring_config: |
     endpoints:
     - port: prometheus
       scheme: http
-      interval: 60s
+      interval: 30s
       path: /metrics
     selector:
       matchLabels:

--- a/integrations/redis/documentation.yaml
+++ b/integrations/redis/documentation.yaml
@@ -62,7 +62,7 @@ podmonitoring_config: |
     endpoints:
     - port: prometheus
       scheme: http
-      interval: 60s
+      interval: 30s
       path: /metrics
     selector:
       matchLabels:


### PR DESCRIPTION
1. Standardize recommended scraping interval at 30s
2. Improve some wording
3. Fix copy-paste issues with podmonitoring labels
4. Fix yaml formatting / indentation issues