### PR TITLE
GMP Documentation and alert: MySQL 

### DIFF
--- a/integrations/mysql/documentation.yaml
+++ b/integrations/mysql/documentation.yaml
@@ -1,0 +1,75 @@
+exporter_type: sidecar
+app_name_short: MySQL
+app_name: {{app_name_short}}
+app_site_name: MySQL
+app_site_url: https://www.mysql.com/
+exporter_name: the Mysql exporter
+exporter_pkg_name: mysqld_exporter
+exporter_repo_url: https://github.com/prometheus/mysqld_exporter
+dashboard_available: true
+minimum_exporter_version: v0.14.0
+multiple_dashboards: false
+dashboard_display_name: {{app_name_short}} Prometheus Overview
+config_mods: |
+  apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    name: mysql
+  spec:
+    serviceName: mysql
+    selector:
+      matchLabels:
+  +     app.kubernetes.io/name: mysql
+    template:
+      metadata:
+        labels:
+  +       app.kubernetes.io/name: mysql
+      spec:
+        containers:
+  +     - name: exporter
+  +       image: prom/mysqld-exporter:v0.14.0
+  +       env:
+  +         - name: DATA_SOURCE_NAME
+  +           value: root:password@(localhost:3306)/
+  +       ports:
+  +       - containerPort: 9104
+  +         name: prometheus
+        - image: mysql:5.7
+          name: mysql
+          env:
+          - name: MYSQL_ROOT_PASSWORD
+            value: password
+          - name: MYSQL_USER
+            value: sbtest
+          - name: MYSQL_PASSWORD
+            value: password
+          - name: MYSQL_DATABASE
+            value: sbtest
+          ports:
+          - containerPort: 3306
+            name: mysql
+podmonitoring_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: PodMonitoring
+  metadata:
+    name: mysql
+    labels:
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    endpoints:
+    - port: prometheus
+      scheme: http
+      interval: 30s
+      path: /metrics
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: mysql
+additional_prereq_info: |
+  See the exporter [Required Grants](https://github.com/prometheus/mysqld_exporter#required-grants){:class=external}
+  documentation for creating a least privileged user.
+additional_install_info:
+  Update the `DATA_SOURCE_NAME` environment variable with credentials that work with your {{app_name}} instance.
+alerts_config: {% includecode content_path="stackdriver/docs/managed-prometheus/exporters/configs/mysql_alerts.yaml" %}
+additional_alert_info: You can adjust the alert thresholds to suit your application.
+sample_promql_query: up{job="mysql", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}

--- a/integrations/mysql/documentation.yaml
+++ b/integrations/mysql/documentation.yaml
@@ -3,7 +3,7 @@ app_name_short: MySQL
 app_name: {{app_name_short}}
 app_site_name: MySQL
 app_site_url: https://www.mysql.com/
-exporter_name: the Mysql exporter
+exporter_name: the MySQL exporter
 exporter_pkg_name: mysqld_exporter
 exporter_repo_url: https://github.com/prometheus/mysqld_exporter
 dashboard_available: true
@@ -66,8 +66,7 @@ podmonitoring_config: |
       matchLabels:
         app.kubernetes.io/name: mysql
 additional_prereq_info: |
-  See the exporter [Required Grants](https://github.com/prometheus/mysqld_exporter#required-grants){:class=external}
-  documentation for creating a least privileged user.
+  For information about creating a least-privileged user, see [Required Grants](https://github.com/prometheus/mysqld_exporter#required-grants){:class=external}.
 additional_install_info:
   Update the `DATA_SOURCE_NAME` environment variable with credentials that work with your {{app_name}} instance.
 sample_promql_query: up{job="mysql", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}

--- a/integrations/mysql/documentation.yaml
+++ b/integrations/mysql/documentation.yaml
@@ -71,3 +71,29 @@ additional_prereq_info: |
 additional_install_info:
   Update the `DATA_SOURCE_NAME` environment variable with credentials that work with your {{app_name}} instance.
 sample_promql_query: up{job="mysql", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}
+alerts_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: Rules
+  metadata:
+    name: mysql-rules
+    labels:
+      app.kubernetes.io/component: rules
+      app.kubernetes.io/name: mysql-rules
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    groups:
+    - name: mysql
+      interval: 30s
+      rules:
+      - alert: MySQLConnectionErrors
+        annotations:
+          description: |-
+            MySQL connection errors
+              VALUE = {{ $value }}
+              LABELS: {{ $labels }}
+          summary: MySQL connection errors (instance {{ $labels.instance }})
+        expr: mysql_global_status_connection_errors_total > 0
+        for: 5m
+        labels:
+          severity: warning
+additional_alert_info: You can adjust the alert thresholds to suit your application.

--- a/integrations/mysql/documentation.yaml
+++ b/integrations/mysql/documentation.yaml
@@ -70,6 +70,4 @@ additional_prereq_info: |
   documentation for creating a least privileged user.
 additional_install_info:
   Update the `DATA_SOURCE_NAME` environment variable with credentials that work with your {{app_name}} instance.
-alerts_config: {% includecode content_path="stackdriver/docs/managed-prometheus/exporters/configs/mysql_alerts.yaml" %}
-additional_alert_info: You can adjust the alert thresholds to suit your application.
 sample_promql_query: up{job="mysql", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}

--- a/integrations/mysql/prometheus_metadata.yaml
+++ b/integrations/mysql/prometheus_metadata.yaml
@@ -1,0 +1,76 @@
+platforms:
+  - type: GKE
+    detections:
+      - characteristic_metric:
+          metric_type: prometheus.googleapis.com/mysql_up/gauge
+    launch_stage: GA
+    exporter_metadata:
+      name: MySQL Prometheus Exporter
+      doc_url: https://github.com/prometheus/mysqld_exporter
+      minimum_supported_version: v0.14.0
+    default_metrics:
+      - name: prometheus.googleapis.com/mysql_global_status_uptime/unknown:counter
+        prometheus_name: mysql_global_status_uptime
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/mysql_up/gauge
+        prometheus_name: mysql_up
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/mysql_global_status_threads_connected/unknown:counter
+        prometheus_name: mysql_global_status_threads_connected
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/mysql_global_variables_max_connections/gauge
+        prometheus_name: mysql_global_variables_max_connections
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/mysql_global_status_connection_errors_total/counter
+        prometheus_name: mysql_global_status_connection_errors_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/mysql_global_variables_open_files_limit/gauge
+        prometheus_name: mysql_global_variables_open_files_limit
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/mysql_global_variables_innodb_open_files/gauge
+        prometheus_name: mysql_global_variables_innodb_open_files
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/mysql_global_status_slow_queries/unknown:counter
+        prometheus_name: mysql_global_variables_innodb_open_files
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/mysql_global_status_table_open_cache_hits/unknown:counter
+        prometheus_name: mysql_global_status_table_open_cache_hits
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/mysql_global_status_table_open_cache_misses/unknown:counter
+        prometheus_name: mysql_global_status_table_open_cache_misses
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/mysql_global_status_innodb_buffer_pool_read_requests/unknown:counter
+        prometheus_name: mysql_global_status_innodb_buffer_pool_read_requests
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/mysql_global_status_innodb_buffer_pool_reads/unknown:counter
+        prometheus_name: mysql_global_status_innodb_buffer_pool_reads
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/mysql_global_status_select_full_join/unknown:counter
+        prometheus_name: mysql_global_status_select_full_join
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/mysql_global_status_select_full_range_join/unknown:counter
+        prometheus_name: mysql_global_status_select_full_range_join
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/mysql_global_status_select_range_check/unknown:counter
+        prometheus_name: mysql_global_status_select_range_check
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/mysql_global_status_select_scan/unknown:counter
+        prometheus_name: mysql_global_status_select_scan
+        kind: CUMULATIVE
+        value_type: DOUBLE
+    install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/mysql


### PR DESCRIPTION
This PR adds documentation configuration for the MySQL GMP integration.

-  Added documentation.yaml
-  Added prometheus_metadata.yaml

The documentation yaml includes an alert ported from https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/tree/master/alerts/mysql-gke
