### PR TITLE
GMP Documentation and alerts: Kafka 

### DIFF
--- a/integrations/kafka/documentation.yaml
+++ b/integrations/kafka/documentation.yaml
@@ -1,4 +1,4 @@
-exporter_type: generic_standalone
+exporter_type: standalone
 app_name_short: Kafka
 app_name: {{app_name_short}}
 app_site_name: Kafka
@@ -54,7 +54,7 @@ podmonitoring_config: |
         app.kubernetes.io/name: kafka-exporter
 additional_install_info: |
   The {{app_name_short}} exporter is configurable with [flags](https://github.com/danielqsj/kafka_exporter#flags){:class=external},
-  which can be set as container args. This example assumes Kafka is available via a ClusterIP service named `kafka`
+  which can be set as container args. This example assumes Kafka is available as a ClusterIP service named `kafka`
   on port `9092`.
 sample_promql_query: up{job="kafka-exporter", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}
 alerts_config: |

--- a/integrations/kafka/documentation.yaml
+++ b/integrations/kafka/documentation.yaml
@@ -1,0 +1,59 @@
+exporter_type: generic_standalone
+app_name_short: Kafka
+app_name: {{app_name_short}}
+app_site_name: Kafka
+app_site_url: https://kafka.apache.org/
+exporter_name: the Kafka exporter
+exporter_pkg_name: kafka_exporter
+exporter_repo_url: https://github.com/danielqsj/kafka_exporter
+dashboard_available: true
+minimum_exporter_version: v1.6.0
+multiple_dashboards: false
+dashboard_display_name: {{app_name_short}} Prometheus Overview
+standalone_config: |
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: kafka-exporter
+    labels:
+      app.kubernetes.io/name: kafka-exporter
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: kafka-exporter
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/name: kafka-exporter
+      spec:
+        containers:
+        - name: exporter
+          image: danielqsj/kafka-exporter:v1.6.0
+          args:
+            - --kafka.server=kafka:9092
+          ports:
+          - containerPort: 9308
+            name: prometheus
+podmonitoring_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: PodMonitoring
+  metadata:
+    name: kafka-exporter
+    labels:
+      app.kubernetes.io/name: kafka-exporter
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    endpoints:
+    - port: prometheus
+      scheme: http
+      interval: 30s
+      path: /metrics
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: kafka-exporter
+additional_install_info: |
+  The {{app_name_short}} exporter is configurable with [flags](https://github.com/danielqsj/kafka_exporter#flags){:class=external},
+  which can be set as container args. This example assumes Kafka is available via a ClusterIP service named `kafka`
+  on port `9092`.
+sample_promql_query: up{job="kafka-exporter", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}

--- a/integrations/kafka/documentation.yaml
+++ b/integrations/kafka/documentation.yaml
@@ -57,3 +57,40 @@ additional_install_info: |
   which can be set as container args. This example assumes Kafka is available via a ClusterIP service named `kafka`
   on port `9092`.
 sample_promql_query: up{job="kafka-exporter", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}
+alerts_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: Rules
+  metadata:
+    name: kafka-rules
+    labels:
+      app.kubernetes.io/component: rules
+      app.kubernetes.io/name: kafka-rules
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    groups:
+    - name: kafka
+      interval: 30s
+      rules:
+      - alert: KafkaChangeInNumberOfISRs
+        annotations:
+          description: |-
+            Kafka change in number of isrs
+              VALUE = {{ $value }}
+              LABELS: {{ $labels }}
+          summary: Kafka change in number of isrs (instance {{ $labels.instance }})
+        expr: kafka_topic_partition_in_sync_replica != 10
+        for: 5m
+        labels:
+          severity: critical
+      - alert: KafkaUnderReplicatedPartitions
+        annotations:
+          description: |-
+            Kafka under replicated partitions
+              VALUE = {{ $value }}
+              LABELS: {{ $labels }}
+          summary: Kafka under replicated partitions (instance {{ $labels.instance }})
+        expr: kafka_topic_partition_under_replicated_partition > 0
+        for: 1m
+        labels:
+          severity: warning
+additional_alert_info: You can adjust the alert thresholds to suit your application.

--- a/integrations/kafka/prometheus_metadata.yaml
+++ b/integrations/kafka/prometheus_metadata.yaml
@@ -1,0 +1,48 @@
+platforms:
+  - type: GKE
+    detections:
+      - characteristic_metric:
+          metric_type: prometheus.googleapis.com/kafka_brokers/gauge
+    launch_stage: GA
+    exporter_metadata:
+      name: Kafka Prometheus Exporter
+      doc_url: https://github.com/danielqsj/kafka_exporter
+      minimum_supported_version: v1.6.0
+    default_metrics:
+      - name: prometheus.googleapis.com/kafka_topic_partitions/gauge
+        prometheus_name: kafka_topic_partitions
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/kafka_brokers/gauge
+        prometheus_name: kafka_brokers
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/kafka_topic_partition_leader/gauge
+        prometheus_name: kafka_topic_partition_leader
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/kafka_topic_partition_leader_is_preferred/gauge
+        prometheus_name: kafka_topic_partition_leader_is_preferred
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/kafka_topic_partition_under_replicated_partition/gauge
+        prometheus_name: kafka_topic_partition_under_replicated_partition
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/kafka_topic_partition_replicas/gauge
+        prometheus_name: kafka_topic_partition_replicas
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/kafka_topic_partition_in_sync_replica/gauge
+        prometheus_name: kafka_topic_partition_in_sync_replica
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/kafka_topic_partition_current_offset/gauge
+        prometheus_name: kafka_topic_partition_current_offset
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/kafka_topic_partition_oldest_offset/gauge
+        prometheus_name: kafka_topic_partition_oldest_offset
+        kind: GAUGE
+        value_type: DOUBLE
+    install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/kafka


### PR DESCRIPTION
This PR adds documentation configuration for the Kafka GMP integration.

-  Added documentation.yaml
-  Added prometheus_metadata.yaml

Documentation yaml includes alerts ported from https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/blob/master/alerts/kafka-gke/kafka-change-in-number-of-isrs.v1.json.
