### PR TITLE
GMP Documentation and alerts: Zookeeper

### DIFF
--- a/integrations/zookeeper/documentation.yaml
+++ b/integrations/zookeeper/documentation.yaml
@@ -52,7 +52,7 @@ podmonitoring_config: |
         app.kubernetes.io/name: zookeeper
 additional_install_info: |
   {{app_name_short}} exposes Prometheus-format metrics automatically when configured
-  using the `ZOO_CFG_EXTRA` environment variable. This example configures {{app_name_short}}
+  to use the `ZOO_CFG_EXTRA` environment variable. This example configures {{app_name_short}}
   to expose Prometheus-format metrics on port `7000`.
 sample_promql_query: up{job="zookeeper", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}
 alerts_config: |

--- a/integrations/zookeeper/documentation.yaml
+++ b/integrations/zookeeper/documentation.yaml
@@ -55,3 +55,51 @@ additional_install_info: |
   using the `ZOO_CFG_EXTRA` environment variable. This example configures {{app_name_short}}
   to expose Prometheus-format metrics on port `7000`.
 sample_promql_query: up{job="zookeeper", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}
+alerts_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: Rules
+  metadata:
+    name: zookeeper-rules
+    labels:
+      app.kubernetes.io/component: rules
+      app.kubernetes.io/name: zookeeper-rules
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    groups:
+    - name: zookeeper
+      interval: 30s
+      rules:
+      - alert: ZooKeeperHighAverageLatency
+        annotations:
+          description: |-
+            ZooKeeper high average latency
+              VALUE = {{ $value }}
+              LABELS: {{ $labels }}
+          summary: ZooKeeper high average latency (instance {{ $labels.instance }})
+        expr: avg_latency > 100
+        for: 5m
+        labels:
+          severity: warning
+      - alert: ZooKeeperHighFsyncDuration
+        annotations:
+          description: |-
+            ZooKeeper high fsync duration
+              VALUE = {{ $value }}
+              LABELS: {{ $labels }}
+          summary: ZooKeeper high fsync duration (instance {{ $labels.instance }})
+        expr: fsynctime_sum > 100
+        for: 5m
+        labels:
+          severity: warning
+      - alert: ZooKeeperLowFreeFileDescriptors
+        annotations:
+          description: |-
+            ZooKeeper high fsync duration
+              VALUE = {{ $value }}
+              LABELS: {{ $labels }}
+          summary: ZooKeeper high fsync duration (instance {{ $labels.instance }})
+        expr: open_file_descriptor_count >= max_file_descriptor_count - 15
+        for: 5m
+        labels:
+          severity: critical
+additional_alert_info: You can adjust the alert thresholds to suit your application.

--- a/integrations/zookeeper/documentation.yaml
+++ b/integrations/zookeeper/documentation.yaml
@@ -1,0 +1,57 @@
+exporter_type: included
+app_name_short: Zookeeper
+app_name: {{app_name_short}}
+app_site_name: Zookeeper
+app_site_url: https://zookeeper.apache.org/
+exporter_name: the Zookeeper exporter
+exporter_pkg_name: zookeeper
+exporter_repo_url: https://zookeeper.apache.org/doc/r3.8.0/zookeeperMonitor.html
+dashboard_available: true
+minimum_exporter_version: "3.8.0"
+multiple_dashboards: false
+dashboard_display_name: {{app_name_short}} Prometheus Overview
+config_mods: |
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: zookeeper
+  spec:
+    selector:
+      matchLabels:
+  +     app.kubernetes.io/name: zookeeper
+    template:
+      metadata:
+        labels:
+  +       app.kubernetes.io/name: zookeeper
+      spec:
+        containers:
+        - name: zookeeper
+          image: zookeeper:3.8.0
+  +       env:
+  +       - name: ZOO_CFG_EXTRA
+  +         value: "metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider metricsProvider.httpPort=7000 metricsProvider.exportJvmInfo=true"
+  +       ports:
+  +       - containerPort: 7000
+  +         name: prometheus
+podmonitoring_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: PodMonitoring
+  metadata:
+    name: zookeeper
+    labels:
+      app.kubernetes.io/name: zookeeper
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    endpoints:
+    - port: prometheus
+      scheme: http
+      interval: 30s
+      path: /metrics
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: zookeeper
+additional_install_info: |
+  {{app_name_short}} exposes Prometheus-format metrics automatically when configured
+  using the `ZOO_CFG_EXTRA` environment variable. This example configures {{app_name_short}}
+  to expose Prometheus-format metrics on port `7000`.
+sample_promql_query: up{job="zookeeper", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}

--- a/integrations/zookeeper/prometheus_metadata.yaml
+++ b/integrations/zookeeper/prometheus_metadata.yaml
@@ -1,0 +1,60 @@
+platforms:
+  - type: GKE
+    detections:
+      - characteristic_metric:
+          metric_type: prometheus.googleapis.com/znode_count/gauge
+    launch_stage: GA
+    exporter_metadata:
+      name: ZooKeeper Prometheus Exporter
+      doc_url: https://zookeeper.apache.org/doc/r3.8.0/zookeeperMonitor.html
+      minimum_supported_version: "3.8.0"
+    default_metrics:
+      - name: prometheus.googleapis.com/uptime/gauge
+        prometheus_name: uptime
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/approximate_data_size/gauge
+        prometheus_name: approximate_data_size
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/znode_count/gauge
+        prometheus_name: znode_count
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/num_alive_connections/gauge
+        prometheus_name: num_alive_connections
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/watch_count/gauge
+        prometheus_name: watch_count
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/election_time_count/summary
+        prometheus_name: election_time_count
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/open_file_descriptor_count/gauge
+        prometheus_name: open_file_descriptor_count
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/fsynctime_sum/summary:counter
+        prometheus_name: fsynctime_sum
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/avg_latency/gauge
+        prometheus_name: avg_latency
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/snapshottime_sum/summary:counter
+        prometheus_name: snapshottime_sum
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/jvm_memory_bytes_used/gauge
+        prometheus_name: jvm_memory_bytes_used
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/jvm_memory_bytes_max/gauge
+        prometheus_name: jvm_memory_bytes_max
+        kind: GAUGE
+        value_type: DOUBLE
+    install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/zookeeper


### PR DESCRIPTION
This PR adds documentation configuration for the Zookeeper GMP integration.

-  Added documentation.yaml
-  Added prometheus_metadata.yaml

The documentation yaml contains alerts ported from https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/tree/master/alerts/zookeeper-gke