### PR TITLE
GMP Documentation: Consul

### DIFF
--- a/integrations/consul/documentation.yaml
+++ b/integrations/consul/documentation.yaml
@@ -1,0 +1,89 @@
+exporter_type: included
+app_name_short: Consul
+app_name: {{app_name_short}}
+app_site_name: Consul
+app_site_url: https://www.consul.io/
+exporter_name: the Consul exporter
+exporter_pkg_name: consul
+exporter_repo_url: https://developer.hashicorp.com/consul/docs/agent/config/config-files#telemetry-parameters
+dashboard_available: true
+minimum_exporter_version: "1.13.3"
+multiple_dashboards: false
+dashboard_display_name: {{app_name_short}} Prometheus Overview
+config_mods: |
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: consul-telemetry
+  data:
+  + metrics.hcl: |
+  +   telemetry {
+  +     prometheus_retention_time = "60s"
+  +     disable_hostname = true
+  +   }
+  ---
+  apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    name: consul
+  spec:
+    serviceName: consul
+    selector:
+      matchLabels:
+  +     app.kubernetes.io/name: consul
+    template:
+      metadata:
+        labels:
+  +       app.kubernetes.io/name: consul
+      spec:
+        containers:
+        - name: consul
+          image: consul:1.13.3
+          ports:
+          - containerPort: 8500
+            name: consul
+            protocol: TCP
+  +       volumeMounts:
+  +       - mountPath: /consul/config/metrics.hcl
+  +         subPath: metrics.hcl
+  +         name: consul-telemetry
+  +     volumes:
+  +     - name: consul-telemetry
+  +       configMap:
+  +         name: consul-telemetry
+  +         items:
+  +         - key: metrics.hcl
+  +           path: metrics.hcl
+podmonitoring_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: PodMonitoring
+  metadata:
+    name: consul
+    labels:
+      app.kubernetes.io/name: consul
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    endpoints:
+  + - port: 8500
+      scheme: http
+      interval: 30s
+  +   path: /v1/agent/metrics
+  +   params:
+  +     format: 
+  +       - prometheus
+    selector:
+      matchLabels:
+  +     app.kubernetes.io/name: consul
+additional_prereq_info: |
+  {{app_name_short}} exposes Prometheus-format metrics when the telemetry configuration options
+  `prometheus_retention_time` and `disable_hostname` are set. These options can be set by mounting
+  a configmap at `/consul/config/metrics.hcl`. Hashicorp recommends that a retention time twice 
+  that of the collection interval be used.
+
+   *  To determine if {{app_name_short}} is exposing metrics, run the following command:
+
+      <pre class="devsite-click-to-copy">
+      kubectl -n <namespace_name> port-forward <consul_pod_name> 8500
+      curl localhost:8500/v1/agent/metrics?format=prometheus
+      </pre>
+sample_promql_query: up{job="consul", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}

--- a/integrations/consul/documentation.yaml
+++ b/integrations/consul/documentation.yaml
@@ -70,7 +70,7 @@ podmonitoring_config: |
       path: /v1/agent/metrics
       params:
         format: 
-          - prometheus
+        - prometheus
     selector:
       matchLabels:
         app.kubernetes.io/name: consul

--- a/integrations/consul/documentation.yaml
+++ b/integrations/consul/documentation.yaml
@@ -80,7 +80,7 @@ additional_prereq_info: |
   a configmap at `/consul/config/metrics.hcl`. Hashicorp recommends using a retention time twice that
   of the collection interval.
 additional_install_info: |
-  To determine if {{app_name_short}} is exposing metrics, run the following commands:
+  To determine if {{app_name_short}} is exposing metrics, run the following command:
 
   <pre class="devsite-click-to-copy">
   kubectl exec -n {{namespace_name}} {{pod_name}} -- curl -sS localhost:8500/v1/agent/metrics?format=prometheus

--- a/integrations/consul/documentation.yaml
+++ b/integrations/consul/documentation.yaml
@@ -80,10 +80,9 @@ additional_prereq_info: |
   a configmap at `/consul/config/metrics.hcl`. Hashicorp recommends using a retention time twice that
   of the collection interval.
 additional_install_info: |
-  To determine if {{app_name_short}} is exposing metrics, run the following command:
+  To determine if {{app_name_short}} is exposing metrics, run the following commands:
 
   <pre class="devsite-click-to-copy">
-  kubectl -n <namespace_name> port-forward <consul_pod_name> 8500
-  curl localhost:8500/v1/agent/metrics?format=prometheus
+  kubectl exec -n {{namespace_name}} {{pod_name}} -- curl -sS localhost:8500/v1/agent/metrics?format=prometheus
   </pre>
 sample_promql_query: up{job="consul", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}

--- a/integrations/consul/documentation.yaml
+++ b/integrations/consul/documentation.yaml
@@ -1,6 +1,6 @@
 exporter_type: included
 app_name_short: Consul
-app_name: {{app_name_short}}
+app_name: HashiCorp {{app_name_short}}
 app_site_name: Consul
 app_site_url: https://www.consul.io/
 exporter_name: the Consul exporter
@@ -77,7 +77,7 @@ podmonitoring_config: |
 additional_prereq_info: |
   {{app_name_short}} exposes Prometheus-format metrics when the telemetry configuration options
   `prometheus_retention_time` and `disable_hostname` are set. These options can be set by mounting
-  a configmap at `/consul/config/metrics.hcl`. Hashicorp recommends using a retention time twice that
+  a configmap at `/consul/config/metrics.hcl`. HashiCorp recommends using a retention time twice that
   of the collection interval.
 additional_install_info: |
   To determine if {{app_name_short}} is exposing metrics, run the following command:

--- a/integrations/consul/documentation.yaml
+++ b/integrations/consul/documentation.yaml
@@ -77,13 +77,13 @@ podmonitoring_config: |
 additional_prereq_info: |
   {{app_name_short}} exposes Prometheus-format metrics when the telemetry configuration options
   `prometheus_retention_time` and `disable_hostname` are set. These options can be set by mounting
-  a configmap at `/consul/config/metrics.hcl`. Hashicorp recommends that a retention time twice 
-  that of the collection interval be used.
+  a configmap at `/consul/config/metrics.hcl`. Hashicorp recommends using a retention time twice that
+  of the collection interval.
+additional_install_info: |
+  To determine if {{app_name_short}} is exposing metrics, run the following command:
 
-   *  To determine if {{app_name_short}} is exposing metrics, run the following command:
-
-      <pre class="devsite-click-to-copy">
-      kubectl -n <namespace_name> port-forward <consul_pod_name> 8500
-      curl localhost:8500/v1/agent/metrics?format=prometheus
-      </pre>
+  <pre class="devsite-click-to-copy">
+  kubectl -n <namespace_name> port-forward <consul_pod_name> 8500
+  curl localhost:8500/v1/agent/metrics?format=prometheus
+  </pre>
 sample_promql_query: up{job="consul", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}

--- a/integrations/consul/documentation.yaml
+++ b/integrations/consul/documentation.yaml
@@ -64,16 +64,16 @@ podmonitoring_config: |
       app.kubernetes.io/part-of: google-cloud-managed-prometheus
   spec:
     endpoints:
-  + - port: 8500
+    - port: 8500
       scheme: http
       interval: 30s
-  +   path: /v1/agent/metrics
-  +   params:
-  +     format: 
-  +       - prometheus
+      path: /v1/agent/metrics
+      params:
+        format: 
+          - prometheus
     selector:
       matchLabels:
-  +     app.kubernetes.io/name: consul
+        app.kubernetes.io/name: consul
 additional_prereq_info: |
   {{app_name_short}} exposes Prometheus-format metrics when the telemetry configuration options
   `prometheus_retention_time` and `disable_hostname` are set. These options can be set by mounting

--- a/integrations/consul/prometheus_metadata.yaml
+++ b/integrations/consul/prometheus_metadata.yaml
@@ -53,4 +53,4 @@ platforms:
         prometheus_name: consul_raft_state_leader
         kind: CUMULATIVE
         value_type: DOUBLE
-    install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters
+    install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/consul

--- a/integrations/consul/prometheus_metadata.yaml
+++ b/integrations/consul/prometheus_metadata.yaml
@@ -1,0 +1,56 @@
+platforms:
+  - type: GKE
+    detections:
+      - characteristic_metric:
+          metric_type: prometheus.googleapis.com/consul_raft_apply/counter
+    launch_stage: GA
+    exporter_metadata:
+      name: Consul Prometheus Exporter
+      doc_url: https://developer.hashicorp.com/consul/docs/agent/config/config-files#telemetry-parameters
+      minimum_supported_version: "1.13.3"
+    default_metrics:
+      - name: prometheus.googleapis.com/consul_autopilot_healthy/gauge
+        prometheus_name: consul_autopilot_healthy
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/consul_runtime_sys_bytes/gauge
+        prometheus_name: consul_runtime_sys_bytes
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/consul_runtime_total_gc_pause_ns/gauge
+        prometheus_name: consul_runtime_total_gc_pause_ns
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/consul_raft_apply/counter
+        prometheus_name: consul_raft_apply
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/consul_kvs_apply/summary
+        prometheus_name: consul_kvs_apply
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/consul_raft_commitTime/summary
+        prometheus_name: consul_raft_commitTime
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/consul_client_rpc/counter
+        prometheus_name: consul_client_rpc
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/consul_client_rpc_exceeded/counter
+        prometheus_name: consul_client_rpc_exceeded
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/consul_client_rpc_failed/counter
+        prometheus_name: consul_client_rpc_failed
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/consul_raft_state_candidate/counter
+        prometheus_name: consul_raft_state_candidate
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/consul_raft_state_leader/counter
+        prometheus_name: consul_raft_state_leader
+        kind: CUMULATIVE
+        value_type: DOUBLE
+    install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters


### PR DESCRIPTION
This PR adds documentation configuration for the Consul GMP integration.

-  Added documentation.yaml
-  Added prometheus_metadata.yaml
