### PR TITLE
GMP Documentation and alert: Elasticsearch

### DIFF
--- a/integrations/elasticsearch/documentation.yaml
+++ b/integrations/elasticsearch/documentation.yaml
@@ -51,11 +51,11 @@ podmonitoring_config: |
     selector:
       matchLabels:
         app.kubernetes.io/name: elasticsearch-exporter
-additional_prereq_info: |
+additional_install_info: |
   The {{app_name_short}} exporter is configurable with [flags](https://github.com/prometheus-community/elasticsearch_exporter#configuration){:class=external},
   which can be set as container args. You can adjust your exporter's configuration to suit your {{app_name_short}} configuration.
 
-  Update the `--es.uri` flag to match your envirionments username, password, and clusterIP service name.
+  Update the `--es.uri` flag to match your envirionment's username, password, and clusterIP service name.
 sample_promql_query: up{job="elasticsearch", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}
 alerts_config: |
   apiVersion: monitoring.googleapis.com/v1

--- a/integrations/elasticsearch/documentation.yaml
+++ b/integrations/elasticsearch/documentation.yaml
@@ -1,0 +1,107 @@
+exporter_type: standalone
+app_name_short: Elasticsearch
+app_name: {{app_name_short}}
+app_site_name: Elasticsearch
+app_site_url: https://www.elastic.co/elasticsearch/
+exporter_name: the Elasticsearch exporter
+exporter_pkg_name: elasticsearch_exporter
+exporter_repo_url: https://github.com/prometheus-community/elasticsearch_exporter
+dashboard_available: true
+minimum_exporter_version: v1.3.0
+multiple_dashboards: false
+dashboard_display_name: {{app_name_short}} Prometheus Overview
+standalone_config: |
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: elasticsearch-exporter
+    labels:
+      app.kubernetes.io/name: elasticsearch-exporter
+  spec:
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: elasticsearch-exporter
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/name: elasticsearch-exporter
+      spec:
+        containers:
+        - name: exporter
+          image: quay.io/prometheuscommunity/elasticsearch-exporter:v1.3.0
+          args:
+            - '--es.uri=https://user:password@elasticsearch-es-internal-http:9200'
+          ports:
+          - containerPort: 9114
+            name: prometheus
+podmonitoring_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: PodMonitoring
+  metadata:
+    name: elasticsearch
+    labels:
+      app.kubernetes.io/name: elasticsearch
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    endpoints:
+    - port: prometheus
+      scheme: http
+      interval: 30s
+      path: /metrics
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: elasticsearch-exporter
+additional_prereq_info: |
+  The {{app_name_short}} exporter is configurable with [flags](https://github.com/prometheus-community/elasticsearch_exporter#configuration){:class=external},
+  which can be set as container args. You can adjust your exporter's configuration to suit your {{app_name_short}} configuration.
+
+  Update the `--es.uri` flag to match your envirionments username, password, and clusterIP service name.
+sample_promql_query: up{job="elasticsearch", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}
+alerts_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: Rules
+  metadata:
+    name: elasticsearch-rules
+    labels:
+      app.kubernetes.io/component: rules
+      app.kubernetes.io/name: elasticsearch-rules
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    groups:
+    - name: elasticsearch
+      interval: 30s
+      rules:
+      - alert: ElasticsearchHighJVMMemoryUsage
+        annotations:
+          description: |-
+            Elasticsearch high jvm memory usage
+              VALUE = {{ $value }}
+              LABELS: {{ $labels }}
+          summary: Elasticsearch high jvm memory usage (instance {{ $labels.instance }})
+        expr: (elasticsearch_jvm_memory_used_bytes / elasticsearch_jvm_memory_max_bytes) > 0.9
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ElasticsearchRedClusterStatus
+        annotations:
+          description: |-
+            Elasticsearch red cluster status
+              VALUE = {{ $value }}
+              LABELS: {{ $labels }}
+          summary: Elasticsearch red cluster status (instance {{ $labels.instance }})
+        expr: sum(elasticsearch_cluster_health_status{color="red"}) > 0
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ElasticsearchYellowClusterStatus
+        annotations:
+          description: |-
+            Elasticsearch yellow cluster status
+              VALUE = {{ $value }}
+              LABELS: {{ $labels }}
+          summary: Elasticsearch yellow cluster status (instance {{ $labels.instance }})
+        expr: sum(elasticsearch_cluster_health_status{color="yellow"}) > 0
+        for: 5m
+        labels:
+          severity: warning
+additional_alert_info: You can adjust the alert thresholds to suit your application.

--- a/integrations/elasticsearch/prometheus_metadata.yaml
+++ b/integrations/elasticsearch/prometheus_metadata.yaml
@@ -1,0 +1,69 @@
+platforms:
+  - type: GKE
+    launch_stage: GA
+    exporter_metadata:
+      name: Elasticsearch Prometheus Exporter
+      doc_url: https://github.com/prometheus-community/elasticsearch_exporter
+      minimum_supported_version: v1.3.0
+    default_metrics:
+      - name: prometheus.googleapis.com/elasticsearch_breakers_tripped/counter
+        prometheus_name: elasticsearch_breakers_tripped
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/elasticsearch_process_cpu_percent/gauge
+        prometheus_name: elasticsearch_process_cpu_percent
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/elasticsearch_jvm_memory_used_bytes/gauge
+        prometheus_name: elasticsearch_jvm_memory_used_bytes
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/elasticsearch_jvm_memory_max_bytes/gauge
+        prometheus_name: elasticsearch_jvm_memory_max_bytes
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/elasticsearch_jvm_memory_pool_peak_used_bytes/counter
+        prometheus_name: elasticsearch_jvm_memory_pool_peak_used_bytes
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/elasticsearch_cluster_health_number_of_nodes/gauge
+        prometheus_name: elasticsearch_cluster_health_number_of_nodes
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/elasticsearch_cluster_health_number_of_data_nodes/gauge
+        prometheus_name: elasticsearch_cluster_health_number_of_data_nodes
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/elasticsearch_cluster_health_number_of_pending_tasks/gauge
+        prometheus_name: elasticsearch_cluster_health_number_of_pending_tasks
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/elasticsearch_cluster_health_status/gauge
+        prometheus_name: elasticsearch_cluster_health_status
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/elasticsearch_process_open_files_count/gauge
+        prometheus_name: elasticsearch_process_open_files_count
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/elasticsearch_os_load15/gauge
+        prometheus_name: elasticsearch_os_load15
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/elasticsearch_filesystem_data_available_bytes/gauge
+        prometheus_name: elasticsearch_filesystem_data_available_bytes
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/elasticsearch_filesystem_data_size_bytes/gauge
+        prometheus_name: elasticsearch_filesystem_data_size_bytes
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/elasticsearch_transport_rx_size_bytes_total/counter
+        prometheus_name: elasticsearch_transport_rx_size_bytes_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/elasticsearch_thread_pool_rejected_count/counter
+        prometheus_name: elasticsearch_thread_pool_rejected_count
+        kind: CUMULATIVE
+        value_type: DOUBLE
+    install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/elasticsearch

--- a/integrations/elasticsearch/prometheus_metadata.yaml
+++ b/integrations/elasticsearch/prometheus_metadata.yaml
@@ -1,6 +1,9 @@
 platforms:
   - type: GKE
     launch_stage: GA
+    detections:
+      - characteristic_metric:
+          metric_type: prometheus.googleapis.com/elasticsearch_process_cpu_percent/gauge
     exporter_metadata:
       name: Elasticsearch Prometheus Exporter
       doc_url: https://github.com/prometheus-community/elasticsearch_exporter


### PR DESCRIPTION
This PR adds documentation configuration for the Elasticsearch GMP integration.

-  Added documentation.yaml
-  Added prometheus_metadata.yaml

The documentation yaml includes an alert ported from https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/tree/master/alerts/elasticsearch-gke
