### PR TITLE
Fix ActiveMQ, Couchdb, Zookeeper GMP app_name: Prefix with 'Apache'

### DIFF
--- a/integrations/activemq/documentation.yaml
+++ b/integrations/activemq/documentation.yaml
@@ -1,6 +1,6 @@
 exporter_type: sidecar
 app_name_short: ActiveMQ
-app_name: {{app_name_short}}
+app_name: Apache {{app_name_short}}
 app_site_name: ActiveMQ
 app_site_url: https://activemq.apache.org/
 exporter_name: the JMX exporter

--- a/integrations/couchdb/documentation.yaml
+++ b/integrations/couchdb/documentation.yaml
@@ -1,6 +1,6 @@
 exporter_type: sidecar
 app_name_short: CouchDB
-app_name: {{app_name_short}}
+app_name: Apache {{app_name_short}}
 app_site_name: CouchDB
 app_site_url: https://couchdb.apache.org/
 exporter_name: the CouchDB exporter

--- a/integrations/kafka/documentation.yaml
+++ b/integrations/kafka/documentation.yaml
@@ -1,6 +1,6 @@
 exporter_type: standalone
 app_name_short: Kafka
-app_name: {{app_name_short}}
+app_name: Apache {{app_name_short}}
 app_site_name: Kafka
 app_site_url: https://kafka.apache.org/
 exporter_name: the Kafka exporter

--- a/integrations/zookeeper/documentation.yaml
+++ b/integrations/zookeeper/documentation.yaml
@@ -1,6 +1,6 @@
 exporter_type: included
 app_name_short: Zookeeper
-app_name: {{app_name_short}}
+app_name: Apache  {{app_name_short}}
 app_site_name: Zookeeper
 app_site_url: https://zookeeper.apache.org/
 exporter_name: the Zookeeper exporter


### PR DESCRIPTION
@mtabasko pointed out that `app_name` should include the `Apache` prefix for these three integrations.