### PR TITLE
 GMP Documentation and alert: Apache Airflow

### DIFF
--- a/integrations/airflow/documentation.yaml
+++ b/integrations/airflow/documentation.yaml
@@ -10,13 +10,14 @@ additional_prereq_info: |
   {{app_name_short}} exposes Prometheus-format metrics automatically; you do not
   have to install it separately. You can run the following checks to verify
   that {{app_name_short}} is exposing Prometheus-format metrics.
+additional_install_info: |
+  To determine if {{exporter_name}} is exposing metrics, access the metrics endpoint
+  with port forwarding and curl.
 
-   *  To determine if {{exporter_name}} is exposing metrics, run the following command:
+  In one terminal, configure port forwarding with `kubectl -n <namespace_name> port-forward <airflow_pod_name> 9102`.
+  The port forwarding command will allow access to port 9102 on your machine.
 
-      <pre class="devsite-click-to-copy">
-      kubectl -n <namespace_name> port-forward <airflow_pod_name> 9102
-      curl localhost:9102/metrics
-      </pre>
+  In a second terminal, curl the metrics endpoint with `curl localhost:9102/metrics`.
 dashboard_available: true
 multiple_dashboards: false
 dashboard_display_name: {{app_name_short}} Prometheus Overview
@@ -30,15 +31,15 @@ podmonitoring_config: |
       app.kubernetes.io/part-of: google-cloud-managed-prometheus
   spec:
     endpoints:
-  + - port: 9102
+    - port: 9102
       scheme: http
       interval: 30s
       path: /metrics
     selector:
       matchLabels:
-  +     tier: airflow
-  +     component: statsd
-  +     release: airflow
+        tier: airflow
+        component: statsd
+        release: airflow
 additional_podmonitoring_info: |
   Ensure that the port and matchLabels match that of the airflow pods you wish to monitor.
   The values shown here are set by default when Airflow is deployed with [helm](https://airflow.apache.org/docs/helm-chart/){:class=external}.

--- a/integrations/airflow/documentation.yaml
+++ b/integrations/airflow/documentation.yaml
@@ -1,0 +1,71 @@
+exporter_type: included
+app_name_short: Airflow
+app_name: {{app_name_short}}
+app_site_name: Airflow
+app_site_url: https://airflow.apache.org/
+exporter_name: the Airflow exporter
+exporter_pkg_name: airflow
+exporter_repo_url: https://airflow.apache.org/docs/apache-airflow/stable/logging-monitoring/metrics.html
+additional_prereq_info: |
+  {{app_name_short}} exposes Prometheus-format metrics automatically; you do not
+  have to install it separately. You can run the following checks to verify
+  that {{app_name_short}} is exposing Prometheus-format metrics.
+
+   *  To determine if {{exporter_name}} is exposing metrics, run the following command:
+
+      <pre class="devsite-click-to-copy">
+      kubectl -n <namespace_name> port-forward <airflow_pod_name> 9102
+      curl localhost:9102/metrics
+      </pre>
+dashboard_available: true
+multiple_dashboards: false
+dashboard_display_name: {{app_name_short}} Prometheus Overview
+podmonitoring_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: PodMonitoring
+  metadata:
+    name: airflow
+    labels:
+      app.kubernetes.io/name: airflow
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    endpoints:
+  + - port: 9102
+      scheme: http
+      interval: 30s
+      path: /metrics
+    selector:
+      matchLabels:
+  +     tier: airflow
+  +     component: statsd
+  +     release: airflow
+additional_podmonitoring_info: |
+  Ensure that the port and matchLabels match that of the airflow pods you wish to monitor.
+  The values shown here are set by default when Airflow is deployed with [helm](https://airflow.apache.org/docs/helm-chart/){:class=external}.
+sample_promql_query: up{job="airflow", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}
+alerts_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: Rules
+  metadata:
+    name: airflow-rules
+    labels:
+      app.kubernetes.io/component: rules
+      app.kubernetes.io/name: airflow-rules
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    groups:
+    - name: airflow
+      interval: 30s
+      rules:
+      - alert: AirflowDAGImportErrors
+        annotations:
+          description: |-
+            Airflow dag import errors
+              VALUE = {{ $value }}
+              LABELS: {{ $labels }}
+          summary: Airflow dag import errors (instance {{ $labels.instance }})
+        expr: airflow_dag_processing_import_errors > 0
+        for: 5m
+        labels:
+          severity: critical
+additional_alert_info: You can adjust the alert thresholds to suit your application.

--- a/integrations/airflow/documentation.yaml
+++ b/integrations/airflow/documentation.yaml
@@ -40,7 +40,7 @@ podmonitoring_config: |
         component: statsd
         release: airflow
 additional_podmonitoring_info: |
-  Ensure that the values of the port and matchLabels match that of the {{app_name_short}} pods you want to monitor.
+  Ensure that the values of the port and matchLabels fields match those of the {{app_name_short}} pods you want to monitor.
   The labels and values shown here are set by default when Airflow is deployed with
   [Helm](https://airflow.apache.org/docs/helm-chart/){:class=external}.
 sample_promql_query: up{job="airflow", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}

--- a/integrations/airflow/documentation.yaml
+++ b/integrations/airflow/documentation.yaml
@@ -1,15 +1,11 @@
 exporter_type: included
 app_name_short: Airflow
-app_name: {{app_name_short}}
+app_name: Apache {{app_name_short}}
 app_site_name: Airflow
 app_site_url: https://airflow.apache.org/
 exporter_name: the Airflow exporter
 exporter_pkg_name: airflow
 exporter_repo_url: https://airflow.apache.org/docs/apache-airflow/stable/logging-monitoring/metrics.html
-additional_prereq_info: |
-  {{app_name_short}} exposes Prometheus-format metrics automatically; you do not
-  have to install it separately. You can run the following checks to verify
-  that {{app_name_short}} is exposing Prometheus-format metrics.
 additional_install_info: |
   To determine if {{exporter_name}} is exposing metrics, access the metrics endpoint
   with port forwarding and curl.
@@ -17,7 +13,7 @@ additional_install_info: |
   In one terminal, configure port forwarding with `kubectl -n <namespace_name> port-forward <airflow_pod_name> 9102`.
   The port forwarding command will allow access to port 9102 on your machine.
 
-  In a second terminal, curl the metrics endpoint with `curl localhost:9102/metrics`.
+  In a second terminal, make a GET request to the metrics endpoint with `curl localhost:9102/metrics`.
 dashboard_available: true
 multiple_dashboards: false
 dashboard_display_name: {{app_name_short}} Prometheus Overview

--- a/integrations/airflow/documentation.yaml
+++ b/integrations/airflow/documentation.yaml
@@ -8,12 +8,12 @@ exporter_pkg_name: airflow
 exporter_repo_url: https://airflow.apache.org/docs/apache-airflow/stable/logging-monitoring/metrics.html
 additional_install_info: |
   To determine if {{exporter_name}} is exposing metrics, access the metrics endpoint
-  with port forwarding and curl.
+  by using port forwarding and curl as follows:
 
-  In one terminal, configure port forwarding with `kubectl -n <namespace_name> port-forward <airflow_pod_name> 9102`.
-  The port forwarding command will allow access to port 9102 on your machine.
+  In one terminal, configure port forwarding by using `kubectl -n <namespace_name> port-forward <airflow_pod_name> 9102`.
+  The port forwarding command allows access to port 9102 on your machine.
 
-  In a second terminal, make a GET request to the metrics endpoint with `curl localhost:9102/metrics`.
+  In a second terminal, make a `GET` request to the metrics endpoint by using `curl localhost:9102/metrics`.
 dashboard_available: true
 multiple_dashboards: false
 dashboard_display_name: {{app_name_short}} Prometheus Overview
@@ -37,8 +37,9 @@ podmonitoring_config: |
         component: statsd
         release: airflow
 additional_podmonitoring_info: |
-  Ensure that the port and matchLabels match that of the airflow pods you wish to monitor.
-  The values shown here are set by default when Airflow is deployed with [helm](https://airflow.apache.org/docs/helm-chart/){:class=external}.
+  Ensure that the port and matchLabels match that of the {{app_name_short}} pods you wish to monitor.
+  The labels and values shown here are set by default when Airflow is deployed with
+  [Helm](https://airflow.apache.org/docs/helm-chart/){:class=external}.
 sample_promql_query: up{job="airflow", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}
 alerts_config: |
   apiVersion: monitoring.googleapis.com/v1

--- a/integrations/airflow/documentation.yaml
+++ b/integrations/airflow/documentation.yaml
@@ -6,14 +6,17 @@ app_site_url: https://airflow.apache.org/
 exporter_name: the Airflow exporter
 exporter_pkg_name: airflow
 exporter_repo_url: https://airflow.apache.org/docs/apache-airflow/stable/logging-monitoring/metrics.html
-additional_install_info: |
-  To determine if {{exporter_name}} is exposing metrics, access the metrics endpoint
-  by using port forwarding and curl as follows:
+additional_prereq_info: |
+  {{exporter_name}} exposes Prometheus-format metrics automatically; you do not have to
+  install it separately. To verify that {{exporter_name}} is emitting metrics on the expected
+  endpoints, set up port-forwarding with the following command:
 
-  In one terminal, configure port forwarding by using `kubectl -n <namespace_name> port-forward <airflow_pod_name> 9102`.
-  The port forwarding command allows access to port 9102 on your machine.
+  <pre class="devsite-click-to-copy">
+  kubectl -n {{namespace_name}} port-forward deploy/airflow-statsd 9102
+  </pre>
 
-  In a second terminal, make a `GET` request to the metrics endpoint by using `curl localhost:9102/metrics`.
+  Access the endpoint `localhost:9102/metrics` by using the browser or curl in another terminal session
+  to verify that the metrics are being exposed by the exporter for scraping.
 dashboard_available: true
 multiple_dashboards: false
 dashboard_display_name: {{app_name_short}} Prometheus Overview
@@ -37,7 +40,7 @@ podmonitoring_config: |
         component: statsd
         release: airflow
 additional_podmonitoring_info: |
-  Ensure that the port and matchLabels match that of the {{app_name_short}} pods you wish to monitor.
+  Ensure that the values of the port and matchLabels match that of the {{app_name_short}} pods you want to monitor.
   The labels and values shown here are set by default when Airflow is deployed with
   [Helm](https://airflow.apache.org/docs/helm-chart/){:class=external}.
 sample_promql_query: up{job="airflow", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}

--- a/integrations/airflow/documentation.yaml
+++ b/integrations/airflow/documentation.yaml
@@ -40,7 +40,7 @@ podmonitoring_config: |
         component: statsd
         release: airflow
 additional_podmonitoring_info: |
-  Ensure that the values of the port and matchLabels fields match those of the {{app_name_short}} pods you want to monitor.
+  Ensure that the values of the `port` and `matchLabels` fields match those of the {{app_name_short}} pods you want to monitor.
   The labels and values shown here are set by default when Airflow is deployed with
   [Helm](https://airflow.apache.org/docs/helm-chart/){:class=external}.
 sample_promql_query: up{job="airflow", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}

--- a/integrations/airflow/prometheus_metadata.yaml
+++ b/integrations/airflow/prometheus_metadata.yaml
@@ -6,7 +6,7 @@ platforms:
           metric_type: prometheus.googleapis.com/airflow_scheduler_tasks_running/gauge
     exporter_metadata:
       name: Airflow Prometheus Exporter
-      doc_url: https://github.com/prometheus/mysqld_exporter
+      doc_url: https://airflow.apache.org/docs/apache-airflow/stable/logging-monitoring/metrics.html
       minimum_supported_version: "2.3.0"
     default_metrics:
       - name: prometheus.googleapis.com/airflow_scheduler_tasks_running/gauge

--- a/integrations/airflow/prometheus_metadata.yaml
+++ b/integrations/airflow/prometheus_metadata.yaml
@@ -1,0 +1,40 @@
+platforms:
+  - type: GKE
+    launch_stage: GA
+    detections:
+      - characteristic_metric:
+          metric_type: prometheus.googleapis.com/airflow_scheduler_tasks_running/gauge
+    exporter_metadata:
+      name: Airflow Prometheus Exporter
+      doc_url: https://github.com/prometheus/mysqld_exporter
+      minimum_supported_version: "2.3.0"
+    default_metrics:
+      - name: prometheus.googleapis.com/airflow_scheduler_tasks_running/gauge
+        prometheus_name: airflow_scheduler_tasks_running
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/airflow_scheduler_tasks_starving/gauge
+        prometheus_name: airflow_scheduler_tasks_starving
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/airflow_scheduler_tasks_executable/gauge
+        prometheus_name: airflow_scheduler_tasks_executable
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/airflow_scheduler_heartbeat/counter
+        prometheus_name: airflow_scheduler_heartbeat
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/airflow_scheduler_orphaned_tasks_cleared/counter
+        prometheus_name: airflow_scheduler_orphaned_tasks_cleared
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/airflow_scheduler_orphaned_tasks_adopted/counter
+        prometheus_name: airflow_scheduler_orphaned_tasks_adopted
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/airflow_scheduler_critical_section_duration/summary
+        prometheus_name: airflow_scheduler_critical_section_duration
+        kind: GAUGE
+        value_type: DOUBLE
+    install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/apache-airflow


### PR DESCRIPTION
This PR adds documentation configuration for the Apache Airflow GMP integration.

-  Added documentation.yaml
-  Added prometheus_metadata.yaml

The documentation yaml includes an alert ported from https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/tree/master/alerts/airflow-gke