### PR TITLE
GMP Documentation and alert: Ingress NGINX

### DIFF
--- a/integrations/ingress-nginx/documentation.yaml
+++ b/integrations/ingress-nginx/documentation.yaml
@@ -11,12 +11,11 @@ additional_prereq_info: |
   have to install it separately. You can run the following checks to verify
   that {{app_name_short}} is exposing Prometheus-format metrics.
 
-   *  To determine if {{exporter_name}} is exposing metrics, run the following command:
+  To determine if {{exporter_name}} is exposing metrics, run the following command:
 
-      <pre class="devsite-click-to-copy">
-      kubectl -n ingress-nginx port-forward deploy/ingress-nginx-controller 10254
-      curl localhost:10254/metrics
-      </pre>
+  <pre class="devsite-click-to-copy">
+  kubectl exec -n {{ namespace }} deploy/ingress-nginx-controller -- curl http://localhost:10254/metrics
+  </pre>
 dashboard_available: true
 multiple_dashboards: false
 dashboard_display_name: {{app_name_short}} Prometheus Overview
@@ -30,13 +29,13 @@ podmonitoring_config: |
       app.kubernetes.io/part-of: google-cloud-managed-prometheus
   spec:
     endpoints:
-  + - port: 10254
+    - port: 10254
       scheme: http
       interval: 30s
       path: /metrics
     selector:
       matchLabels:
-  +     app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/name: ingress-nginx
 additional_podmonitoring_info: |
   Ensure that the port and matchLabels match that of the {{app_name_short}} pods you wish to monitor. By default,
   {{app_name_short}} exposes metrics on port 10254 and has the label `app.kubernetes.io/name: ingress-nginx`.

--- a/integrations/ingress-nginx/documentation.yaml
+++ b/integrations/ingress-nginx/documentation.yaml
@@ -1,0 +1,91 @@
+exporter_type: included
+app_name_short: Ingress NGINX
+app_name: {{app_name_short}}
+app_site_name: Ingress NGINX
+app_site_url: https://kubernetes.github.io/ingress-nginx
+exporter_name: the Ingress NGINX exporter
+exporter_pkg_name: ingress-nginx
+exporter_repo_url: https://kubernetes.github.io/ingress-nginx/user-guide/monitoring/
+additional_prereq_info: |
+  {{app_name_short}} exposes Prometheus-format metrics automatically; you do not
+  have to install it separately. You can run the following checks to verify
+  that {{app_name_short}} is exposing Prometheus-format metrics.
+
+   *  To determine if {{exporter_name}} is exposing metrics, run the following command:
+
+      <pre class="devsite-click-to-copy">
+      kubectl -n ingress-nginx port-forward deploy/ingress-nginx-controller 10254
+      curl localhost:10254/metrics
+      </pre>
+dashboard_available: true
+multiple_dashboards: false
+dashboard_display_name: {{app_name_short}} Prometheus Overview
+podmonitoring_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: PodMonitoring
+  metadata:
+    name: ingress-nginx
+    labels:
+      app.kubernetes.io/name: ingress-nginx
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    endpoints:
+  + - port: 10254
+      scheme: http
+      interval: 30s
+      path: /metrics
+    selector:
+      matchLabels:
+  +     app.kubernetes.io/name: ingress-nginx
+additional_podmonitoring_info: |
+  Ensure that the port and matchLabels match that of the {{app_name_short}} pods you wish to monitor. By default,
+  {{app_name_short}} exposes metrics on port 10254 and has the label `app.kubernetes.io/name: ingress-nginx`.
+sample_promql_query: up{job="ingress-nginx", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}
+alerts_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: Rules
+  metadata:
+    name: nginx-ingress-rules
+    labels:
+      app.kubernetes.io/component: rules
+      app.kubernetes.io/name: nginx-ingress-rules
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    groups:
+    - name: nginx-ingress
+      interval: 30s
+      rules:
+      - alert: NGINXIngressDroppedConnections
+        annotations:
+          description: |-
+            NGINX Ingress dropped connections
+              VALUE = {{ $value }}
+              LABELS: {{ $labels }}
+          summary: NGINX Ingress dropped connections (instance {{ $labels.instance }})
+        expr: (nginx_ingress_controller_nginx_process_connections_total{state="accepted"} - nginx_ingress_controller_nginx_process_connections_total{state="handled"}) > 0
+        for: 5m
+        labels:
+          severity: critical
+      - alert: NGINXIngressHighRequestRate
+        annotations:
+          description: |-
+            NGINX Ingress high request rate
+              VALUE = {{ $value }}
+              LABELS: {{ $labels }}
+          summary: NGINX Ingress high request rate (instance {{ $labels.instance }})
+        expr: rate(nginx_ingress_controller_requests[5m]) > 100
+        for: 5m
+        labels:
+          severity: warning
+      - alert: NGINXIngressLowRequestRate
+        annotations:
+          description: |-
+            NGINX Ingress low request rate
+              VALUE = {{ $value }}
+              LABELS: {{ $labels }}
+          summary: NGINX Ingress low request rate (instance {{ $labels.instance }})
+        expr: rate(nginx_ingress_controller_requests[5m]) < 10
+        for: 5m
+        labels:
+          severity: warning
+additional_alert_info: You can adjust the alert thresholds to suit your application.

--- a/integrations/ingress-nginx/documentation.yaml
+++ b/integrations/ingress-nginx/documentation.yaml
@@ -42,14 +42,14 @@ alerts_config: |
   apiVersion: monitoring.googleapis.com/v1
   kind: Rules
   metadata:
-    name: nginx-ingress-rules
+    name: ingress-nginx-rules
     labels:
       app.kubernetes.io/component: rules
-      app.kubernetes.io/name: nginx-ingress-rules
+      app.kubernetes.io/name: ingress-nginx-rules
       app.kubernetes.io/part-of: google-cloud-managed-prometheus
   spec:
     groups:
-    - name: nginx-ingress
+    - name: ingress-nginx
       interval: 30s
       rules:
       - alert: NGINXIngressDroppedConnections

--- a/integrations/ingress-nginx/documentation.yaml
+++ b/integrations/ingress-nginx/documentation.yaml
@@ -1,17 +1,15 @@
 exporter_type: included
 app_name_short: Ingress NGINX
-app_name: {{app_name_short}}
+app_name: {{app_name_short}} Controller
 app_site_name: Ingress NGINX
 app_site_url: https://kubernetes.github.io/ingress-nginx
-exporter_name: the Ingress NGINX exporter
+exporter_name: the Ingress NGINX Controller
 exporter_pkg_name: ingress-nginx
 exporter_repo_url: https://kubernetes.github.io/ingress-nginx/user-guide/monitoring/
 additional_prereq_info: |
   {{app_name_short}} exposes Prometheus-format metrics automatically; you do not
-  have to install it separately. You can run the following checks to verify
-  that {{app_name_short}} is exposing Prometheus-format metrics.
-
-  To determine if {{exporter_name}} is exposing metrics, run the following command:
+  have to install it separately. To verify that {{exporter_name}} is exposing
+  metrics, run the following command:
 
   <pre class="devsite-click-to-copy">
   kubectl exec -n {{ namespace }} deploy/ingress-nginx-controller -- curl http://localhost:10254/metrics
@@ -37,8 +35,8 @@ podmonitoring_config: |
       matchLabels:
         app.kubernetes.io/name: ingress-nginx
 additional_podmonitoring_info: |
-  Ensure that the port and matchLabels match that of the {{app_name_short}} pods you wish to monitor. By default,
-  {{app_name_short}} exposes metrics on port 10254 and has the label `app.kubernetes.io/name: ingress-nginx`.
+  Ensure that the port and matchLabels match that of the {{app_name_short}} pods you want to monitor. By default,
+  {{exporter_name}} exposes metrics on port 10254 and has the label `app.kubernetes.io/name: ingress-nginx`.
 sample_promql_query: up{job="ingress-nginx", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}
 alerts_config: |
   apiVersion: monitoring.googleapis.com/v1

--- a/integrations/ingress-nginx/prometheus_metadata.yaml
+++ b/integrations/ingress-nginx/prometheus_metadata.yaml
@@ -1,0 +1,40 @@
+platforms:
+  - type: GKE
+    detections:
+      - characteristic_metric:
+          metric_type: prometheus.googleapis.com/nginx_ingress_controller_nginx_process_cpu_seconds_total/counter
+    launch_stage: GA
+    exporter_metadata:
+      name: Ingress NGINX Prometheus Exporter
+      doc_url: https://kubernetes.github.io/ingress-nginx/user-guide/monitoring/
+      minimum_supported_version: "1.4.0"
+    default_metrics:
+      - name: prometheus.googleapis.com/nginx_ingress_controller_requests/counter
+        prometheus_name: nginx_ingress_controller_requests
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/nginx_ingress_controller_nginx_process_connections/gauge
+        prometheus_name: nginx_ingress_controller_nginx_process_connections
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/nginx_ingress_controller_success/counter
+        prometheus_name: nginx_ingress_controller_success
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/nginx_ingress_controller_requests/counter
+        prometheus_name: nginx_ingress_controller_requests
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/nginx_ingress_controller_request_size/histogram
+        prometheus_name: nginx_ingress_controller_request_size
+        kind: CUMULATIVE
+        value_type: DISTRIBUTION
+      - name: prometheus.googleapis.com/nginx_ingress_controller_nginx_process_resident_memory_bytes/gauge
+        prometheus_name: nginx_ingress_controller_nginx_process_resident_memory_bytes
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/nginx_ingress_controller_nginx_process_cpu_seconds_total/counter
+        prometheus_name: nginx_ingress_controller_nginx_process_cpu_seconds_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+    install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/nginx-ingress

--- a/integrations/ingress-nginx/prometheus_metadata.yaml
+++ b/integrations/ingress-nginx/prometheus_metadata.yaml
@@ -37,4 +37,4 @@ platforms:
         prometheus_name: nginx_ingress_controller_nginx_process_cpu_seconds_total
         kind: CUMULATIVE
         value_type: DOUBLE
-    install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/nginx-ingress
+    install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/ingress-nginx


### PR DESCRIPTION
This PR adds documentation configuration for the Ingress NGINX GMP integration.

-  Added documentation.yaml
-  Added prometheus_metadata.yaml

The documentation yaml includes an alert ported from https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/tree/master/alerts/nginx-ingress-gke