### PR TITLE
Added SAP hana availability alert for google cloud workload manager service

### DIFF
--- a/alerts/google-workload-manager/README.md
+++ b/alerts/google-workload-manager/README.md
@@ -1,0 +1,2 @@
+
+Templates in this directory are managed by the Cloud Workload Managerment Eng team and for development purposes.

--- a/alerts/google-workload-manager/metadata.yaml
+++ b/alerts/google-workload-manager/metadata.yaml
@@ -1,0 +1,6 @@
+alert_policy_templates:
+-
+  id: sap-hana-ha-availability-low
+  display_name: sap hana ha availability low
+  description: "sap hana ha availability with threshold 0.8"
+  version: 1

--- a/alerts/google-workload-manager/sap-hana-ha-availability-low.v1.json
+++ b/alerts/google-workload-manager/sap-hana-ha-availability-low.v1.json
@@ -1,0 +1,31 @@
+{
+  "displayName": "SAP HANA HA availability low",
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "SAP HANA HA availability",
+      "conditionThreshold": {
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/sap/hana/ha/availability\"",
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "perSeriesAligner": "ALIGN_MEAN"
+          }
+        ],
+        "comparison": "COMPARISON_LT",
+        "duration": "0s",
+        "trigger": {
+          "count": 1
+        },
+        "thresholdValue": 0.8
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}


### PR DESCRIPTION
Tested as the following. The created alert shows up in pantheon monitoring page as well.
![image](https://user-images.githubusercontent.com/119622929/205142309-0b2b11fe-7a22-4b9e-99be-025e08369e27.png)
