### PR TITLE
Add GMP Rabbitmq doc

### DIFF
--- a/integrations/rabbitmq/documentation.yaml
+++ b/integrations/rabbitmq/documentation.yaml
@@ -8,15 +8,17 @@ exporter_pkg_name: rabbitmq
 exporter_repo_url: https://rabbitmq.com/prometheus.html#overview-prometheus
 additional_prereq_info: |
   {{app_name_short}} exposes Prometheus-format metrics automatically; you do not
-  have to install it separately. You can run the following checks to verify
-  that {{app_name_short}} is exposing Prometheus-format metrics.
+  have to install it separately. To verify that {{exporter_name}} is emitting metrics on the expected
+  endpoints, set up port-forwarding with the following command:
 
-   *  To determine if {{exporter_name}} is exposing metrics, run the following command:
+  To determine if {{exporter_name}} is exposing metrics, run the following command:
 
-      <pre class="devsite-click-to-copy">
-      kubectl -n <namespace_name> port-forward <rabbitmq_pod_name> 15692
-      curl localhost:15692/metrics
-      </pre>
+  <pre class="devsite-click-to-copy">
+  kubectl -n {{namespace_name}} port-forward {{pod_name}} 15692
+  </pre>
+
+  Access the endpoint `localhost:15692/metrics` by using the browser or curl in another terminal session
+  to verify that the metrics are being exposed by the exporter for scraping.
 dashboard_available: true
 multiple_dashboards: false
 dashboard_display_name: {{app_name_short}} Prometheus Overview
@@ -30,18 +32,17 @@ podmonitoring_config: |
       app.kubernetes.io/part-of: google-cloud-managed-prometheus
   spec:
     endpoints:
-  + - port: prometheus
+    - port: prometheus
       scheme: http
       interval: 30s
       path: /metrics
     selector:
       matchLabels:
-  +     app.kubernetes.io/component: rabbitmq
+        app.kubernetes.io/component: rabbitmq
 additional_podmonitoring_info: |
-  Ensure that the port and matchLabels match that of the rabbitmq pods you wish to monitor. When deploying
-  Rabbitmq with the [operator](https://www.rabbitmq.com/kubernetes/operator/operator-overview.html){:class=external},
-  the label `app.kubernetes.io/component: rabbitmq` is set by default.
-additional_alert_info: You can adjust the alert thresholds to suit your application.
+  Ensure that the values of the port and matchLabels match that of the {{app_name_short}} pods you want to monitor.
+  Rabbitmq deployed by the [operator](https://www.rabbitmq.com/kubernetes/operator/operator-overview.html){:class=external}
+  will contain the label `app.kubernetes.io/component: rabbitmq` and `prometheus` port.
 sample_promql_query: up{job="rabbitmq", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}
 alerts_config: |
   apiVersion: monitoring.googleapis.com/v1
@@ -90,3 +91,4 @@ alerts_config: |
         for: 5m
         labels:
           severity: warning
+additional_alert_info: You can adjust the alert thresholds to suit your application.

--- a/integrations/rabbitmq/documentation.yaml
+++ b/integrations/rabbitmq/documentation.yaml
@@ -1,0 +1,92 @@
+exporter_type: included
+app_name_short: RabbitMQ
+app_name: {{app_name_short}}
+app_site_name: RabbitMQ
+app_site_url: https://rabbitmq.com/
+exporter_name: the RabbitMQ exporter
+exporter_pkg_name: rabbitmq
+exporter_repo_url: https://rabbitmq.com/prometheus.html#overview-prometheus
+additional_prereq_info: |
+  {{app_name_short}} exposes Prometheus-format metrics automatically; you do not
+  have to install it separately. You can run the following checks to verify
+  that {{app_name_short}} is exposing Prometheus-format metrics.
+
+   *  To determine if {{exporter_name}} is exposing metrics, run the following command:
+
+      <pre class="devsite-click-to-copy">
+      kubectl -n <namespace_name> port-forward <rabbitmq_pod_name> 15692
+      curl localhost:15692/metrics
+      </pre>
+dashboard_available: true
+multiple_dashboards: false
+dashboard_display_name: {{app_name_short}} Prometheus Overview
+podmonitoring_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: PodMonitoring
+  metadata:
+    name: rabbitmq
+    labels:
+      app.kubernetes.io/name: rabbitmq
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    endpoints:
+  + - port: prometheus
+      scheme: http
+      interval: 30s
+      path: /metrics
+    selector:
+      matchLabels:
+  +     app.kubernetes.io/component: rabbitmq
+additional_podmonitoring_info: |
+  Ensure that the port and matchLabels match that of the rabbitmq pods you wish to monitor. When deploying
+  Rabbitmq with the [operator](https://www.rabbitmq.com/kubernetes/operator/operator-overview.html){:class=external},
+  the label `app.kubernetes.io/component: rabbitmq` is set by default.
+additional_alert_info: You can adjust the alert thresholds to suit your application.
+sample_promql_query: up{job="rabbitmq", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}
+alerts_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: Rules
+  metadata:
+    name: rabbitmq-rules
+    labels:
+      app.kubernetes.io/component: rules
+      app.kubernetes.io/name: rabbitmq-rules
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    groups:
+    - name: rabbitmq
+      interval: 30s
+      rules:
+      - alert: RabbitMQHighUnacknowledgedMessages
+        annotations:
+          description: |-
+            RabbitMQ high unacknowledged messages 
+              VALUE = {{ $value }}
+              LABELS: {{ $labels }}
+          summary: RabbitMQ high unacknowledged messages (instance {{ $labels.instance }})
+        expr: rabbitmq_channel_messages_unacked > 5
+        for: 5m
+        labels:
+          severity: critical
+      - alert: RabbitMQHighUnroutableMessages
+        annotations:
+          description: |-
+            RabbitMQ high unroutable messages
+              VALUE = {{ $value }}
+              LABELS: {{ $labels }}
+          summary: RabbitMQ high unroutable messages (instance {{ $labels.instance }})
+        expr: rate(rabbitmq_channel_messages_unroutable_dropped_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+      - alert: RabbitMQLowDeliveredMessages
+        annotations:
+          description: |-
+            RabbitMQ low delivered messages
+              VALUE = {{ $value }}
+              LABELS: {{ $labels }}
+          summary: RabbitMQ low delivered messages (instance {{ $labels.instance }})
+        expr: rate(rabbitmq_channel_messages_delivered_total[5m]) < 10
+        for: 5m
+        labels:
+          severity: warning

--- a/integrations/rabbitmq/documentation.yaml
+++ b/integrations/rabbitmq/documentation.yaml
@@ -6,6 +6,7 @@ app_site_url: https://rabbitmq.com/
 exporter_name: the RabbitMQ exporter
 exporter_pkg_name: rabbitmq
 exporter_repo_url: https://rabbitmq.com/prometheus.html#overview-prometheus
+minimum_exporter_version: v3.8.0
 additional_prereq_info: |
   {{app_name_short}} exposes Prometheus-format metrics automatically; you do not
   have to install it separately. To verify that {{exporter_name}} is emitting metrics on the expected
@@ -41,7 +42,7 @@ podmonitoring_config: |
         app.kubernetes.io/component: rabbitmq
 additional_podmonitoring_info: |
   Ensure that the values of the port and matchLabels match that of the {{app_name_short}} pods you want to monitor.
-  Rabbitmq deployed by the [operator](https://www.rabbitmq.com/kubernetes/operator/operator-overview.html){:class=external}
+  {{app_name_short}} deployed by the [operator](https://www.rabbitmq.com/kubernetes/operator/operator-overview.html){:class=external}
   will contain the label `app.kubernetes.io/component: rabbitmq` and `prometheus` port.
 sample_promql_query: up{job="rabbitmq", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}
 alerts_config: |

--- a/integrations/rabbitmq/documentation.yaml
+++ b/integrations/rabbitmq/documentation.yaml
@@ -9,17 +9,18 @@ exporter_repo_url: https://rabbitmq.com/prometheus.html#overview-prometheus
 minimum_exporter_version: v3.8.0
 additional_prereq_info: |
   {{app_name_short}} exposes Prometheus-format metrics automatically; you do not
-  have to install it separately. To verify that {{exporter_name}} is emitting metrics on the expected
-  endpoints, set up port-forwarding with the following command:
+  have to install it separately. To verify that {{exporter_name}} is emitting 
+  metrics on the expected endpoints, do the following:
 
-  To determine if {{exporter_name}} is exposing metrics, run the following command:
+
+  Set up port forwarding by using the following command:
 
   <pre class="devsite-click-to-copy">
   kubectl -n {{namespace_name}} port-forward {{pod_name}} 15692
   </pre>
 
-  Access the endpoint `localhost:15692/metrics` by using the browser or curl in another terminal session
-  to verify that the metrics are being exposed by the exporter for scraping.
+  Access the endpoint `localhost:15692/metrics` by using the browser
+  or the `curl` utility in another terminal session.
 dashboard_available: true
 multiple_dashboards: false
 dashboard_display_name: {{app_name_short}} Prometheus Overview
@@ -41,7 +42,7 @@ podmonitoring_config: |
       matchLabels:
         app.kubernetes.io/component: rabbitmq
 additional_podmonitoring_info: |
-  Ensure that the values of the port and matchLabels match that of the {{app_name_short}} pods you want to monitor.
+  Ensure that the values of the `port` and `matchLabels` fields match those of the {{app_name_short}} pods you want to monitor.
   {{app_name_short}} deployed by the [operator](https://www.rabbitmq.com/kubernetes/operator/operator-overview.html){:class=external}
   will contain the label `app.kubernetes.io/component: rabbitmq` and `prometheus` port.
 sample_promql_query: up{job="rabbitmq", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}

--- a/integrations/rabbitmq/prometheus_metadata.yaml
+++ b/integrations/rabbitmq/prometheus_metadata.yaml
@@ -125,4 +125,8 @@ platforms:
         prometheus_name: rabbitmq_queues_deleted_total
         kind: CUMULATIVE
         value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_identity_info/unknown
+        prometheus_name: rabbitmq_identity_info
+        kind: GAUGE
+        value_type: DOUBLE
     install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/rabbitmq

--- a/integrations/rabbitmq/prometheus_metadata.yaml
+++ b/integrations/rabbitmq/prometheus_metadata.yaml
@@ -1,0 +1,128 @@
+platforms:
+  - type: GKE
+    detections:
+      - characteristic_metric:
+          metric_type: prometheus.googleapis.com/rabbitmq_connections/gauge
+    launch_stage: GA
+    exporter_metadata:
+      name: RabbitMQ Prometheus Exporter
+      doc_url: https://rabbitmq.com/prometheus.html#overview-prometheus
+      minimum_supported_version: v3.8.0
+    default_metrics:
+      - name: prometheus.googleapis.com/rabbitmq_queue_messages_ready/gauge
+        prometheus_name: rabbitmq_queue_messages_ready
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_channel_messages_published_total/counter
+        prometheus_name: rabbitmq_channel_messages_published_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_channels/gauge
+        prometheus_name: rabbitmq_channels
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_channel_consumers/gauge
+        prometheus_name: rabbitmq_channel_consumers
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_connections/gauge
+        prometheus_name: rabbitmq_connections
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_queues/gauge
+        prometheus_name: rabbitmq_queues
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_queue_messages_unacked/gauge
+        prometheus_name: rabbitmq_queue_messages_unacked
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_channel_messages_redelivered_total/counter
+        prometheus_name: rabbitmq_channel_messages_redelivered_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_channel_messages_delivered_total/counter
+        prometheus_name: rabbitmq_channel_messages_delivered_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_channel_messages_delivered_ack_total/counter
+        prometheus_name: rabbitmq_channel_messages_delivered_ack_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus/rabbitmq_channel_get_total/counter
+        prometheus_name: rabbitmq_channel_get_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_channel_get_ack_total/counter
+        prometheus_name: rabbitmq_channel_get_ack_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_build_info/unknown:counter
+        prometheus_name: rabbitmq_build_info
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_resident_memory_limit_bytes/gauge
+        prometheus_name: rabbitmq_resident_memory_limit_bytes
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_process_resident_memory_bytes/gauge
+        prometheus_name: rabbitmq_process_resident_memory_bytes
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_disk_space_available_bytes/gauge
+        prometheus_name: rabbitmq_disk_space_available_bytes
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_process_max_tcp_sockets/gauge
+        prometheus_name: rabbitmq_process_max_tcp_sockets
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_process_open_tcp_sockets/gauge
+        prometheus_name: rabbitmq_process_open_tcp_sockets
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_channel_messages_confirmed_total/counter
+        prometheus_name: rabbitmq_channel_messages_confirmed_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_queue_messages_published_total/counter
+        prometheus_name: rabbitmq_queue_messages_published_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_channel_messages_unconfirmed/gauge
+        prometheus_name: rabbitmq_channel_messages_unconfirmed
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_channel_messages_unroutable_dropped_total/counter
+        prometheus_name: rabbitmq_channel_messages_unroutable_dropped_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_channel_messages_unroutable_returned_total/counter
+        prometheus_name: rabbitmq_channel_messages_unroutable_returned_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_channel_messages_acked_total/counter
+        prometheus_name: rabbitmq_channel_messages_acked_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_channel_messages_delivered_total/counter
+        prometheus_name: rabbitmq_channel_messages_delivered_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_channel_get_empty_total/counter
+        prometheus_name: rabbitmq_channel_get_empty_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_queues_declared_total/counter
+        prometheus_name: rabbitmq_queues_declared_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_queues_created_total/counter
+        prometheus_name: rabbitmq_queues_created_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/rabbitmq_queues_deleted_total/counter
+        prometheus_name: rabbitmq_queues_deleted_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+    install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/rabbitmq

--- a/integrations/rabbitmq/prometheus_metadata.yaml
+++ b/integrations/rabbitmq/prometheus_metadata.yaml
@@ -3,7 +3,7 @@ platforms:
     detections:
       - characteristic_metric:
           metric_type: prometheus.googleapis.com/rabbitmq_connections/gauge
-    launch_stage: GA
+    launch_stage: HIDDEN
     exporter_metadata:
       name: RabbitMQ Prometheus Exporter
       doc_url: https://rabbitmq.com/prometheus.html#overview-prometheus


### PR DESCRIPTION
This PR adds documentation configuration for the Rabbitmq GMP integration.

-  Added documentation.yaml
-  Added prometheus_metadata.yaml

The documentation yaml includes an alert ported from https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/tree/master/alerts/rabbitmq-gke