### PR TITLE
GMP Istio doc and alerts configuration

### DIFF
--- a/integrations/istio/documentation.yaml
+++ b/integrations/istio/documentation.yaml
@@ -1,0 +1,186 @@
+exporter_type: included
+app_name_short: Istio
+app_name: {{app_name_short}}
+app_site_name: Istio
+app_site_url: https://istio.io
+exporter_name: Istio
+exporter_pkg_name: istio
+exporter_repo_url: https://istio.io/latest/docs/ops/integrations/prometheus
+additional_prereq_info: |
+  {{exporter_name}} exposes Prometheus-format metrics automatically; you do not
+  have to install it separately. You can run the following checks to verify
+  that the Istio Proxy has been injected as a sidecar and that both Istiod, the
+  control plane of {{exporter_name}}, and Istio Proxy are emitting metrics on
+  the expected endpoints.
+
+   *  To determine if {{exporter_name}} Proxy is injected as a sidecar, run the
+      following command, which enumerates the containers running in the application's pods:
+
+      <pre class="devsite-click-to-copy">
+      kubectl get pod -l app={{application_name}} -n {{namespace_name}} -o jsonpath='{.items[0].spec.containers[*].name}'
+      </pre>
+
+      If you see that the pods contain the {{exporter_literal}} sidecar
+      container, then the exporter has been injected. If the sidecar is not
+      injected, then follow the instructions at
+      [Istio: Installing the sidecar](https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/){:class=external}.
+
+   *  To verify that metrics are being emitted by the Istio Proxy, run the
+      following command, which inspects the `/stats/prometheus` endpoint of the
+      {{exporter_literal}} on the specified pod:
+
+      <pre class="devsite-click-to-copy">
+      kubectl exec {{pod_name}} -n {{namespace_name}} -c istio-proxy -- curl -sS 'localhost:15090/stats/prometheus'
+      </pre>
+
+      If you see raw `istio_*` and `envoy_*` Prometheus metrics, then
+      metrics are being emitted correctly.
+
+   *  To verify that metrics are being emitted similarly on Istiod, run the
+      following command, which inspects the `/metrics` endpoint of Istiod on one
+      of the pods in the `istiod` deployment:
+
+      <pre class="devsite-click-to-copy">
+      kubectl exec -n istio-system deployment/istiod -- curl -sS 'localhost:15014/metrics'
+      </pre>
+
+dashboard_available: true
+multiple_dashboards: false
+dashboard_display_name: Envoy Proxy Prometheus Overview
+podmonitoring_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: PodMonitoring
+  metadata:
+    name: istiod
+    namespace: istio-system
+    labels:
+      app.kubernetes.io/name: istiod
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    selector:
+      matchLabels:
+        app: istiod
+    endpoints:
+    - port: 15014
+      interval: 30s
+      path: /metrics
+    targetLabels:
+      fromPod:
+      - from: app
+        to: app
+  \---
+  apiVersion: monitoring.googleapis.com/v1
+  kind: PodMonitoring
+  metadata:
+    name: istio-proxy
+    labels:
+      app.kubernetes.io/name: istio-proxy
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    selector:
+      matchLabels:
+    endpoints:
+    - port: http-envoy-prom
+      scheme: http
+      interval: 30s
+      path: /stats/prometheus
+additional_podmonitoring_info: |
+  {{app_name_short}} requires two separate PodMonitoring resources:
+  One that monitors Istiod and another one that monitors the {{app_name_short}}
+  Proxy sidecars and the ingress and egress gateways. To monitor
+  {{app_name_short}} Proxy metrics across all namespaces in the cluster at once,
+  apply the `istio-proxy` PodMonitoring to every namespace or set up a
+  [ClusterPodMonitoring](https://github.com/GoogleCloudPlatform/prometheus-engine/blob/v0.4.3-gke.0/doc/api.md#clusterpodmonitoring){:class=external}
+  resource instead of a PodMonitoring resource per namespace.
+
+  If you plan to use the
+  [{{app_name_short}}-provided Grafana dashboards](https://istio.io/latest/docs/tasks/observability/metrics/using-istio-dashboard/){:class=external}
+  then in addition to the PodMonitoring resources described in this document
+  ensure that you also configured
+  [Kubelet and cAdvisor scraping](/stackdriver/docs/managed-prometheus/exporters/kubelet-cadvisor).
+sample_promql_query: sum(istio_build{cluster="{{cluster_name}}"}) by (component)
+alerts_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: Rules
+  metadata:
+    name: istio-rules
+    labels:
+      app.kubernetes.io/component: rules
+      app.kubernetes.io/name: istio-rules
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    groups:
+    - name: istio
+      interval: 30s
+      rules:
+      - alert: IstioHighTotalRequestRate
+        expr: sum(rate(istio_requests_total{reporter="destination"}[5m])) > 1000
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: Istio high total request rate (instance {{ $labels.instance }})
+          description: |-
+            Global request rate in the service mesh is unusually high.
+              VALUE = {{ $value }}
+              LABELS = {{ $labels }}
+      - alert: IstioLowTotalRequestRate
+        expr: sum(rate(istio_requests_total{reporter="destination"}[5m])) < 100
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: Istio low total request rate (instance {{ $labels.instance }})
+          description: |-
+            Global request rate in the service mesh is unusually low.
+              VALUE = {{ $value }}
+              LABELS = {{ $labels }}
+      - alert: IstioHigh4xxErrorRate
+        expr: sum(rate(istio_requests_total{reporter="destination", response_code=~"4.*"}[5m])) / sum(rate(istio_requests_total{reporter="destination"}[5m])) * 100 > 5
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: Istio high 4xx error rate (instance {{ $labels.instance }})
+          description: |-
+            High percentage of HTTP 5xx responses in Istio (> 5%).
+              VALUE = {{ $value }}
+              LABELS = {{ $labels }}
+      - alert: IstioHigh5xxErrorRate
+        expr: sum(rate(istio_requests_total{reporter="destination", response_code=~"5.*"}[5m])) / sum(rate(istio_requests_total{reporter="destination"}[5m])) * 100 > 5
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: Istio high 5xx error rate (instance {{ $labels.instance }})
+          description: |-
+            High percentage of HTTP 5xx responses in Istio (> 5%).
+              VALUE = {{ $value }}
+              LABELS = {{ $labels }}
+      - alert: IstioHighRequestLatency
+        expr: rate(istio_request_duration_milliseconds_sum{reporter="destination"}[1m]) / rate(istio_request_duration_milliseconds_count{reporter="destination"}[1m]) > 100
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: Istio high request latency (instance {{ $labels.instance }})
+          description: |-
+            Istio average requests execution is longer than 100ms.
+              VALUE = {{ $value }}
+              LABELS = {{ $labels }}
+      - alert: IstioLatency99Percentile
+        expr: histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket[1m])) by (destination_canonical_service, destination_workload_namespace, source_canonical_service, source_workload_namespace, le)) > 1
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: Istio latency 99 percentile (instance {{ $labels.instance }})
+          description: |-
+            Istio 1% slowest requests are longer than 1s.
+              VALUE = {{ $value }}
+              LABELS = {{ $labels }}
+additional_alert_info: |
+  This `Rules` configuration was adapted from the
+  [Istio rules](https://awesome-prometheus-alerts.grep.to/rules.html#istio-1){:class=external} provided by
+  [Awesome Prometheus Alerts](https://github.com/samber/awesome-prometheus-alerts/blob/master/LICENSE){:class=external}.
+  You can adjust the alert thresholds to suit your application.

--- a/integrations/istio/prometheus_metadata.yaml
+++ b/integrations/istio/prometheus_metadata.yaml
@@ -1,0 +1,63 @@
+platforms:
+  - type: GKE
+    detections:
+      - characteristic_metric:
+          metric_type: prometheus.googleapis.com/envoy_server_live/gauge
+    launch_stage: GA
+    exporter_metadata:
+      name: Istio Prometheus Exporter
+      doc_url: https://istio.io/latest/docs/ops/integrations/prometheus
+    default_metrics:
+      - name: prometheus.googleapis.com/envoy_server_live/gauge
+        prometheus_name: envoy_server_live
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/envoy_server_uptime/gauge
+        prometheus_name: envoy_server_uptime
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/envoy_server_memory_allocated/gauge
+        prometheus_name: envoy_server_memory_allocated
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/envoy_server_memory_heap_size/gauge
+        prometheus_name: envoy_server_memory_heap_size
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/envoy_cluster_membership_healthy/gauge
+        prometheus_name: envoy_cluster_membership_healthy
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/envoy_cluster_membership_total/gauge
+        prometheus_name: envoy_cluster_membership_total
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/envoy_cluster_upstream_cx_active/gauge
+        prometheus_name: envoy_cluster_upstream_cx_active
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/envoy_cluster_upstream_rq_total/counter
+        prometheus_name: envoy_cluster_upstream_rq_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/envoy_server_memory_allocated/gauge
+        prometheus_name: envoy_server_memory_allocated
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/envoy_cluster_upstream_cx_rx_bytes_total/counter
+        prometheus_name: envoy_cluster_upstream_cx_rx_bytes_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/envoy_cluster_manager_cds_update_attempt/counter
+        prometheus_name: envoy_cluster_manager_cds_update_attempt
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/envoy_cluster_manager_cds_update_success/counter
+        prometheus_name: envoy_cluster_manager_cds_update_success
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/envoy_cluster_manager_cds_update_failure/counter
+        prometheus_name: envoy_cluster_manager_cds_update_failure
+        kind: CUMULATIVE
+        value_type: DOUBLE
+    install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/mysql


### PR DESCRIPTION
This doc and alerts is derived from the official doc [here](https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/istio).

We were instructed to use launch stage "HIDDEN", however, I have left it on GA because the doc is already public. Let me know if this should change.