### PR TITLE
Add airflow metadata.yaml and mark hidden

### DIFF
--- a/integrations/airflow/metadata.yaml
+++ b/integrations/airflow/metadata.yaml
@@ -1,0 +1,7 @@
+id: airflow
+short_name: Airflow
+display_name: Apache Airflow
+description: Apache Airflow is an open-source platform for developing,
+  scheduling, and monitoring batch-oriented workflows. Airflow is deployable
+  in many ways, varying from a single process on your laptop to a distributed
+  setup to support even the biggest workflows.

--- a/integrations/airflow/prometheus_metadata.yaml
+++ b/integrations/airflow/prometheus_metadata.yaml
@@ -37,4 +37,4 @@ platforms:
         prometheus_name: airflow_scheduler_critical_section_duration
         kind: GAUGE
         value_type: DOUBLE
-    install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/apache-airflow
+    install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/airflow

--- a/integrations/airflow/prometheus_metadata.yaml
+++ b/integrations/airflow/prometheus_metadata.yaml
@@ -1,6 +1,6 @@
 platforms:
   - type: GKE
-    launch_stage: GA
+    launch_stage: HIDDEN
     detections:
       - characteristic_metric:
           metric_type: prometheus.googleapis.com/airflow_scheduler_tasks_running/gauge


### PR DESCRIPTION
Adds metadata.yaml file for airflow integration directory and marks GKE integration hidden until public doc is published.