### PR TITLE
fix typos for google cloud workload manager alert templates

### DIFF
--- a/alerts/google-workload-manager/README.md
+++ b/alerts/google-workload-manager/README.md
@@ -1,2 +1,2 @@
 
-Templates in this directory are managed by the Cloud Workload Managerment Eng team and for development purposes.
+Templates in this directory are managed by the Cloud Workload Management Eng team and for development purposes.

--- a/alerts/google-workload-manager/sap-hana-availability-low.v1.json
+++ b/alerts/google-workload-manager/sap-hana-availability-low.v1.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "SAPHanaAvailability",
+  "displayName": "SAP HANA Availability",
   "documentation": {
     "content": "# SAPHanaAvailability\n\nAn alert is triggered if the HANA standalone system is not up and running. The metrics frequency is 5 seconds(default). The query window is 1m to tolerate one-off measurements. The following metrics are used in this alert:\n\n```\nworkload.googleapis.com/sap/mntmode\n    0 -- no maintenance; alert if system not available\n    1 -- maintenance; no alert (availability of system does not matter)\nworkload.googleapis.com/sap/hana/availability\n    3 -- system available\n    <3 -- system not available\n```",
     "mimeType": "text/markdown"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/119622929/206276427-809d3237-342a-4129-a9fd-67487b66d88f.png)
tested in command line. alerts created in google cloud.