### PR TITLE
Revert "Hide GKE integrations without published documentation"

### DIFF
--- a/integrations/elasticsearch/prometheus_metadata.yaml
+++ b/integrations/elasticsearch/prometheus_metadata.yaml
@@ -1,6 +1,6 @@
 platforms:
   - type: GKE
-    launch_stage: HIDDEN
+    launch_stage: GA
     detections:
       - characteristic_metric:
           metric_type: prometheus.googleapis.com/elasticsearch_process_cpu_percent/gauge

--- a/integrations/memcached/prometheus_metadata.yaml
+++ b/integrations/memcached/prometheus_metadata.yaml
@@ -1,6 +1,6 @@
 platforms:
   - type: GKE
-    launch_stage: HIDDEN
+    launch_stage: GA
     detections:
       - characteristic_metric:
           metric_type: prometheus.googleapis.com/memcached_commands_total/counter


### PR DESCRIPTION
Reverts GoogleCloudPlatform/monitoring-dashboard-samples#397 since the docs for elasticsearch and memcached are published now.