### PR TITLE
Update validate_alerts_format script to not require display_name

### DIFF
--- a/scripts/alerts/validate_alerts_format.py
+++ b/scripts/alerts/validate_alerts_format.py
@@ -21,7 +21,7 @@ def check_metadata_entries(path):
   templates_metadata = data.get("alert_policy_templates")
   if not templates_metadata:
     raise Exception("alert_policy_templates not defined in {}".format(path))
-  required_fields = {"id", "version", "display_name", "description"}
+  required_fields = {"id", "version", "description"}
   for template_metadata in templates_metadata:
     missing_fields = required_fields - template_metadata.keys()
     if missing_fields:


### PR DESCRIPTION
display_name is no longer required in metadata.yaml for the alerts folder. Updating the presubmit accordingly.