### PR TITLE
GMP Documentation, Alerts, and Filtering: ScyllaDB

### DIFF
--- a/integrations/scylladb/documentation.yaml
+++ b/integrations/scylladb/documentation.yaml
@@ -1,0 +1,86 @@
+exporter_type: included
+app_name_short: ScyllaDB
+app_name: {{app_name_short}}
+app_site_name: ScyllaDB
+app_site_url: https://www.scylladb.com/
+exporter_name: the ScyllaDB exporter
+exporter_pkg_name: scylladb_monitoring_stack
+exporter_repo_url: https://monitoring.docs.scylladb.com/stable/reference/monitoring_apis.html
+dashboard_available: true
+minimum_exporter_version: "5.0"
+multiple_dashboards: false
+dashboard_display_name: {{app_name_short}} Prometheus Overview
+config_mods: |
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: scylladb
+  spec:
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: scylladb
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/name: scylladb
+      spec:
+        containers:
+        - name: scylladb
+          image: scylladb/scylla:5.0.5
+  +       ports:
+  +       - containerPort: 9180
+  +         name: prometheus
+podmonitoring_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: PodMonitoring
+  metadata:
+    name: scylladb
+    labels:
+      app.kubernetes.io/name: scylladb
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    endpoints:
+    - port: prometheus
+      interval: 30s
+      path: /metrics
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: scylladb
+sample_promql_query: up{job="scylladb", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}
+alerts_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: Rules
+  metadata:
+    name: scylladb-rules
+    labels:
+      app.kubernetes.io/component: rules
+      app.kubernetes.io/name: scylladb-rules
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    groups:
+    - name: scylladb
+      interval: 30s
+      rules:
+      - alert: ScyllaDBHighCompactionLoad
+        annotations:
+          description: |-
+            ScyllaDB high compaction load
+              VALUE = {{ $value }}
+              LABELS: {{ $labels }}
+          summary: ScyllaDB high compaction load (instance {{ $labels.instance }})
+        expr: scylla_scheduler_shares{group="compaction"} >= 1000
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ScyllaDBHighPreparedStatementEvictionRate
+        annotations:
+          description: |-
+            ScyllaDB high prepared statement eviction rate
+              VALUE = {{ $value }}
+              LABELS: {{ $labels }}
+          summary: ScyllaDB high prepared statement eviction rate (instance {{ $labels.instance }})
+        expr: (scylla_cql_prepared_cache_evictions + scylla_cql_authorized_prepared_statements_cache_evictions) > 100
+        for: 5m
+        labels:
+          severity: warning
+additional_alert_info: You can adjust the alert thresholds to suit your application.

--- a/integrations/scylladb/prometheus_metadata.yaml
+++ b/integrations/scylladb/prometheus_metadata.yaml
@@ -1,0 +1,57 @@
+platforms:
+  - type: GKE
+    launch_stage: GA
+    exporter_metadata:
+      name: ScyllaDB Prometheus Exporter
+      doc_url: https://monitoring.docs.scylladb.com/stable/reference/monitoring_apis.html
+      minimum_supported_version: "5.0"
+    default_metrics:
+      - name: prometheus.googleapis.com/scylla_node_operation_mode/gauge
+        prometheus_name: scylla_node_operation_mode
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/scylla_reactor_utilization/gauge
+        prometheus_name: scylla_reactor_utilization
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/scylla_transport_requests_served/counter
+        prometheus_name: scylla_transport_requests_served
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/scylla_compaction_manager_compactions/gauge
+        prometheus_name: scylla_compaction_manager_compactions
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/scylla_storage_proxy_coordinator_reads_local_node/counter
+        prometheus_name: scylla_storage_proxy_coordinator_reads_local_node
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/scylla_storage_proxy_coordinator_read_latency_sum/counter
+        prometheus_name: scylla_storage_proxy_coordinator_read_latency_sum
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/scylla_storage_proxy_coordinator_read_timeouts/counter
+        prometheus_name: scylla_storage_proxy_coordinator_read_timeouts
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/scylla_storage_proxy_coordinator_write_latency_sum/counter
+        prometheus_name: scylla_storage_proxy_coordinator_write_latency_sum
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/scylla_storage_proxy_coordinator_write_timeouts/counter
+        prometheus_name: scylla_storage_proxy_coordinator_write_timeouts
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/scylla_cache_bytes_used/gauge
+        prometheus_name: scylla_cache_bytes_used
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/scylla_cache_partition_hits/counter
+        prometheus_name: scylla_cache_partition_hits
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/scylla_cache_partition_misses/counter
+        prometheus_name: scylla_cache_partition_misses
+        kind: CUMULATIVE
+        value_type: DOUBLE
+    install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/scylladb

--- a/integrations/scylladb/prometheus_metadata.yaml
+++ b/integrations/scylladb/prometheus_metadata.yaml
@@ -1,6 +1,6 @@
 platforms:
   - type: GKE
-    launch_stage: GA
+    launch_stage: HIDDEN
     exporter_metadata:
       name: ScyllaDB Prometheus Exporter
       doc_url: https://monitoring.docs.scylladb.com/stable/reference/monitoring_apis.html


### PR DESCRIPTION
This PR includes the following for the ScyllaDB GMP integration:
* documentation
* alerts
* dashboard filters