### PR TITLE
GMP Documentation: Apache HTTP

### DIFF
--- a/integrations/apache/documentation.yaml
+++ b/integrations/apache/documentation.yaml
@@ -9,7 +9,7 @@ exporter_repo_url: https://github.com/Lusitaniae/apache_exporter
 dashboard_available: true
 minimum_exporter_version: v0.11.0
 multiple_dashboards: false
-dashboard_display_name: {{app_name_short}} Prometheus Overview
+dashboard_display_name: Apache Prometheus Overview
 config_mods: |
   apiVersion: v1
   kind: ConfigMap

--- a/integrations/apache/documentation.yaml
+++ b/integrations/apache/documentation.yaml
@@ -18,10 +18,10 @@ config_mods: |
   data:
     httpd.conf: |
       ...
-      <Location "/server-status">
-          SetHandler server-status
-      </Location>
-      LoadModule status_module modules/mod_status.so
+  +   <Location "/server-status">
+  +       SetHandler server-status
+  +   </Location>
+  +   LoadModule status_module modules/mod_status.so
       ...
   ---
   apiVersion: apps/v1
@@ -64,7 +64,9 @@ config_mods: |
   +           path: httpd.conf 
 additional_install_info: |
   These instructions assume you already have a working {{app_name_short}}
-  installation and want to modify it to include an exporter.
+  installation and want to modify it to include an exporter. Apache HTTP server
+  can be configured to serve metrics on `/server-status` by modifying the configuration
+  with a new Location directive and by loading the [status_module](https://httpd.apache.org/docs/2.4/mod/mod_status.html){:class=external}.
 podmonitoring_config: |
   apiVersion: monitoring.googleapis.com/v1
   kind: PodMonitoring
@@ -83,8 +85,7 @@ podmonitoring_config: |
       matchLabels:
         app.kubernetes.io/name: httpd
 additional_prereq_info: |
-  Apache HTTP can be [configured to expose metrics using the `mod_status` module.](https://httpd.apache.org/docs/trunk/en/misc/perf-scaling.html)
-  These metrics are exposed at the `/server-status` endpoint and can be scraped by the exporter.
+  Ensure that the values of the `port` and `matchLabels` fields match those of the {{app_name_short}} pods you want to monitor.
 alerts_config: {% includecode content_path="stackdriver/docs/managed-prometheus/exporters/configs/httpd_alerts.yaml" %}
 additional_alert_info: You can adjust the alert thresholds to suit your application.
 sample_promql_query: up{job="httpd", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}

--- a/integrations/apache/documentation.yaml
+++ b/integrations/apache/documentation.yaml
@@ -86,6 +86,4 @@ podmonitoring_config: |
         app.kubernetes.io/name: httpd
 additional_prereq_info: |
   Ensure that the values of the `port` and `matchLabels` fields match those of the {{app_name_short}} pods you want to monitor.
-alerts_config: {% includecode content_path="stackdriver/docs/managed-prometheus/exporters/configs/httpd_alerts.yaml" %}
-additional_alert_info: You can adjust the alert thresholds to suit your application.
 sample_promql_query: up{job="httpd", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}

--- a/integrations/apache/documentation.yaml
+++ b/integrations/apache/documentation.yaml
@@ -1,0 +1,90 @@
+exporter_type: sidecar
+app_name_short: Apache HTTP
+app_name: {{app_name_short}}
+app_site_name: Apache HTTP
+app_site_url: https://httpd.apache.org/
+exporter_name: the Apache HTTP exporter
+exporter_pkg_name: httpd_exporter
+exporter_repo_url: https://github.com/Lusitaniae/apache_exporter
+dashboard_available: true
+minimum_exporter_version: v0.11.0
+multiple_dashboards: false
+dashboard_display_name: {{app_name_short}} Prometheus Overview
+config_mods: |
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: httpd
+  data:
+    httpd.conf: |
+      ...
+      <Location "/server-status">
+          SetHandler server-status
+      </Location>
+      LoadModule status_module modules/mod_status.so
+      ...
+  ---
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: httpd
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+  +     app.kubernetes.io/name: httpd
+    template:
+      metadata:
+        labels:
+  +       app.kubernetes.io/name: httpd
+      spec:
+        containers:
+        - name: httpd
+          image: httpd:2.4
+          ports:
+          - containerPort: 80
+            name: httpd
+  +       volumeMounts:
+  +       - mountPath: /usr/local/apache2/conf/httpd.conf
+  +         subPath: httpd.conf
+  +         name: httpd
+  +     - name: httpd-exporter
+  +       image: lusotycoon/apache-exporter:v0.11.0
+  +       ports:
+  +       - containerPort: 9117
+  +         name: prometheus
+  +       command: ["/bin/apache_exporter"]
+  +       args: ['--scrape_uri=http://localhost/server-status?auto', '--telemetry.address=:9117', '--telemetry.endpoint=/metrics']
+  +     volumes:
+  +     - name: httpd
+  +       configMap:
+  +         name: httpd
+  +         items:
+  +         - key: httpd.conf
+  +           path: httpd.conf 
+additional_install_info: |
+  These instructions assume you already have a working {{app_name_short}}
+  installation and want to modify it to include an exporter.
+podmonitoring_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: PodMonitoring
+  metadata:
+    name: httpd
+    labels:
+      app.kubernetes.io/name: httpd
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    endpoints:
+    - port: prometheus
+      scheme: http
+      interval: 30s
+      path: /metrics
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: httpd
+additional_prereq_info: |
+  Apache HTTP can be [configured to expose metrics using the `mod_status` module.](https://httpd.apache.org/docs/trunk/en/misc/perf-scaling.html)
+  These metrics are exposed at the `/server-status` endpoint and can be scraped by the exporter.
+alerts_config: {% includecode content_path="stackdriver/docs/managed-prometheus/exporters/configs/httpd_alerts.yaml" %}
+additional_alert_info: You can adjust the alert thresholds to suit your application.
+sample_promql_query: up{job="httpd", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}

--- a/integrations/apache/prometheus_metadata.yaml
+++ b/integrations/apache/prometheus_metadata.yaml
@@ -1,0 +1,44 @@
+platforms:
+  - type: GKE
+    launch_stage: GA
+    detections:
+      - characteristic_metric:
+          metric_type: prometheus.googleapis.com/apache_connections/gauge
+    exporter_metadata:
+      name: Apache HTTP Prometheus Exporter
+      doc_url: https://github.com/Lusitaniae/apache_exporter
+      minimum_supported_version: v0.11.0
+    default_metrics:
+      - name: prometheus.googleapis.com/apache_sent_kilobytes_total/counter
+        prometheus_name: apache_sent_kilobytes_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/apache_duration_ms_total/counter
+        prometheus_name: apache_duration_ms_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/apache_connections/gauge
+        prometheus_name: apache_connections
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/apache_scoreboard/gauge
+        prometheus_name: apache_scoreboard
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/apache_workers/gauge
+        prometheus_name: apache_workers
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/apache_processes/gauge
+        prometheus_name: apache_processes
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/apache_cpuload/gauge
+        prometheus_name: apache_cpuload
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/apache_load/gauge
+        prometheus_name: apache_load
+        kind: GAUGE
+        value_type: DOUBLE
+    install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/apache

--- a/integrations/apache/prometheus_metadata.yaml
+++ b/integrations/apache/prometheus_metadata.yaml
@@ -1,6 +1,6 @@
 platforms:
   - type: GKE
-    launch_stage: GA
+    launch_stage: HIDDEN
     detections:
       - characteristic_metric:
           metric_type: prometheus.googleapis.com/apache_connections/gauge


### PR DESCRIPTION
This PR includes the following for the Apache HTTP GMP integration:
* documentation