### PR TITLE
Update redis-prometheus.json

### DIFF
--- a/dashboards/redis/redis-prometheus.json
+++ b/dashboards/redis/redis-prometheus.json
@@ -25,7 +25,7 @@
       {
         "height": 4,
         "widget": {
-          "title": "Network I/O",
+          "title": "Network I/O - Input",
           "xyChart": {
             "chartOptions": {
               "mode": "COLOR"
@@ -35,7 +35,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "rate(redis_net_output_bytes_total{${Cluster}, ${Location}, ${Namespace}} [5m])"
+                  "prometheusQuery": "rate(redis_net_input_bytes_total{${Cluster}, ${Location}, ${Namespace}} [5m])"
                 }
               }
             ],
@@ -48,8 +48,8 @@
           }
         },
         "width": 6,
-        "xPos": 6,
-        "yPos": 7
+        "xPos": 0,
+        "yPos": 8
       },
       {
         "height": 4,
@@ -78,10 +78,10 @@
         },
         "width": 6,
         "xPos": 6,
-        "yPos": 3
+        "yPos": 4
       },
       {
-        "height": 3,
+        "height": 4,
         "widget": {
           "title": "Commands Per Second",
           "xyChart": {
@@ -105,7 +105,7 @@
             }
           }
         },
-        "width": 12,
+        "width": 6,
         "xPos": 0,
         "yPos": 0
       },
@@ -136,7 +136,7 @@
         },
         "width": 6,
         "xPos": 0,
-        "yPos": 3
+        "yPos": 4
       },
       {
         "height": 4,
@@ -164,8 +164,37 @@
           }
         },
         "width": 6,
-        "xPos": 0,
-        "yPos": 7
+        "xPos": 6,
+        "yPos": 0
+      },
+      {
+        "height": 4,
+        "widget": {
+          "title": "Network I/O - Output",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "prometheusQuery": "rate(redis_net_output_bytes_total{${Cluster}, ${Location}, ${Namespace}} [5m])"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        },
+        "width": 6,
+        "xPos": 6,
+        "yPos": 8
       }
     ]
   }

--- a/integrations/redis/prometheus_metadata.yaml
+++ b/integrations/redis/prometheus_metadata.yaml
@@ -29,4 +29,8 @@ platforms:
         prometheus_name: redis_net_output_bytes_total
         kind: CUMULATIVE
         value_type: DOUBLE
+      - name: prometheus.googleapis.com/redis_net_input_bytes_total/counter
+        prometheus_name: redis_net_input_bytes_total
+        kind: CUMULATIVE
+        value_type: DOUBLE
     install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/redis


### PR DESCRIPTION
Adds separate chart for network input chart. It seems like charts only support a single prometheus query dataset, so separate charts appears to be the solution here.

![image](https://user-images.githubusercontent.com/1757661/210416655-0d204d18-0799-4b63-895f-67bf1713ba29.png)
