### PR TITLE
Fix dashboard name for istio prometheus dashboard

### DIFF
--- a/dashboards/istio/metadata.yaml
+++ b/dashboards/istio/metadata.yaml
@@ -2,7 +2,7 @@ sample_dashboards:
   -
     category: Istio
     id: istio-envoy-prometheus
-    display_name: Istio Envoy
+    display_name: Istio Envoy Prometheus Overview
     description: |-
       This dashboard has charts displaying Live Proxies, Average Uptime (minutes), Allocated Memory, Heap Size, Unhealty Proxies, Total Active Connections, Total Requests Rate, Allocated Memory, Upstream Network Traffic, CDS Update Attemps, CDS Update Success, and CDS Update Failure
     related_integrations:


### PR DESCRIPTION
With this change, the metadata.yaml file will have the same dashboard name as the corresponding readme.