### PR TITLE
Fix type mismatch in cassandra alert query

### DIFF
--- a/alerts/cassandra/high-error-rate.v1.json
+++ b/alerts/cassandra/high-error-rate.v1.json
@@ -13,7 +13,7 @@
                 "trigger": {
                     "count": 1
                 },
-                "query": "{\n    t_0: fetch gce_instance::workload.googleapis.com/cassandra.client.request.count\n    ; \n    t_1: fetch gce_instance::workload.googleapis.com/cassandra.client.request.error.count\n}\n| outer_join 1\n| group_by [metric.status, metric.operation]\n| value val(1) / if(has_value(val(0)), 1, val(0))\n| window 1m\n| condition val() > .1"
+                "query": "{\n    t_0: fetch gce_instance::workload.googleapis.com/cassandra.client.request.count\n    ; \n    t_1: fetch gce_instance::workload.googleapis.com/cassandra.client.request.error.count\n}\n| outer_join 1\n| group_by [metric.status, metric.operation]\n| value val(1) / if(has_value(val(0)), 1.0, val(0))\n| window 1m\n| condition val() > .1"
             }
         }
     ],


### PR DESCRIPTION
Fixes type issue in MQL query which needs all arguments to be of type `double`.
Query working in metric explorer 
![image](https://user-images.githubusercontent.com/1757661/216129665-ffdede87-becd-4c11-8725-12910db4d182.png)
