### PR TITLE
Fix RabbitMQ Prometheus Dashboard queries

### DIFF
--- a/dashboards/rabbitmq/rabbitmq-prometheus.json
+++ b/dashboards/rabbitmq/rabbitmq-prometheus.json
@@ -28,7 +28,7 @@
           "scorecard": {
             "blankView": {},
             "timeSeriesQuery": {
-              "prometheusQuery": "sum(rabbitmq_queue_messages_ready{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}})"
+              "prometheusQuery": "sum(rabbitmq_queue_messages_ready{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{${Cluster},${Location},${Namespace}})"
             }
           },
           "title": "Ready Messages"
@@ -45,7 +45,7 @@
               "sparkChartType": "SPARK_LINE"
             },
             "timeSeriesQuery": {
-              "prometheusQuery": "sum(rate(rabbitmq_channel_messages_published_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}})"
+              "prometheusQuery": "sum(rate(rabbitmq_channel_messages_published_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{${Cluster},${Location},${Namespace}})"
             }
           },
           "title": "Incoming Messages / second"
@@ -60,7 +60,7 @@
           "scorecard": {
             "blankView": {},
             "timeSeriesQuery": {
-              "prometheusQuery": "sum(rabbitmq_channels{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) - sum(rabbitmq_channel_consumers * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\"})"
+              "prometheusQuery": "sum(rabbitmq_channels{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) - sum(rabbitmq_channel_consumers * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{${Cluster},${Location},${Namespace}})"
             }
           },
           "title": "Publishers"
@@ -75,7 +75,7 @@
           "scorecard": {
             "blankView": {},
             "timeSeriesQuery": {
-              "prometheusQuery": "sum(rabbitmq_connections{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}})"
+              "prometheusQuery": "sum(rabbitmq_connections{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{${Cluster},${Location},${Namespace}})"
             }
           },
           "title": "Connections"
@@ -90,7 +90,7 @@
           "scorecard": {
             "blankView": {},
             "timeSeriesQuery": {
-              "prometheusQuery": "sum(rabbitmq_queues{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}})"
+              "prometheusQuery": "sum(rabbitmq_queues{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{${Cluster},${Location},${Namespace}})"
             }
           },
           "title": "Queues"
@@ -105,7 +105,7 @@
           "scorecard": {
             "blankView": {},
             "timeSeriesQuery": {
-              "prometheusQuery": "sum(rabbitmq_queue_messages_unacked{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}})"
+              "prometheusQuery": "sum(rabbitmq_queue_messages_unacked{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{${Cluster},${Location},${Namespace}})"
             }
           },
           "title": "Unacknowledged Messages"
@@ -122,7 +122,7 @@
               "sparkChartType": "SPARK_LINE"
             },
             "timeSeriesQuery": {
-              "prometheusQuery": "sum(rate(rabbitmq_channel_messages_redelivered_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) +\nsum(rate(rabbitmq_channel_messages_delivered_total[60s]) * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) +\nsum(rate(rabbitmq_channel_messages_delivered_ack_total[60s]) * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) +\nsum(rate(rabbitmq_channel_get_total[60s]) * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) +\nsum(rate(rabbitmq_channel_get_ack_total[60s]) * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}})"
+              "prometheusQuery": "sum(rate(rabbitmq_channel_messages_redelivered_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) +\nsum(rate(rabbitmq_channel_messages_delivered_total[60s]) * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) +\nsum(rate(rabbitmq_channel_messages_delivered_ack_total[60s]) * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) +\nsum(rate(rabbitmq_channel_get_total[60s]) * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) +\nsum(rate(rabbitmq_channel_get_ack_total[60s]) * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{${Cluster},${Location},${Namespace}})"
             }
           },
           "title": "Outgoing Messages / second"
@@ -137,7 +137,7 @@
           "scorecard": {
             "blankView": {},
             "timeSeriesQuery": {
-              "prometheusQuery": "sum(rabbitmq_channel_consumers{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}})"
+              "prometheusQuery": "sum(rabbitmq_channel_consumers{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{${Cluster},${Location},${Namespace}})"
             }
           },
           "title": "Consumers"
@@ -152,7 +152,7 @@
           "scorecard": {
             "blankView": {},
             "timeSeriesQuery": {
-              "prometheusQuery": "sum(rabbitmq_channels{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}})"
+              "prometheusQuery": "sum(rabbitmq_channels{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{${Cluster},${Location},${Namespace}})"
             }
           },
           "title": "Channels"
@@ -167,7 +167,7 @@
           "scorecard": {
             "blankView": {},
             "timeSeriesQuery": {
-              "prometheusQuery": "sum(rabbitmq_build_info{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}})"
+              "prometheusQuery": "sum(rabbitmq_build_info{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{${Cluster},${Location},${Namespace}})"
             }
           },
           "title": "Nodes"
@@ -196,7 +196,7 @@
               {
                 "tableDisplayOptions": {},
                 "timeSeriesQuery": {
-                  "prometheusQuery": "rabbitmq_build_info{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}"
+                  "prometheusQuery": "rabbitmq_build_info{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}"
                 }
               }
             ],
@@ -221,7 +221,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "(rabbitmq_resident_memory_limit_bytes{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) -\n(rabbitmq_process_resident_memory_bytes * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}})"
+                  "prometheusQuery": "(rabbitmq_resident_memory_limit_bytes{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) -\n(rabbitmq_process_resident_memory_bytes * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}})"
                 }
               }
             ],
@@ -249,7 +249,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "rabbitmq_disk_space_available_bytes{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}"
+                  "prometheusQuery": "rabbitmq_disk_space_available_bytes{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}"
                 }
               }
             ],
@@ -277,7 +277,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "(rabbitmq_process_max_tcp_sockets{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) -\n(rabbitmq_process_open_tcp_sockets * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}})"
+                  "prometheusQuery": "(rabbitmq_process_max_tcp_sockets{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) -\n(rabbitmq_process_open_tcp_sockets * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}})"
                 }
               }
             ],
@@ -317,7 +317,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum(rabbitmq_queue_messages_ready{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
+                  "prometheusQuery": "sum(rabbitmq_queue_messages_ready{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
                 }
               }
             ],
@@ -345,7 +345,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum(rabbitmq_queue_messages_unacked{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
+                  "prometheusQuery": "sum(rabbitmq_queue_messages_unacked{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
                 }
               }
             ],
@@ -385,7 +385,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum(rate(rabbitmq_channel_messages_published_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
+                  "prometheusQuery": "sum(rate(rabbitmq_channel_messages_published_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
                 }
               }
             ],
@@ -413,7 +413,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum(rate(rabbitmq_channel_messages_unconfirmed{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
+                  "prometheusQuery": "sum(rate(rabbitmq_channel_messages_unconfirmed{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
                 }
               }
             ],
@@ -441,7 +441,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum(rate(rabbitmq_queue_messages_published_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
+                  "prometheusQuery": "sum(rate(rabbitmq_queue_messages_published_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
                 }
               }
             ],
@@ -469,7 +469,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum(rate(rabbitmq_channel_messages_confirmed_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
+                  "prometheusQuery": "sum(rate(rabbitmq_channel_messages_confirmed_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
                 }
               }
             ],
@@ -497,7 +497,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum(rate(rabbitmq_channel_messages_unroutable_dropped_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
+                  "prometheusQuery": "sum(rate(rabbitmq_channel_messages_unroutable_dropped_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
                 }
               }
             ],
@@ -525,7 +525,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum(rate(rabbitmq_channel_messages_unroutable_returned_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
+                  "prometheusQuery": "sum(rate(rabbitmq_channel_messages_unroutable_returned_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
                 }
               }
             ],
@@ -565,7 +565,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum(rate(rabbitmq_channel_get_empty_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
+                  "prometheusQuery": "sum(rate(rabbitmq_channel_get_empty_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
                 }
               }
             ],
@@ -593,7 +593,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum(rate(rabbitmq_channel_messages_redelivered_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
+                  "prometheusQuery": "sum(rate(rabbitmq_channel_messages_redelivered_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
                 }
               }
             ],
@@ -621,7 +621,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum(\n  (rate(rabbitmq_channel_messages_delivered_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) +\n  (rate(rabbitmq_channel_messages_delivered_ack_total[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}})\n) by(rabbitmq_node)"
+                  "prometheusQuery": "sum(\n  (rate(rabbitmq_channel_messages_delivered_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) +\n  (rate(rabbitmq_channel_messages_delivered_ack_total[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}})\n) by(rabbitmq_node)"
                 }
               }
             ],
@@ -649,7 +649,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum(rate(rabbitmq_channel_messages_delivered_ack_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
+                  "prometheusQuery": "sum(rate(rabbitmq_channel_messages_delivered_ack_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
                 }
               }
             ],
@@ -677,7 +677,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum(rate(rabbitmq_channel_get_ack_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
+                  "prometheusQuery": "sum(rate(rabbitmq_channel_get_ack_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
                 }
               }
             ],
@@ -705,7 +705,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum(rate(rabbitmq_channel_messages_delivered_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
+                  "prometheusQuery": "sum(rate(rabbitmq_channel_messages_delivered_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
                 }
               }
             ],
@@ -733,7 +733,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum(rate(rabbitmq_channel_messages_acked_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
+                  "prometheusQuery": "sum(rate(rabbitmq_channel_messages_acked_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
                 }
               }
             ],
@@ -761,7 +761,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum(rate(rabbitmq_channel_get_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
+                  "prometheusQuery": "sum(rate(rabbitmq_channel_get_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
                 }
               }
             ],
@@ -801,7 +801,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "rabbitmq_queues{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}"
+                  "prometheusQuery": "rabbitmq_queues{${Cluster},${Location},${Namespace}} * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}"
                 }
               }
             ],
@@ -829,7 +829,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum(rate(rabbitmq_queues_created_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
+                  "prometheusQuery": "sum(rate(rabbitmq_queues_created_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
                 }
               }
             ],
@@ -857,7 +857,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum(rate(rabbitmq_queues_declared_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
+                  "prometheusQuery": "sum(rate(rabbitmq_queues_declared_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
                 }
               }
             ],
@@ -885,7 +885,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum(rate(rabbitmq_queues_deleted_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"rabbitmq\", namespace=\"default\",${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
+                  "prometheusQuery": "sum(rate(rabbitmq_queues_deleted_total{${Cluster},${Location},${Namespace}}[60s]) * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{${Cluster},${Location},${Namespace}}) by(rabbitmq_node)"
                 }
               }
             ],


### PR DESCRIPTION
Previously, the RabbitMQ dashboard queries had extraneous filters that assumed a specific cluster and namespace name. This led to issues where it would show up in the list of integration dashboards (because the characteristic metrics were detected) but display empty data.

Fix tested on wilfredl@'s local setup.