### PR TITLE
GMP Doc Update: Aerospike 

### DIFF
--- a/integrations/aerospike/prometheus_metadata.yaml
+++ b/integrations/aerospike/prometheus_metadata.yaml
@@ -13,9 +13,10 @@ platforms:
         prometheus_name: aerospike_namespace_memory_free_pct
         kind: GAUGE
         value_type: DOUBLE
-        value_type: DOUBLE
       - name: prometheus.googleapis.com/aerospike_namespace_device_available_pct/gauge
         prometheus_name: aerospike_namespace_device_available_pct
+        kind: GAUGE
+        value_type: DOUBLE
       - name: prometheus.googleapis.com/aerospike_node_stats_fabric_connections/gauge
         prometheus_name: aerospike_node_stats_fabric_connections
         kind: GAUGE

--- a/integrations/aerospike/prometheus_metadata.yaml
+++ b/integrations/aerospike/prometheus_metadata.yaml
@@ -13,6 +13,9 @@ platforms:
         prometheus_name: aerospike_namespace_memory_free_pct
         kind: GAUGE
         value_type: DOUBLE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/aerospike_namespace_device_available_pct/gauge
+        prometheus_name: aerospike_namespace_device_available_pct
       - name: prometheus.googleapis.com/aerospike_node_stats_fabric_connections/gauge
         prometheus_name: aerospike_node_stats_fabric_connections
         kind: GAUGE


### PR DESCRIPTION
* added `device_available_pct` metric to `default_metrics` list