### PR TITLE
GMP Doc Update: CouchDB

### DIFF
--- a/integrations/couchdb/prometheus_metadata.yaml
+++ b/integrations/couchdb/prometheus_metadata.yaml
@@ -12,6 +12,9 @@ platforms:
       - name: prometheus.googleapis.com/couchdb_httpd_request_methods/gauge
         prometheus_name: couchdb_httpd_request_methods
         kind: GAUGE
+      - name: prometheus.googleapis.com/couchdb_httpd_requests/gauge
+        prometheus_name: couchdb_httpd_requests
+        kind: GAUGE
         value_type: DOUBLE
       - name: prometheus.googleapis.com/couchdb_httpd_status_codes/gauge
         prometheus_name: couchdb_httpd_status_codes


### PR DESCRIPTION
* added `couchdb_httpd_requests` to `default_metrics` list