### PR TITLE
Add deprecation prefix to old dashboard samples

### DIFF
--- a/dashboards/anthos/metadata.yaml
+++ b/dashboards/anthos/metadata.yaml
@@ -2,40 +2,40 @@ sample_dashboards:
   -
     category: Anthos
     id: Anthos-cluster-control-plane-uptime
-    display_name: Anthos cluster control plane uptime
+    display_name: (Deprecated) Anthos cluster control plane uptime
     description: "This dashboard has 4 charts to indicate the uptime of control plane components."
   -
     category: Anthos
     id: Anthos-cluster-node-status
-    display_name: Anthos cluster node status
+    display_name: (Deprecated) Anthos cluster node status
     description: "This dashboard has 6 charts to indicate the status of node, including Node condition, CPU usage per node per mode per CPU, Allocatable CPU cores per node, Memory usage per node, Allocatable memory per node and Available filesystem size per node per device."
   -
     category: Anthos
     id: Anthos-cluster-pod-status
-    display_name: Anthos cluster pod status
+    display_name: (Deprecated) Anthos cluster pod status
     description: "This dashboard has 6 charts to indicate the status of pod, including Number of restarts per container, Container memory usage per container, Container CPU usage per container, Network ingress (bytes) per pod, Network egress (bytes) per pod and Pod phase."
   -
     category: Anthos
     id: Anthos-utilization-metering
-    display_name: Anthos utilization metering
+    display_name: (Deprecated) Anthos utilization metering
     description: "This dashboard has 6 charts to indicate the requests and consumptions of cpu, memory, and ephemeral storage per cluster."
   -
     category: Anthos
     id: GKE-on-prem-node-status
-    display_name: GKE on-prem node status
+    display_name: (Deprecated) GKE on-prem node status
     description: "This dashboard has 6 charts to indicate the status of node, including Node condition, CPU usage per node per mode per CPU, Allocatable CPU cores per node, Memory usage per node, Allocatable memory per node and Available filesystem size per node per device."
   -
     category: Anthos
     id: GKE-on-prem-control-plane-uptime
-    display_name: GKE on-prem control plane uptime
+    display_name: (Deprecated) GKE on-prem control plane uptime
     description: "This dashboard has 8 charts to indicate the uptime of control plane components."
   -
     category: Anthos
     id: GKE-on-prem-pod-status
-    display_name: GKE on-prem pod status
+    display_name: (Deprecated) GKE on-prem pod status
     description: "This dashboard has 6 charts to indicate the status of pod, including Number of restarts per container, Container memory usage per container, Container CPU usage per container, Network ingress (bytes) per pod, Network egress (bytes) per pod and Pod phase."
   -
     category: Anthos
     id: GKE-on-prem-vSphere-vm-health
-    display_name: GKE on-prem vSphere vm health
+    display_name: (Deprecated) GKE on-prem vSphere vm health
     description: "This dashboard has 4 charts to indicate the health of vSphere VMs, including CPU readiness per vCPU, Memory page-fault latency, Average virtual disk read latency, and Average virtual disk write latency."


### PR DESCRIPTION
- The new dashboards have been added here: https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/tree/master/dashboards/google-anthos
- Plan to remove old dashboards from Sample Library completely after few minor Anthos release