### PR TITLE
Fix aggregation of charts in Anthos Utilization Metering dashboard to be SUM

### DIFF
--- a/dashboards/google-anthos/anthos-cluster-utilization-metering.json
+++ b/dashboards/google-anthos/anthos-cluster-utilization-metering.json
@@ -61,7 +61,7 @@
                   "filter": "metric.type=\"kubernetes.io/anthos/container/cpu/core_usage_time\" resource.type=\"k8s_container\"",
                   "secondaryAggregation": {
                     "alignmentPeriod": "60s",
-                    "crossSeriesReducer": "REDUCE_MEAN",
+                    "crossSeriesReducer": "REDUCE_SUM",
                     "groupByFields": [
                       "resource.label.\"project_id\"",
                       "resource.label.\"location\"",
@@ -92,11 +92,10 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "apiSource": "DEFAULT_CLOUD",
                 "timeSeriesFilter": {
                   "aggregation": {
                     "alignmentPeriod": "60s",
-                    "crossSeriesReducer": "REDUCE_MEAN",
+                    "crossSeriesReducer": "REDUCE_SUM",
                     "groupByFields": [
                       "resource.label.\"project_id\"",
                       "resource.label.\"location\"",
@@ -128,11 +127,10 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "apiSource": "DEFAULT_CLOUD",
                 "timeSeriesFilter": {
                   "aggregation": {
                     "alignmentPeriod": "60s",
-                    "crossSeriesReducer": "REDUCE_MEAN",
+                    "crossSeriesReducer": "REDUCE_SUM",
                     "groupByFields": [
                       "resource.label.\"project_id\"",
                       "resource.label.\"location\"",
@@ -160,10 +158,24 @@
           },
           "dataSets": [
             {
+              "minAlignmentPeriod": "60s",
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "fetch k8s_container\n| metric 'kubernetes.io/anthos/container/ephemeral_storage/request_bytes'\n| group_by 1m, [value_request_bytes_mean: mean(value.request_bytes)]\n| every 1m\n| group_by [resource.project_id, resource.location, resource.cluster_name],\n    [value_request_bytes_mean_aggregate: aggregate(value_request_bytes_mean)]"
+                "apiSource": "DEFAULT_CLOUD",
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "alignmentPeriod": "60s",
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "groupByFields": [
+                      "resource.label.\"project_id\"",
+                      "resource.label.\"location\"",
+                      "resource.label.\"cluster_name\""
+                    ],
+                    "perSeriesAligner": "ALIGN_MEAN"
+                  },
+                  "filter": "metric.type=\"kubernetes.io/anthos/container/ephemeral_storage/request_bytes\" resource.type=\"k8s_container\""
+                }
               }
             }
           ],


### PR DESCRIPTION
The aggregation of the cpu usage, and memory charts was incorrectly set as MEAN. This fixes the sample dashboard to correctly use SUM aggregation. Additionally the ephemeral storage request chart is standardized into a basic chart definition instead of MQL.

There is some context for this change in https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/pull/486/files/c262f3ce9d7cc3ee09cf9d34ff50d552ab9ca01d#diff-cdf5dda82812733c7222cd62c1731ae6c461b266d459b176551ae42c61799bb4