### PR TITLE
Fix scylladb integration metadata

### DIFF
--- a/integrations/scylladb/documentation.yaml
+++ b/integrations/scylladb/documentation.yaml
@@ -18,11 +18,11 @@ config_mods: |
   spec:
     selector:
       matchLabels:
-        app.kubernetes.io/name: scylladb
+  +     app.kubernetes.io/name: scylladb
     template:
       metadata:
         labels:
-          app.kubernetes.io/name: scylladb
+  +       app.kubernetes.io/name: scylladb
       spec:
         containers:
         - name: scylladb

--- a/integrations/scylladb/prometheus_metadata.yaml
+++ b/integrations/scylladb/prometheus_metadata.yaml
@@ -5,6 +5,9 @@ platforms:
       name: ScyllaDB Prometheus Exporter
       doc_url: https://monitoring.docs.scylladb.com/stable/reference/monitoring_apis.html
       minimum_supported_version: "5.0"
+    detections:
+      - characteristic_metric:
+          metric_type: prometheus.googleapis.com/scylla_node_operation_mode/gauge
     default_metrics:
       - name: prometheus.googleapis.com/scylla_node_operation_mode/gauge
         prometheus_name: scylla_node_operation_mode
@@ -52,6 +55,18 @@ platforms:
         value_type: DOUBLE
       - name: prometheus.googleapis.com/scylla_cache_partition_misses/counter
         prometheus_name: scylla_cache_partition_misses
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/scylla_scheduler_shares/gauge
+        prometheus_name: scylla_scheduler_shares
+        kind: GAUGE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/scylla_cql_prepared_cache_evictions/counter
+        prometheus_name: scylla_cql_prepared_cache_evictions
+        kind: CUMULATIVE
+        value_type: DOUBLE
+      - name: prometheus.googleapis.com/scylla_cql_authorized_prepared_statements_cache_evictions/counter
+        prometheus_name: scylla_cql_authorized_prepared_statements_cache_evictions
         kind: CUMULATIVE
         value_type: DOUBLE
     install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/scylladb


### PR DESCRIPTION
1. Use `+` for exporter.yaml labels, to indicate that users need to add this, for the later PodMonitoring to pick up these pods
2. Add missing characteristic metric
3. Add metrics we are recommending alerts on into the list of metrics provided by the integration