### PR TITLE
Create FailedScheduling log based recommended alert for ts playbook

### DIFF
--- a/alerts/google-gke/failedscheduling-log-event-within-cluster.v1.json
+++ b/alerts/google-gke/failedscheduling-log-event-within-cluster.v1.json
@@ -1,0 +1,21 @@
+{
+  "displayName": "GKE Pod - FailedScheduling Log Event (${CLUSTER_NAME})",
+  "documentation": {
+    "content":
+        "- A \"FailedScheduling\" event occurs when a pending pod cannot be scheduled, This alert fires when an event with reason \"FailedSceduling\" occurs in the logs; limited to notifying once per hour.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [{
+    "displayName":
+        "${CLUSTER_NAME} cluster has a FailedScheduling Log Event",
+    "conditionMatchedLog": {
+      "filter":
+          "resource.type=\"k8s_pod\" AND resource.labels.cluster_name=\"${CLUSTER_NAME}\" AND jsonPayload.reason=\"FailedScheduling\""
+    }
+  }],
+  "alertStrategy":
+      {"notificationRateLimit": {"period": "3600s"}, "autoClose": "604800s"},
+  "combiner": "OR",
+  "enabled": true
+}

--- a/alerts/google-gke/metadata.yaml
+++ b/alerts/google-gke/metadata.yaml
@@ -14,6 +14,13 @@ alert_policy_templates:
     - id: gke
       platform: GCP
 -
+  id: failedscheduling-log-event-within-cluster
+  description: "Monitors log events with cluster and alerts if there is an event with reason 'FailedScheduling'."
+  version: 1
+  related_integrations:
+    - id: gke
+      platform: GCP
+-
   id: memory-limit-utilization-all-containers
   description: "Monitors memory limit utilization across all containers in the current project and alerts if a container's memory limit utilization is above 90% on average for 1 minute."
   version: 1


### PR DESCRIPTION
For our Troubleshooting Dashboard initiative, I am creating a log based recommended alert for FailedScheduling events. 

The alert filters to logs within a supplied cluster with resource type k8s_pods and reason FailedScheduling.
This is an initial commit and may be subject to change as we refine.
