### PR TITLE
fix related integration ID for argo workflows dashboard

### DIFF
--- a/dashboards/argo-workflows/metadata.yaml
+++ b/dashboards/argo-workflows/metadata.yaml
@@ -5,5 +5,5 @@ sample_dashboards:
     display_name: Argo Workflows Prometheus Overview
     description: "This dashboard has charts displaying: Running Workflows, Pending Workflows, Skipped Workflows, Succeeded Workflows, Failed Workflows, Errors, Operation Duration (seconds), Queue Adds, Queue Depth, and Queue Latency"
     related_integrations:
-      - id: argo_workflows
+      - id: argo
         platform: GKE


### PR DESCRIPTION
Fix Argo Workflows dashboard's integration ID. It was wrong which breaks linking.

See here for correct ID: https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/blob/master/integrations/argo-workflows/metadata.yaml#L1