### PR TITLE
Updated the Apache Flink documentation

### DIFF
--- a/integrations/flink/documentation.yaml
+++ b/integrations/flink/documentation.yaml
@@ -9,7 +9,7 @@ minimum_exporter_version: "1.15"
 exporter_repo_url: https://flink.apache.org/features/2019/03/11/prometheus-monitoring.html
 additional_prereq_info: |
   {{app_name_short}} exposes Prometheus-format metrics when configured with
-  `metrics.reporter.prom.class: org.apache.flink.metrics.prometheus.PrometheusReporter`.
+  `metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory`.
   If you deployed Flink with the official [getting started manifests](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/resource-providers/standalone/kubernetes/){:class="external"},
   add this new option to the ConfigMap:
   <pre>
@@ -22,7 +22,7 @@ additional_prereq_info: |
   data:
     flink-conf.yaml: |+
       ...
-  +   metrics.reporter.prom.class: org.apache.flink.metrics.prometheus.PrometheusReporter
+  +   metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
   </pre>
   If you deployed Flink with the official [operator](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/try-flink-kubernetes-operator/quick-start/){:class="external"},
   add this new option to the FlinkDeployment's `spec.flinkConfiguration` field:
@@ -36,7 +36,7 @@ additional_prereq_info: |
     flinkVersion: v1_15
     flinkConfiguration:
       taskmanager.numberOfTaskSlots: "2"
-  +   metrics.reporter.prom.class: org.apache.flink.metrics.prometheus.PrometheusReporter
+  +   metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
   </pre>
   Alternatively, you can specify the Prometheus reporter as a default option within the [Flink operator
   configuration](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/operations/configuration/){:class="external"}.

--- a/integrations/flink/documentation.yaml
+++ b/integrations/flink/documentation.yaml
@@ -5,7 +5,7 @@ app_site_name: Apache Flink
 app_site_url: https://flink.apache.org/
 exporter_name: the Flink exporter
 exporter_pkg_name: flink
-minimum_exporter_version: "1.15"
+minimum_exporter_version: "1.17"
 exporter_repo_url: https://flink.apache.org/features/2019/03/11/prometheus-monitoring.html
 additional_prereq_info: |
   {{app_name_short}} exposes Prometheus-format metrics when configured with

--- a/integrations/flink/documentation.yaml
+++ b/integrations/flink/documentation.yaml
@@ -32,8 +32,8 @@ additional_prereq_info: |
   metadata:
     name: basic-example
   spec:
-    image: flink:1.15
-    flinkVersion: v1_15
+    image: flink:1.17
+    flinkVersion: v1_17
     flinkConfiguration:
       taskmanager.numberOfTaskSlots: "2"
   +   metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory

--- a/integrations/flink/prometheus_metadata.yaml
+++ b/integrations/flink/prometheus_metadata.yaml
@@ -7,7 +7,7 @@ platforms:
     exporter_metadata:
       name: Apache Flink Prometheus Exporter
       doc_url: https://flink.apache.org/features/2019/03/11/prometheus-monitoring.html
-      minimum_supported_version: "1.15"
+      minimum_supported_version: "1.17"
     default_metrics:
       - name: prometheus.googleapis.com/flink_jobmanager_numRegisteredTaskManagers/gauge
         prometheus_name: flink_jobmanager_numRegisteredTaskManagers


### PR DESCRIPTION
**Changes**
* [updated the flink documentation to use the latest configuration for the Prometheus reporter](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/commit/5726528cadc31a25ebd63d65ddc0d3b977d8cb2c)

**Details**

For Apache Flink, version `1.17.x` the appropriate way to configure prometheus metrics is to set the following in the configuration file:
```
metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
```
Previously, it was this
```
metrics.reporter.prom.class: org.apache.flink.metrics.prometheus.PrometheusReporter
```