### PR TITLE
Updated Apache HTTP documentation

### DIFF
--- a/integrations/apache/documentation.yaml
+++ b/integrations/apache/documentation.yaml
@@ -7,7 +7,7 @@ exporter_name: the Apache HTTP exporter
 exporter_pkg_name: httpd_exporter
 exporter_repo_url: https://github.com/Lusitaniae/apache_exporter
 dashboard_available: true
-minimum_exporter_version: v0.11.0
+minimum_exporter_version: v1.0.0
 multiple_dashboards: false
 dashboard_display_name: Apache Prometheus Overview
 config_mods: |
@@ -49,12 +49,11 @@ config_mods: |
   +         subPath: httpd.conf
   +         name: httpd
   +     - name: httpd-exporter
-  +       image: lusotycoon/apache-exporter:v0.11.0
+  +       image: lusotycoon/apache-exporter:v1.0.0
   +       ports:
   +       - containerPort: 9117
   +         name: prometheus
   +       command: ["/bin/apache_exporter"]
-  +       args: ['--scrape_uri=http://localhost/server-status?auto', '--telemetry.address=:9117', '--telemetry.endpoint=/metrics']
   +     volumes:
   +     - name: httpd
   +       configMap:

--- a/integrations/apache/documentation.yaml
+++ b/integrations/apache/documentation.yaml
@@ -54,6 +54,7 @@ config_mods: |
   +       - containerPort: 9117
   +         name: prometheus
   +       command: ["/bin/apache_exporter"]
+  +       args: ["--scrape_uri=http://localhost/server-status?auto", "--web.listen-address=:9117", "--telemetry.endpoint=/metrics"]
   +     volumes:
   +     - name: httpd
   +       configMap:

--- a/integrations/apache/prometheus_metadata.yaml
+++ b/integrations/apache/prometheus_metadata.yaml
@@ -7,7 +7,7 @@ platforms:
     exporter_metadata:
       name: Apache HTTP Prometheus Exporter
       doc_url: https://github.com/Lusitaniae/apache_exporter
-      minimum_supported_version: v0.11.0
+      minimum_supported_version: v1.0.0
     default_metrics:
       - name: prometheus.googleapis.com/apache_sent_kilobytes_total/counter
         prometheus_name: apache_sent_kilobytes_total

--- a/integrations/apache/prometheus_metadata.yaml
+++ b/integrations/apache/prometheus_metadata.yaml
@@ -1,6 +1,6 @@
 platforms:
   - type: GKE
-    launch_stage: HIDDEN
+    launch_stage: GA
     detections:
       - characteristic_metric:
           metric_type: prometheus.googleapis.com/apache_connections/gauge


### PR DESCRIPTION
**Changes**
* [removed args for the exporter due to them all being default values, updated min version](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/commit/d0f0618581428d80aad07a55fa54edbf0fdae3c3) 
* [updated the args to include web.listen-address which replaced telemetry.address](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/commit/960e5356b6b58b0469073cbe7945981d71943072) 

**Details**
In the latest version of the exporter, the `--telemetry.address` flag is replaced by `--web.listen-address`. Wasn't initially clear to me from the docker container documentation and the github documentation was more helpful. I thought it initially had something to do with the flags having a certain number of dashes and I noticed we we're using default values, so I just removed the args, but that wasn't the issue.

Another note, I didn't see the dashboard appear in the **Integrations** tab, as I believe we would expect. I was able to verify that metrics were flowing using a clone of the dashboard.