### PR TITLE
Updated the PostgreSQL Prometheus documentation and dashboard

### DIFF
--- a/dashboards/postgresql/postgresql-prometheus.json
+++ b/dashboards/postgresql/postgresql-prometheus.json
@@ -17,7 +17,7 @@
       "templateVariable": "Namespace"
     }
   ],
-  "displayName": "PostgreSQL Prometheus Overview",
+  "displayName": "PostgreSQL Prometheus Overview - Q2 2023 Currency Testing Fix",
   "labels": {},
   "mosaicLayout": {
     "columns": 12,
@@ -32,22 +32,32 @@
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_database_tup_returned{${Cluster},${Location},${Namespace}}"
+                  "prometheusQuery": "pg_stat_database_tup_fetched_total{${Cluster},${Location},${Namespace}}",
+                  "unitOverride": ""
                 }
               },
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_database_tup_returned{${Cluster},${Location},${Namespace}}"
+                  "prometheusQuery": "pg_stat_database_tup_returned_total{${Cluster},${Location},${Namespace}}",
+                  "unitOverride": ""
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
@@ -66,22 +76,21 @@
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_database_tup_returned{${Cluster},${Location},${Namespace}}"
-                }
-              },
-              {
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_database_tup_returned{${Cluster},${Location},${Namespace}}"
+                  "prometheusQuery": "pg_stat_database_temp_bytes_total{${Cluster},${Location},${Namespace}}",
+                  "unitOverride": ""
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
@@ -100,29 +109,43 @@
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_database_tup_deleted{${Cluster},${Location},${Namespace}}"
+                  "prometheusQuery": "pg_stat_database_tup_inserted_total{${Cluster},${Location},${Namespace}}",
+                  "unitOverride": ""
                 }
               },
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_database_tup_updated{${Cluster},${Location},${Namespace}}"
+                  "prometheusQuery": "pg_stat_database_tup_updated_total{${Cluster},${Location},${Namespace}}",
+                  "unitOverride": ""
                 }
               },
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_database_tup_deleted{${Cluster},${Location},${Namespace}}"
+                  "prometheusQuery": "pg_stat_database_tup_deleted_total{${Cluster},${Location},${Namespace}}",
+                  "unitOverride": ""
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
@@ -141,22 +164,32 @@
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_bgwriter_checkpoints_req_total{${Cluster},${Location},${Namespace}}"
+                  "prometheusQuery": "pg_stat_bgwriter_checkpoints_req_total{${Cluster},${Location},${Namespace}}",
+                  "unitOverride": ""
                 }
               },
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_bgwriter_checkpoints_timed_total{${Cluster},${Location},${Namespace}}"
+                  "prometheusQuery": "pg_stat_bgwriter_checkpoints_timed_total{${Cluster},${Location},${Namespace}}",
+                  "unitOverride": ""
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
@@ -175,29 +208,43 @@
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_bgwriter_buffers_checkpoint_total{${Cluster},${Location},${Namespace}}"
+                  "prometheusQuery": "pg_stat_bgwriter_buffers_checkpoint_total{${Cluster},${Location},${Namespace}}",
+                  "unitOverride": ""
                 }
               },
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_bgwriter_buffers_clean_total{${Cluster},${Location},${Namespace}}"
+                  "prometheusQuery": "pg_stat_bgwriter_buffers_clean_total{${Cluster},${Location},${Namespace}}",
+                  "unitOverride": ""
                 }
               },
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_bgwriter_buffers_backend_total{${Cluster},${Location},${Namespace}}"
+                  "prometheusQuery": "pg_stat_bgwriter_buffers_backend_total{${Cluster},${Location},${Namespace}}",
+                  "unitOverride": ""
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
@@ -211,10 +258,13 @@
         "widget": {
           "scorecard": {
             "gaugeView": {
+              "lowerBound": 0,
               "upperBound": 1
             },
+            "thresholds": [],
             "timeSeriesQuery": {
-              "prometheusQuery": "sum(pg_stat_database_numbackends{${Cluster},${Location},${Namespace}}) / sum(pg_settings_max_connections{${Cluster},${Location},${Namespace}})"
+              "prometheusQuery": "sum(pg_stat_database_numbackends{${Cluster},${Location},${Namespace}}) / sum(pg_settings_max_connections{${Cluster},${Location},${Namespace}})",
+              "unitOverride": ""
             }
           },
           "title": "Backend Utilization %"
@@ -233,22 +283,32 @@
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_database_blks_hit{${Cluster},${Location},${Namespace}}"
+                  "prometheusQuery": "pg_stat_database_blks_hit_total{${Cluster},${Location},${Namespace}}",
+                  "unitOverride": ""
                 }
               },
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_database_blks_read{${Cluster},${Location},${Namespace}}"
+                  "prometheusQuery": "pg_stat_database_blks_read_total{${Cluster},${Location},${Namespace}}",
+                  "unitOverride": ""
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }

--- a/dashboards/postgresql/postgresql-prometheus.json
+++ b/dashboards/postgresql/postgresql-prometheus.json
@@ -38,7 +38,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_database_tup_fetched_total{${Cluster},${Location},${Namespace}}",
+                  "prometheusQuery": "pg_stat_database_tup_fetched{${Cluster},${Location},${Namespace}}",
                   "unitOverride": ""
                 }
               },
@@ -49,7 +49,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_database_tup_returned_total{${Cluster},${Location},${Namespace}}",
+                  "prometheusQuery": "pg_stat_database_tup_returned{${Cluster},${Location},${Namespace}}",
                   "unitOverride": ""
                 }
               }
@@ -82,7 +82,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_database_temp_bytes_total{${Cluster},${Location},${Namespace}}",
+                  "prometheusQuery": "pg_stat_database_temp_bytes{${Cluster},${Location},${Namespace}}",
                   "unitOverride": ""
                 }
               }
@@ -115,7 +115,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_database_tup_inserted_total{${Cluster},${Location},${Namespace}}",
+                  "prometheusQuery": "pg_stat_database_tup_inserted{${Cluster},${Location},${Namespace}}",
                   "unitOverride": ""
                 }
               },
@@ -126,7 +126,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_database_tup_updated_total{${Cluster},${Location},${Namespace}}",
+                  "prometheusQuery": "pg_stat_database_tup_updated{${Cluster},${Location},${Namespace}}",
                   "unitOverride": ""
                 }
               },
@@ -137,7 +137,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_database_tup_deleted_total{${Cluster},${Location},${Namespace}}",
+                  "prometheusQuery": "pg_stat_database_tup_deleted{${Cluster},${Location},${Namespace}}",
                   "unitOverride": ""
                 }
               }
@@ -170,7 +170,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_bgwriter_checkpoints_req_total{${Cluster},${Location},${Namespace}}",
+                  "prometheusQuery": "pg_stat_bgwriter_checkpoints_req{${Cluster},${Location},${Namespace}}",
                   "unitOverride": ""
                 }
               },
@@ -181,7 +181,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_bgwriter_checkpoints_timed_total{${Cluster},${Location},${Namespace}}",
+                  "prometheusQuery": "pg_stat_bgwriter_checkpoints_timed{${Cluster},${Location},${Namespace}}",
                   "unitOverride": ""
                 }
               }
@@ -214,7 +214,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_bgwriter_buffers_checkpoint_total{${Cluster},${Location},${Namespace}}",
+                  "prometheusQuery": "pg_stat_bgwriter_buffers_checkpoint{${Cluster},${Location},${Namespace}}",
                   "unitOverride": ""
                 }
               },
@@ -225,7 +225,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_bgwriter_buffers_clean_total{${Cluster},${Location},${Namespace}}",
+                  "prometheusQuery": "pg_stat_bgwriter_buffers_clean{${Cluster},${Location},${Namespace}}",
                   "unitOverride": ""
                 }
               },
@@ -236,7 +236,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_bgwriter_buffers_backend_total{${Cluster},${Location},${Namespace}}",
+                  "prometheusQuery": "pg_stat_bgwriter_buffers_backend{${Cluster},${Location},${Namespace}}",
                   "unitOverride": ""
                 }
               }
@@ -289,7 +289,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_database_blks_hit_total{${Cluster},${Location},${Namespace}}",
+                  "prometheusQuery": "pg_stat_database_blks_hit{${Cluster},${Location},${Namespace}}",
                   "unitOverride": ""
                 }
               },
@@ -300,7 +300,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "pg_stat_database_blks_read_total{${Cluster},${Location},${Namespace}}",
+                  "prometheusQuery": "pg_stat_database_blks_read{${Cluster},${Location},${Namespace}}",
                   "unitOverride": ""
                 }
               }

--- a/dashboards/postgresql/postgresql-prometheus.json
+++ b/dashboards/postgresql/postgresql-prometheus.json
@@ -17,7 +17,7 @@
       "templateVariable": "Namespace"
     }
   ],
-  "displayName": "PostgreSQL Prometheus Overview - Q2 2023 Currency Testing Fix",
+  "displayName": "PostgreSQL Prometheus Overview",
   "labels": {},
   "mosaicLayout": {
     "columns": 12,

--- a/integrations/postgresql/documentation.yaml
+++ b/integrations/postgresql/documentation.yaml
@@ -7,7 +7,7 @@ exporter_name: the PostgreSQL exporter
 exporter_pkg_name: postgres_exporter
 exporter_repo_url: https://github.com/prometheus-community/postgres_exporter
 dashboard_available: true
-minimum_exporter_version: v0.14.0
+minimum_exporter_version: v0.11.0
 multiple_dashboards: false
 dashboard_display_name: {{app_name_short}} Prometheus Overview
 config_mods: |

--- a/integrations/postgresql/documentation.yaml
+++ b/integrations/postgresql/documentation.yaml
@@ -7,7 +7,7 @@ exporter_name: the PostgreSQL exporter
 exporter_pkg_name: postgres_exporter
 exporter_repo_url: https://github.com/prometheus-community/postgres_exporter
 dashboard_available: true
-minimum_exporter_version: v0.11.1
+minimum_exporter_version: v0.13.1
 multiple_dashboards: false
 dashboard_display_name: {{app_name_short}} Prometheus Overview
 config_mods: |
@@ -26,7 +26,7 @@ config_mods: |
   +       app.kubernetes.io/name: postgresql
       spec:
         containers:
-        - image: postgres:14.0
+        - image: postgres:15.3
           name: postgresql
           env:
           - name: POSTGRES_USER
@@ -36,7 +36,9 @@ config_mods: |
           - name: POSTGRES_DB
             value: dev
   +     - name: exporter
-  +       image: quay.io/prometheuscommunity/postgres-exporter:v0.11.1
+  +       image: quay.io/prometheuscommunity/postgres-exporter:v0.13.1
+  +       args:
+  +       - --collector.stat_statements
   +       env:
   +       - name: DATA_SOURCE_NAME
   +         value: postgresql://root:password@localhost:5432/dev?sslmode=disable

--- a/integrations/postgresql/documentation.yaml
+++ b/integrations/postgresql/documentation.yaml
@@ -7,7 +7,7 @@ exporter_name: the PostgreSQL exporter
 exporter_pkg_name: postgres_exporter
 exporter_repo_url: https://github.com/prometheus-community/postgres_exporter
 dashboard_available: true
-minimum_exporter_version: v0.13.1
+minimum_exporter_version: v0.14.0
 multiple_dashboards: false
 dashboard_display_name: {{app_name_short}} Prometheus Overview
 config_mods: |
@@ -36,7 +36,7 @@ config_mods: |
           - name: POSTGRES_DB
             value: dev
   +     - name: exporter
-  +       image: quay.io/prometheuscommunity/postgres-exporter:v0.13.1
+  +       image: quay.io/prometheuscommunity/postgres-exporter:v0.14.0
   +       args:
   +       - --collector.stat_statements
   +       env:

--- a/integrations/postgresql/prometheus_metadata.yaml
+++ b/integrations/postgresql/prometheus_metadata.yaml
@@ -7,7 +7,7 @@ platforms:
     exporter_metadata:
       name: GKE Prometheus Exporter
       doc_url: https://github.com/prometheus-community/postgres_exporter
-      minimum_supported_version: v0.14.0
+      minimum_supported_version: v0.11.0
     default_metrics:
       - name: prometheus.googleapis.com/pg_stat_database_numbackends/gauge
         prometheus_name: pg_stat_database_numbackends

--- a/integrations/postgresql/prometheus_metadata.yaml
+++ b/integrations/postgresql/prometheus_metadata.yaml
@@ -7,7 +7,7 @@ platforms:
     exporter_metadata:
       name: GKE Prometheus Exporter
       doc_url: https://github.com/prometheus-community/postgres_exporter
-      minimum_supported_version: v0.13.1
+      minimum_supported_version: v0.14.0
     default_metrics:
       - name: prometheus.googleapis.com/pg_stat_database_numbackends/gauge
         prometheus_name: pg_stat_database_numbackends

--- a/integrations/postgresql/prometheus_metadata.yaml
+++ b/integrations/postgresql/prometheus_metadata.yaml
@@ -7,7 +7,7 @@ platforms:
     exporter_metadata:
       name: GKE Prometheus Exporter
       doc_url: https://github.com/prometheus-community/postgres_exporter
-      minimum_supported_version: v0.11.1
+      minimum_supported_version: v0.13.1
     default_metrics:
       - name: prometheus.googleapis.com/pg_stat_database_numbackends/gauge
         prometheus_name: pg_stat_database_numbackends


### PR DESCRIPTION
**Changes**
* [updated postgresql dashboard json to account for changes in the exporter](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/commit/6bb1be830942eefe8c6f73eb33d34fb9ca5f01ce)
* [updated docs and metadata to account for changes in the exporter](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/commit/5908985ff3bed385932235a8785b02525cecc485)

**Details**
> As a result of downloading the json, editing that, and re-uploading, a few extra keys are now present, unsure if removing them is a good idea (ie. breakdowns, dimensions, measures/etc)

During testing, we learned that 
* the postgres dashboard json had errors, on top of the changes that were needed as a result of changes in the exporter. It was all just incorrect metrics in various charts, or duplicates, should be good to go now
* Certain metrics coming from the exporter are now [enabled/disabled with a flag](https://github.com/prometheus-community/postgres_exporter#flags) and so the flag was added as an argument in the documentation.
* Various metrics had a `_total` suffix added to them and updates were made to the dashboard json to account for this.