### PR TITLE
Updated HAProxy Prometheus documentation

### DIFF
--- a/integrations/haproxy/documentation.yaml
+++ b/integrations/haproxy/documentation.yaml
@@ -7,7 +7,7 @@ exporter_name: the HAProxy exporter
 exporter_pkg_name: haproxy_exporter
 exporter_repo_url: https://github.com/prometheus/haproxy_exporter
 dashboard_available: true
-minimum_exporter_version: v0.13.0
+minimum_exporter_version: v0.15.0
 multiple_dashboards: false
 dashboard_display_name: {{app_name_short}} Prometheus Overview
 config_mods: |
@@ -38,7 +38,7 @@ config_mods: |
       spec:
         containers:
   +     - name: exporter
-  +       image: quay.io/prometheus/haproxy-exporter:v0.13.0
+  +       image: quay.io/prometheus/haproxy-exporter:v0.15.0
   +       args:
   +       - --haproxy.scrape-uri=http://localhost:8404/stats?stats;csv
   +       ports:

--- a/integrations/haproxy/prometheus_metadata.yaml
+++ b/integrations/haproxy/prometheus_metadata.yaml
@@ -7,7 +7,7 @@ platforms:
     exporter_metadata:
       name: HAProxy Prometheus Exporter
       doc_url: https://github.com/prometheus/haproxy_exporter
-      minimum_supported_version: v0.13.0
+      minimum_supported_version: v0.15.0
     default_metrics:
       - name: prometheus.googleapis.com/haproxy_frontend_http_responses_total/counter
         prometheus_name: haproxy_frontend_http_responses_total


### PR DESCRIPTION
**Changes**
* [updated min version for haproxy](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/commit/7fb5cd28ece1adf659dc944c6340832475a75e0d)

**Details**
Update the minimum version for the HAProxy exporter in the documentation and metadata. 