### PR TITLE
Updated Velero Prometheus documentation

### DIFF
--- a/integrations/velero/documentation.yaml
+++ b/integrations/velero/documentation.yaml
@@ -6,7 +6,7 @@ app_site_url: https://velero.io/
 exporter_name: the Velero Prometheus exporter
 exporter_pkg_name: velero
 exporter_repo_url: https://velero.io/docs/
-minimum_exporter_version: v1.10.1
+minimum_exporter_version: v1.7.1
 additional_prereq_info: |
   {{app_name_short}} exposes Prometheus-format metrics automatically; you do not
   have to install it separately. To verify that {{exporter_name}} is emitting

--- a/integrations/velero/documentation.yaml
+++ b/integrations/velero/documentation.yaml
@@ -6,7 +6,7 @@ app_site_url: https://velero.io/
 exporter_name: the Velero Prometheus exporter
 exporter_pkg_name: velero
 exporter_repo_url: https://velero.io/docs/
-minimum_exporter_version: v1.3.0
+minimum_exporter_version: v1.11.0
 additional_prereq_info: |
   {{app_name_short}} exposes Prometheus-format metrics automatically; you do not
   have to install it separately. To verify that {{exporter_name}} is emitting

--- a/integrations/velero/documentation.yaml
+++ b/integrations/velero/documentation.yaml
@@ -6,7 +6,7 @@ app_site_url: https://velero.io/
 exporter_name: the Velero Prometheus exporter
 exporter_pkg_name: velero
 exporter_repo_url: https://velero.io/docs/
-minimum_exporter_version: v1.11.0
+minimum_exporter_version: v1.10.1
 additional_prereq_info: |
   {{app_name_short}} exposes Prometheus-format metrics automatically; you do not
   have to install it separately. To verify that {{exporter_name}} is emitting

--- a/integrations/velero/prometheus_metadata.yaml
+++ b/integrations/velero/prometheus_metadata.yaml
@@ -7,7 +7,7 @@ platforms:
     exporter_metadata:
       name: Velero Prometheus Exporter
       doc_url: https://velero.io/docs/
-      minimum_supported_version: v1.10.1
+      minimum_supported_version: v1.7.1
     default_metrics:
       - name: prometheus.googleapis.com/velero_backup_success_total/counter
         prometheus_name: velero_backup_success_total

--- a/integrations/velero/prometheus_metadata.yaml
+++ b/integrations/velero/prometheus_metadata.yaml
@@ -7,7 +7,7 @@ platforms:
     exporter_metadata:
       name: Velero Prometheus Exporter
       doc_url: https://velero.io/docs/
-      minimum_supported_version: v1.11.0
+      minimum_supported_version: v1.10.1
     default_metrics:
       - name: prometheus.googleapis.com/velero_backup_success_total/counter
         prometheus_name: velero_backup_success_total

--- a/integrations/velero/prometheus_metadata.yaml
+++ b/integrations/velero/prometheus_metadata.yaml
@@ -7,7 +7,7 @@ platforms:
     exporter_metadata:
       name: Velero Prometheus Exporter
       doc_url: https://velero.io/docs/
-      minimum_supported_version: v1.3.0
+      minimum_supported_version: v1.11.0
     default_metrics:
       - name: prometheus.googleapis.com/velero_backup_success_total/counter
         prometheus_name: velero_backup_success_total


### PR DESCRIPTION
**Changes**
* [updated min exporter version to be the latest version of Velero supported by the GCP plugin for Velero](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/commit/69e04124ea5a7015ab012d0ee4ccd8d74a220aa1) 

**Details**
I'm not certain why the minimum version was `1.3.0` and because the metrics are exposed by default, my thought was to change the minimum version to the version of Velero that [this plugin](https://github.com/vmware-tanzu/velero-plugin-for-gcp) deploys. I used the latest version of the plugin, which claims support for Velero `1.11.0`, which may be true, but I just checked and what's deployed is `1.10.1`
```yaml
Init Containers:
  velero-velero-plugin-for-gcp:
    Container ID:   containerd://6910f038efb86f20bdcb45bef497a3d79e8ff7a3c4fcd220dec689f13f6e64b4
    Image:          velero/velero-plugin-for-gcp:v1.7.0
    Image ID:       docker.io/velero/velero-plugin-for-gcp@sha256:1ed38c11563fa40d428b92a104913dccd704e616c95c66360a2136fd769ce600
    Port:           <none>
    Host Port:      <none>
    State:          Terminated
      Reason:       Completed
      Exit Code:    0
      Started:      Thu, 13 Jul 2023 10:22:08 -0400
      Finished:     Thu, 13 Jul 2023 10:22:08 -0400
    Ready:          True
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /target from plugins (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-mvm4j (ro)
Containers:
  velero:
    Container ID:  containerd://dc2db8ef729c2bf7b4dce847c3a3f91ef838268ceee1b994b946c00a1b6d630f
    Image:         velero/velero:v1.10.1
    Image ID:      docker.io/velero/velero@sha256:b45e13f7e18e630a3061073242a8dcb1e4b70965a287633bc21f691c1e249c5a
    Port:          8085/TCP
    Host Port:     0/TCP
    Command:
```