### PR TITLE
Updated HAProxy Prometheus documentation

### DIFF
--- a/integrations/haproxy/documentation.yaml
+++ b/integrations/haproxy/documentation.yaml
@@ -12,9 +12,11 @@ multiple_dashboards: false
 dashboard_display_name: {{app_name_short}} Prometheus Overview
 additional_prereq_info: |
   {{app_name_short}} exposes Prometheus-format metrics only when it is 
-  [built with the service enabled](https://github.com/haproxy/haproxy/blob/master/addons/promex/README) and an appropriate `frontend` is included in the configuration.
+  [built with the service enabled](https://github.com/haproxy/haproxy/blob/master/addons/promex/README){:class="external"} and an appropriate `frontend` is included in the configuration.
+
   Most of the official docker images for versions greater than or equal to 2.4 are built with this service enabled.
-  The following example was built referencing [HAProxy Enterprise documentation](https://www.haproxy.com/documentation/hapee/latest/observability/metrics/prometheus/).
+
+  The following example was built referencing [HAProxy Enterprise documentation](https://www.haproxy.com/documentation/hapee/latest/observability/metrics/prometheus/){:class="external"}.
   It works with the community edition and can be modified to suit specific needs:
   <pre>
   apiVersion: v1
@@ -60,6 +62,7 @@ additional_prereq_info: |
             items:
             - key: haproxy.cfg
               path: haproxy.cfg
+
   </pre>
   To verify that {{exporter_name}} is emitting metrics on the expected endpoints, do the following:
   1. Set up port forwarding by using the following command:
@@ -87,6 +90,7 @@ podmonitoring_config: |
         app.kubernetes.io/name: haproxy
 additional_podmonitoring_info: |
   Ensure that the values of the `port` and `matchLabels` fields match those of the {{app_name_short}} pods you want to monitor.
+  
   {{app_name_short}} exposes metrics from targets defined in the `bind` configuration option. This option requires a user to define the IP address and port to be listened on for scraping metrics.
 sample_promql_query: up{job="haproxy", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}
 alerts_config: |

--- a/integrations/haproxy/documentation.yaml
+++ b/integrations/haproxy/documentation.yaml
@@ -29,7 +29,45 @@ additional_prereq_info: |
   +     bind *:8404
   +     http-request use-service prometheus-exporter if { path /metrics }
       ...
+  ---
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: haproxy
+  spec:
+    selector:
+      matchLabels:
+  +     app.kubernetes.io/name: haproxy
+    template:
+      metadata:
+        labels:
+  +       app.kubernetes.io/name: haproxy
+      spec:
+        containers:
+        - name: haproxy
+          image: haproxy:2.8
+          ports:
+          - containerPort: 8404
+            name: prometheus
+          volumeMounts:
+          - mountPath: /usr/local/etc/haproxy/haproxy.cfg
+            subPath: haproxy.cfg
+            name: haproxy
+        volumes:
+        - name: haproxy
+          configMap:
+            name: haproxy
+            items:
+            - key: haproxy.cfg
+              path: haproxy.cfg
   </pre>
+  To verify that {{exporter_name}} is emitting metrics on the expected endpoints, do the following:
+  1. Set up port forwarding by using the following command:
+    <pre class="devsite-click-to-copy">
+    kubectl -n {{namespace_name}} port-forward {{pod_name}} 8404
+    </pre>
+  2. Access the endpoint `localhost:8404/metrics` by using the browser
+     or the `curl` utility in another terminal session.
 podmonitoring_config: |
   apiVersion: monitoring.googleapis.com/v1
   kind: PodMonitoring
@@ -40,7 +78,7 @@ podmonitoring_config: |
       app.kubernetes.io/part-of: google-cloud-managed-prometheus
   spec:
     endpoints:
-    - port: 8404
+    - port: prometheus
       scheme: http
       interval: 30s
       path: /metrics

--- a/integrations/haproxy/documentation.yaml
+++ b/integrations/haproxy/documentation.yaml
@@ -3,7 +3,7 @@ app_name_short: HAProxy
 app_name: {{app_name_short}}
 app_site_name: HAProxy
 app_site_url: https://www.haproxy.com/
-exporter_name: the HAProxy promex exporter
+exporter_name: the PROMEX service for HAProxy
 exporter_pkg_name: haproxy_promex
 exporter_repo_url: https://github.com/haproxy/haproxy/blob/master/addons/promex/README
 dashboard_available: true
@@ -14,7 +14,7 @@ additional_prereq_info: |
   {{app_name_short}} exposes Prometheus-format metrics only when it is 
   [built with the service enabled](https://github.com/haproxy/haproxy/blob/master/addons/promex/README){:class="external"} and an appropriate `frontend` is included in the configuration.
 
-  Most of the official docker images for versions greater than or equal to 2.4 are built with this service enabled.
+  Most of the official Docker images for versions greater than or equal to 2.4 are built with this service enabled.
 
   The following example was built referencing [HAProxy Enterprise documentation](https://www.haproxy.com/documentation/hapee/latest/observability/metrics/prometheus/){:class="external"}.
   It works with the community edition and can be modified to suit specific needs:

--- a/integrations/haproxy/documentation.yaml
+++ b/integrations/haproxy/documentation.yaml
@@ -1,61 +1,35 @@
-exporter_type: sidecar
+exporter_type: included
 app_name_short: HAProxy
 app_name: {{app_name_short}}
 app_site_name: HAProxy
 app_site_url: https://www.haproxy.com/
-exporter_name: the HAProxy exporter
-exporter_pkg_name: haproxy_exporter
-exporter_repo_url: https://github.com/prometheus/haproxy_exporter
+exporter_name: the HAProxy promex exporter
+exporter_pkg_name: haproxy_promex
+exporter_repo_url: https://github.com/haproxy/haproxy/blob/master/addons/promex/README
 dashboard_available: true
 minimum_exporter_version: "2.4"
 multiple_dashboards: false
 dashboard_display_name: {{app_name_short}} Prometheus Overview
-config_mods: |
+additional_prereq_info: |
+  {{app_name_short}} exposes Prometheus-format metrics only when it is 
+  [built with the service enabled](https://github.com/haproxy/haproxy/blob/master/addons/promex/README) and an appropriate `frontend` is included in the configuration.
+  Most of the official docker images for versions greater than or equal to 2.4 are built with this service enabled.
+  The following example was built referencing [HAProxy Enterprise documentation](https://www.haproxy.com/documentation/hapee/latest/observability/metrics/prometheus/).
+  It works with the community edition and can be modified to suit specific needs:
+  <pre>
   apiVersion: v1
   kind: ConfigMap
   metadata:
     name: haproxy
   data:
     haproxy.cfg: |
+      ...
   +   frontend prometheus
   +     mode http
   +     bind *:8404
   +     http-request use-service prometheus-exporter if { path /metrics }
-  ---
-  apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    name: haproxy
-  spec:
-    selector:
-      matchLabels:
-  +     app.kubernetes.io/name: haproxy
-    template:
-      metadata:
-        labels:
-  +       app.kubernetes.io/name: haproxy
-      spec:
-        containers:
-        - name: haproxy
-          image: haproxy:2.4
-          ports:
-  +       - containerPort: 8404
-  +         name: prometheus
-          volumeMounts:
-          - mountPath: /usr/local/etc/haproxy/haproxy.cfg
-            subPath: haproxy.cfg
-            name: haproxy
-        volumes:
-        - name: haproxy
-          configMap:
-            name: haproxy
-            items:
-            - key: haproxy.cfg
-              path: haproxy.cfg
-additional_install_info: |
-  The recommended changes in <code>haproxy.cfg</code> defines a frontend with the "stats enable" directive 
-  and enables the {{app_name_short}} stats page. This frontend can be scraped by {{exporter_pkg_name}}.
-  For more information, see [Exploring the HAProxy Stats page](https://www.haproxy.com/blog/exploring-the-haproxy-stats-page/){:class=external}.
+      ...
+  </pre>
 podmonitoring_config: |
   apiVersion: monitoring.googleapis.com/v1
   kind: PodMonitoring
@@ -66,13 +40,16 @@ podmonitoring_config: |
       app.kubernetes.io/part-of: google-cloud-managed-prometheus
   spec:
     endpoints:
-    - port: prometheus
+    - port: 8404
       scheme: http
       interval: 30s
       path: /metrics
     selector:
       matchLabels:
         app.kubernetes.io/name: haproxy
+additional_podmonitoring_info: |
+  Ensure that the values of the `port` and `matchLabels` fields match those of the {{app_name_short}} pods you want to monitor.
+  {{app_name_short}} exposes metrics from targets defined in the `bind` configuration option. This option requires a user to define the IP address and port to be listened on for scraping metrics.
 sample_promql_query: up{job="haproxy", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}
 alerts_config: |
   apiVersion: monitoring.googleapis.com/v1

--- a/integrations/haproxy/documentation.yaml
+++ b/integrations/haproxy/documentation.yaml
@@ -7,7 +7,7 @@ exporter_name: the HAProxy exporter
 exporter_pkg_name: haproxy_exporter
 exporter_repo_url: https://github.com/prometheus/haproxy_exporter
 dashboard_available: true
-minimum_exporter_version: v0.13.0
+minimum_exporter_version: "2.4"
 multiple_dashboards: false
 dashboard_display_name: {{app_name_short}} Prometheus Overview
 config_mods: |
@@ -17,11 +17,10 @@ config_mods: |
     name: haproxy
   data:
     haproxy.cfg: |
-  +   frontend stats
+  +   frontend prometheus
   +     mode http
   +     bind *:8404
-  +     stats enable
-  +     stats uri /stats
+  +     http-request use-service prometheus-exporter if { path /metrics }
   ---
   apiVersion: apps/v1
   kind: Deployment
@@ -37,18 +36,11 @@ config_mods: |
   +       app.kubernetes.io/name: haproxy
       spec:
         containers:
-  +     - name: exporter
-  +       image: quay.io/prometheus/haproxy-exporter:v0.13.0
-  +       args:
-  +       - --haproxy.scrape-uri=http://localhost:8404/stats?stats;csv
-  +       ports:
-  +       - containerPort: 9101
-  +         name: prometheus
         - name: haproxy
-          image: haproxy:2.3
+          image: haproxy:2.4
           ports:
   +       - containerPort: 8404
-  +         name: stats
+  +         name: prometheus
           volumeMounts:
           - mountPath: /usr/local/etc/haproxy/haproxy.cfg
             subPath: haproxy.cfg

--- a/integrations/haproxy/prometheus_metadata.yaml
+++ b/integrations/haproxy/prometheus_metadata.yaml
@@ -7,7 +7,7 @@ platforms:
     exporter_metadata:
       name: HAProxy Prometheus Exporter
       doc_url: https://github.com/prometheus/haproxy_exporter
-      minimum_supported_version: v0.13.0
+      minimum_supported_version: "2.4"
     default_metrics:
       - name: prometheus.googleapis.com/haproxy_frontend_http_responses_total/counter
         prometheus_name: haproxy_frontend_http_responses_total


### PR DESCRIPTION
**Changes**
* [Updated haproxy config, port name, and image version. Updated minimum version to match haproxy version](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/commit/e86b4755558615af95111c82a18d9a2e0759fef3) 
* [Changed haproxy exporter type to be 'included' and updated the documentation to fit that template](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/pull/587/commits/bbbc4fc0336da5ddb5f8236c3bf50ce63a3f6157)
* [added back deployment yaml, named port, and metric verification instructions](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/pull/587/commits/cf69b5b50fc6517063eb6e1afd18375771f79984) 

**Details**
The exporter initially used has been retired and an official exporter is available as of version `2.4`. The changes here remove the unofficial exporter from the documentation and shift the focus towards the official exporter. 

There are [instructions](https://github.com/prometheus/haproxy_exporter#official-prometheus-exporter) on building HAProxy with the Prometheus exporter module enabled and the docker images seem to have this enabled by default, I checked the latest available version of [2.4](https://hub.docker.com/layers/library/haproxy/2.4.23/images/sha256-9899b3684922d1caa59d6a2fe51798215a9d499135d817df2f05952b2f18f59e?context=explore) and [2.8](https://hub.docker.com/layers/library/haproxy/2.8.1/images/sha256-cce5fb4fbdf6aee43630c87d2c64568869673815dd52920b48295f0748c34c0f?context=explore), both have it enabled. The metrics appear to be the same, or changes that are present don't affect the dashboard.

The documentation has been modified to fit the format for `exporter_type: included`. 