### PR TITLE
Update vm-lifecycle-dashboard.json with getting started instructions

### DIFF
--- a/dashboards/google-compute-engine/vm-lifecycle-dashboard.json
+++ b/dashboards/google-compute-engine/vm-lifecycle-dashboard.json
@@ -105,7 +105,27 @@
           },
           "width": 9,
           "yPos": 3
-        }
-      ]
+      },
+      {
+        "height": 2,
+        "widget": {
+          "text": {
+            "content": "To use this dashboard a user-defined log-based metric using this project's Cloud Audit Logs is required. For more more information on how to use this dashboard  see [Monitor VM lifecycle events](https://cloud.devsite.corp.google.com/compute/docs/troubleshooting/troubleshooting-reboots#monitor-events).",
+            "format": "MARKDOWN",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FS_LARGE",
+              "horizontalAlignment": "H_LEFT",
+              "padding": "P_EXTRA_SMALL",
+              "textColor": "#000000",
+              "verticalAlignment": "V_TOP"
+            }
+          },
+          "title": "Getting started:"
+        },
+        "width": 3,
+        "yPos": 7
+      }
+    ]
     }
     }


### PR DESCRIPTION
Add static text widget to dashboard explaining that a user is required to create log-based metric using their Cloud Audit Logs before the dashboard can be used.