### PR TITLE
Updated MongoDB Prometheus documentation

### DIFF
--- a/integrations/mongodb/documentation.yaml
+++ b/integrations/mongodb/documentation.yaml
@@ -29,9 +29,10 @@ standalone_config: |
       spec:
         containers:
         - name: exporter
-          image: percona/mongodb_exporter:0.20
+          image: percona/mongodb_exporter:0.39
           args:
           - --mongodb.uri=mongodb://user:password@mongodb-service-name:27017
+          - --collect-all
           ports:
           - name: prometheus
             containerPort: 9216
@@ -43,8 +44,8 @@ additional_install_info: |
   to suit your {{app_name_short}} configuration.
   Update the `--mongodb.uri` flag to match your environment's username, password,
   and clusterIP service name.
-
-  The exporter does not support scraping metrics from MongoDB 6.0.4.
+  The flag `--collect-all` is specified in the example and there are [other flags 
+  available](https://github.com/percona/mongodb_exporter/blob/main/REFERENCE.md#flags) to tune metric collection.
 
 podmonitoring_config: |
   apiVersion: monitoring.googleapis.com/v1


### PR DESCRIPTION
**Changes**
* [removed note about mongodb 6.0.4, updated deployment example and additional install info](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/commit/061636ef3fe80fa922e023a0a540d6f8e9561c99) 

**Details**
Further testing revealed that MongoDB 6.0.4/6.0.5 are supported by the latest version of the exporter `0.39` and an additional flag was needed based on the exporter changes that allow specific collectors to run by passing in various [flags](https://github.com/percona/mongodb_exporter/blob/main/REFERENCE.md#flags).

[**Related PR**](https://github.com/GoogleCloudPlatform/prometheus-engine/pull/523)
This link is for a PR to update the exporter example in the `prometheus-engine` repository
