### PR TITLE
Fixed typo for Kafka Prometheus dashboard

### DIFF
--- a/dashboards/kafka/kafka-prometheus.json
+++ b/dashboards/kafka/kafka-prometheus.json
@@ -106,7 +106,7 @@
       {
         "height": 4,
         "widget": {
-          "title": "Under Replicated Partition{${Cluster},${Location},${Namespace}}",
+          "title": "Under Replicated Partition",
           "xyChart": {
             "chartOptions": {
               "mode": "COLOR"


### PR DESCRIPTION
**Changes**
* [Fixed typo in the Under Replicated Partition chart title](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/commit/2e28fd7a7eaebf2fc9b30790abe881151b48c439)

**Details**

Looks like part of the prometheus query ended up in the title. It has been removed. 