### PR TITLE
Updated MySQL Prometheus documentation

### DIFF
--- a/integrations/mysql/documentation.yaml
+++ b/integrations/mysql/documentation.yaml
@@ -20,7 +20,7 @@ config_mods: |
   +     [client]
   +     user=root
   +     password=password
-  -------
+  ---
   apiVersion: apps/v1
   kind: StatefulSet
   metadata:
@@ -48,6 +48,7 @@ config_mods: |
   +         subPath: my.cnf
   +         name: mysql-exporter-config
         - name: mysql
+          image: mysql:5.7
           env:
           - name: MYSQL_ROOT_PASSWORD
             value: password
@@ -61,9 +62,11 @@ config_mods: |
           - containerPort: 3306
   +     volumes:
   +     - name: mysql-exporter-config
-  +       items:
-  +       - key: my.cnf
-  +         path: my.cnf
+  +       configMap:
+  +         name: mysql-exporter-config
+  +         items:
+  +         - key: my.cnf
+  +           path: my.cnf
 podmonitoring_config: |
   apiVersion: monitoring.googleapis.com/v1
   kind: PodMonitoring

--- a/integrations/mysql/documentation.yaml
+++ b/integrations/mysql/documentation.yaml
@@ -7,7 +7,7 @@ exporter_name: the MySQL exporter
 exporter_pkg_name: mysqld_exporter
 exporter_repo_url: https://github.com/prometheus/mysqld_exporter
 dashboard_available: true
-minimum_exporter_version: v0.14.0
+minimum_exporter_version: v0.15.0
 multiple_dashboards: false
 dashboard_display_name: {{app_name_short}} Prometheus Overview
 config_mods: |
@@ -27,10 +27,12 @@ config_mods: |
       spec:
         containers:
   +     - name: exporter
-  +       image: prom/mysqld-exporter:v0.14.0
+  +       image: prom/mysqld-exporter:v0.15.0
+  +       args:
+  +         - --mysqld.username=root
   +       env:
-  +         - name: DATA_SOURCE_NAME
-  +           value: root:password@(localhost:3306)/
+  +         - name: MYSQLD_EXPORTER_PASSWORD
+  +           value: password
   +       ports:
   +       - containerPort: 9104
   +         name: prometheus
@@ -68,7 +70,7 @@ podmonitoring_config: |
 additional_prereq_info: |
   For information about creating a least-privileged user, see [Required Grants](https://github.com/prometheus/mysqld_exporter#required-grants){:class=external}.
 additional_install_info:
-  Update the `DATA_SOURCE_NAME` environment variable with credentials that work with your {{app_name}} instance.
+  Update the `--mysqld.username` argument and the `MYSQLD_EXPORTER_PASSWORD` environment variable with credentials that work with your {{app_name}} instance 
 sample_promql_query: up{job="mysql", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}
 alerts_config: |
   apiVersion: monitoring.googleapis.com/v1

--- a/integrations/mysql/documentation.yaml
+++ b/integrations/mysql/documentation.yaml
@@ -11,45 +11,42 @@ minimum_exporter_version: v0.15.0
 multiple_dashboards: false
 dashboard_display_name: {{app_name_short}} Prometheus Overview
 config_mods: |
-  apiVersion: apps/v1
-  kind: StatefulSet
+  apiVersion: v1
+  kind: ConfigMap
   metadata:
-    name: mysql
-  spec:
-    serviceName: mysql
-    selector:
-      matchLabels:
-  +     app.kubernetes.io/name: mysql
-    template:
-      metadata:
-        labels:
-  +       app.kubernetes.io/name: mysql
-      spec:
-        containers:
-  +     - name: exporter
-  +       image: prom/mysqld-exporter:v0.15.0
-  +       args:
-  +         - --mysqld.username=root
-  +       env:
-  +         - name: MYSQLD_EXPORTER_PASSWORD
-  +           value: password
-  +       ports:
-  +       - containerPort: 9104
-  +         name: prometheus
-        - image: mysql:5.7
-          name: mysql
-          env:
-          - name: MYSQL_ROOT_PASSWORD
-            value: password
-          - name: MYSQL_USER
-            value: sbtest
-          - name: MYSQL_PASSWORD
-            value: password
-          - name: MYSQL_DATABASE
-            value: sbtest
-          ports:
-          - containerPort: 3306
-            name: mysql
+    name: mysql-exporter-config
+  data:
+    my.cnf: |
+      [client]
+      user=root
+      password=password
+  -------
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      name: mysql
+    spec:
+      serviceName: mysql
+      selector:
+        matchLabels:
+    +     app.kubernetes.io/name: mysql
+      template:
+        metadata:
+          labels:
+    +       app.kubernetes.io/name: mysql
+        spec:
+          containers:
+    +     - name: exporter
+    +       image: prom/mysqld-exporter:v0.15.0
+    +       args:
+    +         - --config.my-cnf=/home/my.cnf
+    +       ports:
+    +       - containerPort: 9104
+    +         name: prometheus
+    +       volumeMounts:
+    +       - mountPath: /home/my.cnf
+    +         subPath: my.cnf
+    +         name: mysql-exporter-config
 podmonitoring_config: |
   apiVersion: monitoring.googleapis.com/v1
   kind: PodMonitoring
@@ -70,7 +67,7 @@ podmonitoring_config: |
 additional_prereq_info: |
   For information about creating a least-privileged user, see [Required Grants](https://github.com/prometheus/mysqld_exporter#required-grants){:class=external}.
 additional_install_info:
-  Update the `--mysqld.username` argument and the `MYSQLD_EXPORTER_PASSWORD` environment variable with credentials that work with your {{app_name}} instance 
+  Update the `--config.my-cnf` argument with a path to a configuration file with credentials that work with your {{app_name}} instance 
 sample_promql_query: up{job="mysql", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}
 alerts_config: |
   apiVersion: monitoring.googleapis.com/v1

--- a/integrations/mysql/documentation.yaml
+++ b/integrations/mysql/documentation.yaml
@@ -7,7 +7,7 @@ exporter_name: the MySQL exporter
 exporter_pkg_name: mysqld_exporter
 exporter_repo_url: https://github.com/prometheus/mysqld_exporter
 dashboard_available: true
-minimum_exporter_version: v0.15.0
+minimum_exporter_version: v0.14.0
 multiple_dashboards: false
 dashboard_display_name: {{app_name_short}} Prometheus Overview
 config_mods: |
@@ -47,6 +47,23 @@ config_mods: |
     +       - mountPath: /home/my.cnf
     +         subPath: my.cnf
     +         name: mysql-exporter-config
+          - name: mysql
+            env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: password
+            - name: MYSQL_USER
+              value: sbtest
+            - name: MYSQL_PASSWORD
+              value: password
+            - name: MYSQL_DATABASE
+              value: sbtest
+            ports:
+            - containerPort: 3306
+    +     volumes:
+    +     - name: mysql-exporter-config
+    +       items:
+    +       - key: my.cnf
+    +         path: my.cnf
 podmonitoring_config: |
   apiVersion: monitoring.googleapis.com/v1
   kind: PodMonitoring

--- a/integrations/mysql/documentation.yaml
+++ b/integrations/mysql/documentation.yaml
@@ -11,59 +11,59 @@ minimum_exporter_version: v0.14.0
 multiple_dashboards: false
 dashboard_display_name: {{app_name_short}} Prometheus Overview
 config_mods: |
-  apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    name: mysql-exporter-config
-  data:
-    my.cnf: |
-      [client]
-      user=root
-      password=password
+  + apiVersion: v1
+  + kind: ConfigMap
+  + metadata:
+  +  name: mysql-exporter-config
+  + data:
+  +   my.cnf: |
+  +     [client]
+  +     user=root
+  +     password=password
   -------
-    apiVersion: apps/v1
-    kind: StatefulSet
-    metadata:
-      name: mysql
-    spec:
-      serviceName: mysql
-      selector:
-        matchLabels:
-    +     app.kubernetes.io/name: mysql
-      template:
-        metadata:
-          labels:
-    +       app.kubernetes.io/name: mysql
-        spec:
-          containers:
-    +     - name: exporter
-    +       image: prom/mysqld-exporter:v0.15.0
-    +       args:
-    +         - --config.my-cnf=/home/my.cnf
-    +       ports:
-    +       - containerPort: 9104
-    +         name: prometheus
-    +       volumeMounts:
-    +       - mountPath: /home/my.cnf
-    +         subPath: my.cnf
-    +         name: mysql-exporter-config
-          - name: mysql
-            env:
-            - name: MYSQL_ROOT_PASSWORD
-              value: password
-            - name: MYSQL_USER
-              value: sbtest
-            - name: MYSQL_PASSWORD
-              value: password
-            - name: MYSQL_DATABASE
-              value: sbtest
-            ports:
-            - containerPort: 3306
-    +     volumes:
-    +     - name: mysql-exporter-config
-    +       items:
-    +       - key: my.cnf
-    +         path: my.cnf
+  apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    name: mysql
+  spec:
+    serviceName: mysql
+    selector:
+      matchLabels:
+  +     app.kubernetes.io/name: mysql
+    template:
+      metadata:
+        labels:
+  +       app.kubernetes.io/name: mysql
+      spec:
+        containers:
+  +     - name: exporter
+  +       image: prom/mysqld-exporter:v0.15.0
+  +       args:
+  +         - --config.my-cnf=/home/my.cnf
+  +       ports:
+  +       - containerPort: 9104
+  +         name: prometheus
+  +       volumeMounts:
+  +       - mountPath: /home/my.cnf
+  +         subPath: my.cnf
+  +         name: mysql-exporter-config
+        - name: mysql
+          env:
+          - name: MYSQL_ROOT_PASSWORD
+            value: password
+          - name: MYSQL_USER
+            value: sbtest
+          - name: MYSQL_PASSWORD
+            value: password
+          - name: MYSQL_DATABASE
+            value: sbtest
+          ports:
+          - containerPort: 3306
+  +     volumes:
+  +     - name: mysql-exporter-config
+  +       items:
+  +       - key: my.cnf
+  +         path: my.cnf
 podmonitoring_config: |
   apiVersion: monitoring.googleapis.com/v1
   kind: PodMonitoring

--- a/integrations/mysql/prometheus_metadata.yaml
+++ b/integrations/mysql/prometheus_metadata.yaml
@@ -7,7 +7,7 @@ platforms:
     exporter_metadata:
       name: MySQL Prometheus Exporter
       doc_url: https://github.com/prometheus/mysqld_exporter
-      minimum_supported_version: v0.14.0
+      minimum_supported_version: v0.15.0
     default_metrics:
       - name: prometheus.googleapis.com/mysql_global_status_uptime/unknown:counter
         prometheus_name: mysql_global_status_uptime

--- a/integrations/mysql/prometheus_metadata.yaml
+++ b/integrations/mysql/prometheus_metadata.yaml
@@ -7,7 +7,7 @@ platforms:
     exporter_metadata:
       name: MySQL Prometheus Exporter
       doc_url: https://github.com/prometheus/mysqld_exporter
-      minimum_supported_version: v0.15.0
+      minimum_supported_version: v0.14.0
     default_metrics:
       - name: prometheus.googleapis.com/mysql_global_status_uptime/unknown:counter
         prometheus_name: mysql_global_status_uptime


### PR DESCRIPTION
## **Changes**
* [updated the minimum exporter version, example configuration, and additional install info](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/commit/81a4c3d5d2bff3f78ef547fa3ae91868c9f5b733) 
* [updated the minimum supported version in metadata](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/commit/361e1136fdd66b71cde0a5ae1bc0cb9772f2a0f7)

## **Details**
The latest version of the MySQL Prometheus exporter works with MySQL 5.7 and MySQL 8.0.34. This new version of the exporter removes the `DATA_SOURCE_NAME` environment variable and instead we can pass in the `--mysqld.username` argument and the `MYSQLD_EXPORTER_PASSWORD` environment variable for authentication, or we can mount a configuration file with the credentials in it and pass the `--config.my-cnf=<PATH_TO_MOUNTED_CONFIG_FILE>`. 

Example configuration file:
```
[client]
user=root
password=password
```

I'm not sure which option to go with for the example configuration and wanted to get an opinion, we could change it to look something like
```
config_mods: |
apiVersion: v1
kind: ConfigMap
metadata:
  name: mysql-exporter-config
data:
  .my-cnf: |
    [client]
    user=root
    password=password
-------
  apiVersion: apps/v1
  kind: StatefulSet
  metadata:
    name: mysql
  spec:
    serviceName: mysql
    selector:
      matchLabels:
  +     app.kubernetes.io/name: mysql
    template:
      metadata:
        labels:
  +       app.kubernetes.io/name: mysql
      spec:
        containers:
  +     - name: exporter
  +       image: prom/mysqld-exporter:v0.15.0
  +       args:
  +         - --config.my-cnf=<PATH_TO_MOUNTED_CONFIGURATION>
  +       ports:
  +       - containerPort: 9104
  +         name: prometheus
  +       volumeMounts:
  +       - mountPath: /home/.my.cnf
  +         subPath: .my.cnf
  +         name: mysql-exporter-config
        - image: mysql:5.7
          name: mysql
          env:
          - name: MYSQL_ROOT_PASSWORD
            value: password
          - name: MYSQL_USER
            value: sbtest
          - name: MYSQL_PASSWORD
            value: password
          - name: MYSQL_DATABASE
            value: sbtest
          ports:
          - containerPort: 3306
            name: mysql
```