### PR TITLE
Update dashboards for gpu integrations

### DIFF
--- a/dashboards/nvidia-gpu/metadata.yaml
+++ b/dashboards/nvidia-gpu/metadata.yaml
@@ -5,11 +5,6 @@ sample_dashboards:
     display_name: NVIDIA GPU Monitoring Overview (GCE & GKE)
     description: |-
       Displays GPU metrics for both GKE Nodes and GCE VMs.  GPU metrics for the GCE VMs require the Ops Agent to be installed.
-    related_integrations:
-      - id: nvml
-        platform: GCE
-      - id: dcgm
-        platform: GCE
   -
     category: NVIDIA GPUs
     id: nvidia-dcgm

--- a/dashboards/nvidia-gpu/nvidia-dcgm.json
+++ b/dashboards/nvidia-gpu/nvidia-dcgm.json
@@ -18,7 +18,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch gce_instance\n| metric 'workload.googleapis.com/dcgm.gpu.pipe_utilization'\n"
+                  "timeSeriesQueryLanguage": "fetch gce_instance\n| metric 'workload.googleapis.com/dcgm.gpu.profiling.pipe_utilization'\n"
                 }
               }
             ],
@@ -46,7 +46,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch gce_instance\n| metric 'workload.googleapis.com/dcgm.gpu.pcie_traffic_rate'\n| cast_units(\"By/s\")"
+                  "timeSeriesQueryLanguage": "fetch gce_instance\n| metric 'workload.googleapis.com/dcgm.gpu.profiling.pcie_traffic_rate'\n| cast_units(\"By/s\")"
                 }
               }
             ],
@@ -74,7 +74,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch gce_instance\n| metric 'workload.googleapis.com/dcgm.gpu.sm_utilization'\n"
+                  "timeSeriesQueryLanguage": "fetch gce_instance\n| metric 'workload.googleapis.com/dcgm.gpu.profiling.sm_utilization'\n"
                 }
               }
             ],
@@ -122,7 +122,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch gce_instance\n| metric 'workload.googleapis.com/dcgm.gpu.sm_occupancy'\n"
+                  "timeSeriesQueryLanguage": "fetch gce_instance\n| metric 'workload.googleapis.com/dcgm.gpu.profiling.sm_occupancy'\n"
                 }
               }
             ],
@@ -150,7 +150,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch gce_instance\n| metric 'workload.googleapis.com/dcgm.gpu.nvlink_traffic_rate'\n| cast_units(\"By/s\")"
+                  "timeSeriesQueryLanguage": "fetch gce_instance\n| metric 'workload.googleapis.com/dcgm.gpu.profiling.nvlink_traffic_rate'\n| cast_units(\"By/s\")"
                 }
               }
             ],


### PR DESCRIPTION
There are two changes here in preparing for GPU metrics in Ops Agent: 
1. Remove the link between the `NVIDIA GPU Monitoring Overview (GCE & GKE)` dashboard to any integration. This dashboard uses metrics from both GCE VM and GKE, so we won't automatically install it to projects, and keep it as a sample dashboard; 
2. Update the `NVIDIA GPU Monitoring Advanced DCGM Metrics (GCE Only)` since the metrics descriptors have a name changing. Tested and verified that the DCGM dashboard works with Ops Agent w/ updated metrics names. 