### PR TITLE
Mark ScyllaDB v2 integration hidden

### DIFF
--- a/integrations/scylladb/prometheus_metadata.yaml
+++ b/integrations/scylladb/prometheus_metadata.yaml
@@ -77,7 +77,7 @@ platforms:
     install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/scylladb
   - type: GKE
     version: '2'
-    launch_stage: GA
+    launch_stage: HIDDEN
     exporter_metadata:
       name: ScyllaDB Prometheus Exporter
       doc_url: https://monitoring.docs.scylladb.com/stable/reference/monitoring_apis.html


### PR DESCRIPTION
Temporarily hide scylladb v2 so we can QA it in the console before GA.