### PR TITLE
Use query builder for the DCGM dashboard

### DIFF
--- a/dashboards/nvidia-gpu/nvidia-dcgm.json
+++ b/dashboards/nvidia-gpu/nvidia-dcgm.json
@@ -15,10 +15,17 @@
             },
             "dataSets": [
               {
+                "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch gce_instance\n| metric 'workload.googleapis.com/dcgm.gpu.profiling.pipe_utilization'\n"
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/dcgm.gpu.profiling.pipe_utilization\" resource.type=\"gce_instance\""
+                  }
                 }
               }
             ],
@@ -43,10 +50,18 @@
             },
             "dataSets": [
               {
+                "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch gce_instance\n| metric 'workload.googleapis.com/dcgm.gpu.profiling.pcie_traffic_rate'\n| cast_units(\"By/s\")"
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/dcgm.gpu.profiling.pcie_traffic_rate\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": "By/s"
                 }
               }
             ],
@@ -71,10 +86,17 @@
             },
             "dataSets": [
               {
+                "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch gce_instance\n| metric 'workload.googleapis.com/dcgm.gpu.profiling.sm_utilization'\n"
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/dcgm.gpu.profiling.sm_utilization\" resource.type=\"gce_instance\""
+                  }
                 }
               }
             ],
@@ -119,10 +141,17 @@
             },
             "dataSets": [
               {
+                "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch gce_instance\n| metric 'workload.googleapis.com/dcgm.gpu.profiling.sm_occupancy'\n"
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/dcgm.gpu.profiling.sm_occupancy\" resource.type=\"gce_instance\""
+                  }
                 }
               }
             ],
@@ -147,10 +176,18 @@
             },
             "dataSets": [
               {
+                "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch gce_instance\n| metric 'workload.googleapis.com/dcgm.gpu.profiling.nvlink_traffic_rate'\n| cast_units(\"By/s\")"
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/dcgm.gpu.profiling.nvlink_traffic_rate\" resource.type=\"gce_instance\""
+                  }, 
+                  "unitOverride": "By/s"
                 }
               }
             ],


### PR DESCRIPTION
Currently, the DCGM dashboard uses MQL to build the charts, and the dashboard can't get the system metadata labels: http://screencast/cast/NjA0NTYwMzIxNjc1MjY0MHxhMWJkMjY0Ni04NA

This PR switches the dashboard to use query builder, and enable filtering by system metadata labels: http://screencast/cast/NjA3OTgwMjY5OTE1MzQwOHw4MWJjYWYyMC1lZg

side-by-side new vs old: https://screenshot.googleplex.com/3T9ZqAGyNznhWg3

b/296229834