### PR TITLE
Fix Cloud Redis integration alert IDs

### DIFF
--- a/alerts/google-cloud-redis/metadata.yaml
+++ b/alerts/google-cloud-redis/metadata.yaml
@@ -23,7 +23,7 @@ alert_policy_templates:
     - id: cloud_redis
       platform: GCP
 -
-  id: integrations-system-memory-usage-ratio-high-integrations
+  id: integrations-system-memory-usage-ratio-high
   display_name: Cloud Redis - System Memory Usage Ratio High
   description: "This alert fires if the system memory utilization is above the set threshold. The utilization is measured on a scale of 0 to 1."
   version: 1
@@ -31,7 +31,7 @@ alert_policy_templates:
     - id: cloud_redis
       platform: GCP
 -
-  id: integrations-standard-instance-failover-integrations
+  id: integrations-standard-instance-failover
   display_name: Cloud Redis - Standard Instance Failover
   description: "This alert fires if failover occurs for a standard tier instance. To ensure that alerts always fire, we recommend keeping the threshold value to 0."
   version: 1


### PR DESCRIPTION
Removes extra `-integration` suffix to make policy ids match the corresponding file names.