### PR TITLE
Fix no data issue with the nvidia dashboard

### DIFF
--- a/dashboards/nvidia-gpu/nvidia-overview.json
+++ b/dashboards/nvidia-gpu/nvidia-overview.json
@@ -427,7 +427,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "{\n    {\n\n    fetch gce_instance\n    | metric 'agent.googleapis.com/gpu/memory/bytes_used'\n    | filter (metric.memory_state == 'used')\n    | group_by []\n    | add [Memory: 'Used']\n\n    ;\n\n    fetch k8s_node\n    | metric 'kubernetes.io/node/accelerator/memory_used'\n    | group_by []\n    | add [Memory: 'Used']\n\n    }\n    | outer_join 0\n    | add\n;\n\n    {\n\n    fetch gce_instance\n    | metric 'agent.googleapis.com/gpu/memory/bytes_used'\n    | group_by []\n    | add [Memory: 'Total']\n\n    ;\n\n    fetch k8s_node\n    | metric 'kubernetes.io/node/accelerator/memory_total'\n    | group_by []\n    | add [Memory: 'Total']\n\n    }\n    | outer_join 0\n    | add\n} | union"
+                  "timeSeriesQueryLanguage": "{\n    {\n\n    fetch gce_instance\n    | metric 'agent.googleapis.com/gpu/memory/bytes_used'\n    | filter (metric.memory_state == 'used')\n    | group_by []\n    | add [Memory: 'Used']\n\n    ;\n\n    fetch k8s_node\n    | metric 'kubernetes.io/node/accelerator/memory_used'\n    | group_by []\n    | add [Memory: 'Used']\n\n    }\n    | outer_join 0, 0\n    | add\n;\n\n    {\n\n    fetch gce_instance\n    | metric 'agent.googleapis.com/gpu/memory/bytes_used'\n    | group_by []\n    | add [Memory: 'Total']\n\n    ;\n\n    fetch k8s_node\n    | metric 'kubernetes.io/node/accelerator/memory_total'\n    | group_by []\n    | add [Memory: 'Total']\n\n    }\n    | outer_join 0, 0\n    | add\n} | union"
                 }
               }
             ],
@@ -512,7 +512,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "{\n    {\n        \n    fetch gce_instance\n    | metric 'agent.googleapis.com/gpu/memory/bytes_used'\n    | filter metric.memory_state == 'used'\n    | group_by [metric.model]\n    | value [val: val()]\n\n    ;\n\n\n    fetch k8s_node\n    | metric 'kubernetes.io/node/accelerator/memory_used'\n    | group_by [metric.model]\n    | value [val: val()]\n\n    } | union\n\n;\n    {\n        \n    fetch k8s_node\n    | metric 'kubernetes.io/node/accelerator/memory_used'\n    | group_by [metric.model]\n    | value [val: val()]\n\n    ;\n\n    fetch k8s_node\n    | metric 'kubernetes.io/node/accelerator/memory_total'\n    | group_by [metric.model]\n    | value [val: val()]\n\n    } | union\n} \n| ratio | mul(100) |cast_units(\"%\")"
+                  "timeSeriesQueryLanguage": "{\n    {\n        \n    fetch gce_instance\n    | metric 'agent.googleapis.com/gpu/memory/bytes_used'\n    | filter metric.memory_state == 'used'\n    | group_by [metric.model]\n    | value [val: val()]\n\n    ;\n\n\n    fetch k8s_node\n    | metric 'kubernetes.io/node/accelerator/memory_used'\n    | group_by [metric.model]\n    | value [val: val()]\n\n    } | union\n\n;\n    {\n        \n    fetch gce_instance\n    | metric 'agent.googleapis.com/gpu/memory/bytes_used'\n    | group_by [metric.model]\n    | value [val: val()]\n\n    ;\n\n    fetch k8s_node\n    | metric 'kubernetes.io/node/accelerator/memory_total'\n    | group_by [metric.model]\n    | value [val: val()]\n\n    } | union\n} \n| ratio | mul(100) |cast_units(\"%\")"
                 }
               }
             ],


### PR DESCRIPTION
b/296253311

For `GPU Memory - Used and Total`: the chart shows `no data` when the project does not have GKE GPU metrics. To fix the issue, update the query to provide default values 0: `outer_join 0, 0` so that when either left (GCE GPU metrics) or right (GKE) is missing, using 0s to do the join; 

For `Memory Usage % by Model`: fix the typo in the query: for this query, we want to union GCE and GKE used memory first, and union **GCE** and GKE total memory, and finally divide to get the percentage. 

