### PR TITLE
Adds GKE Workload CPU request utilization recommended alert

### DIFF
--- a/alerts/google-gke/cpu-request-utilization-entire-workload.v1.json
+++ b/alerts/google-gke/cpu-request-utilization-entire-workload.v1.json
@@ -1,0 +1,32 @@
+{
+  "displayName": "GKE Workload - High CPU Request Utilization (${WORKLOAD_NAME})",
+  "documentation": {
+    "content": "[View Workload Details](https://console.cloud.google.com/kubernetes/deployment/${CLUSTER_LOCATION}/${CLUSTER_NAME}/${NAMESPACE}/${WORKLOAD_NAME}/observability?project=${PROJECT_ID}).\n- Workloads with high CPU limit utilization likely have containers that are CPU throttled. To avoid application slowdown and unresponsiveness, keep CPU usage below the CPU request limit [View Documentation](https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-resource-requests-and-limits)\n- If alerts tend to be false positive or noisy, consider visiting the alert policy page and changing the threshold, the rolling (alignment) window, and the retest (duration) window. [Alerting policies documentation](https://cloud.google.com/monitoring/alerts/concepts-indepth), [MQL documentation](https://cloud.google.com/monitoring/mql/alerts)",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {
+    "workload_name": "${WORKLOAD_NAME}",
+    "workload_type": "${WORKLOAD_TYPE}",
+    "project_id": "${PROJECT_ID}",
+    "location": "${CLUSTER_LOCATION}",
+    "cluster": "${CLUSTER_NAME}",
+    "namespace": "${NAMESPACE}"
+  },
+  "conditions": [
+    {
+      "displayName": "CPU Request Utilization is high for: ${WORKLOAD_NAME}",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "0s",
+        "trigger": {
+          "count": 1
+        },
+        "query": "fetch k8s_container\n| \n{\n    metric 'kubernetes.io/container/cpu/core_usage_time'\n    | filter\n        resource.project_id == 'lesser-weevil'\n        &&\n        (metadata.system_labels.top_level_controller_name == 'currencyservice'\n        && metadata.system_labels.top_level_controller_type == 'Deployment')\n        &&\n        (resource.cluster_name == 'big-boi-ben'\n        && resource.location == 'europe-west4'\n        && resource.namespace_name == 'default')\n    | align rate(5m)\n    | every 1m\n    | group_by [],\n        [value_core_usage_time_aggregate: aggregate(value.core_usage_time)]\n;\n    metric 'kubernetes.io/container/cpu/request_cores'\n    | filter\n        resource.project_id == 'lesser-weevil'\n        &&\n        (metadata.system_labels.top_level_controller_name == 'currencyservice'\n        && metadata.system_labels.top_level_controller_type == 'Deployment')\n        &&\n        (resource.cluster_name == 'big-boi-ben'\n        && resource.location == 'europe-west4'\n        && resource.namespace_name == 'default')\n    | group_by 5m, [value_request_cores_mean: mean(value.request_cores)]\n    | every 1m\n    | group_by [],\n        [value_request_cores_mean_aggregate: aggregate(value_request_cores_mean)]\n}\n| join\n| div\n| scale('%')\n| condition val() > 90'%'"
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true
+}

--- a/alerts/google-gke/metadata.yaml
+++ b/alerts/google-gke/metadata.yaml
@@ -48,3 +48,10 @@ alert_policy_templates:
   related_integrations:
     - id: gke
       platform: GCP
+-
+  id: cpu-request-utilization-entire-workload
+  description: "Alerts if the workload's CPU request usage exceeds 90% for 5 minutes."
+  version: 1
+  related_integrations:
+    - id: gke
+      platform: GCP


### PR DESCRIPTION
Due to the usage of template variables in user labels, the gcloud cli does not work because of the usage of "$".

I've removed the user label template variables and gcloud cli works:
![image](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/assets/4435399/85bc149a-9407-42d1-b0a0-9efcbd09a860)
