### PR TITLE
Multi Private Cloud support for GCVE

### DIFF
--- a/dashboards/vmware/overview.json
+++ b/dashboards/vmware/overview.json
@@ -1,4 +1,11 @@
 {
+  "dashboardFilters": [
+    {
+      "filterType": "RESOURCE_LABEL",
+      "labelKey": "namespace",
+      "templateVariable": ""
+    }
+  ],
   "displayName": "GCVE Overview",
   "mosaicLayout": {
     "columns": 12,
@@ -349,7 +356,7 @@
             "timeSeriesQuery": {
               "timeSeriesFilter": {
                 "aggregation": {
-                  "crossSeriesReducer": "REDUCE_MEAN",
+                  "crossSeriesReducer": "REDUCE_SUM",
                   "perSeriesAligner": "ALIGN_MEAN"
                 },
                 "filter": "metric.type=\"external.googleapis.com/vmware/vcenter.vsphere.clusters.total\" resource.type=\"generic_node\""
@@ -368,7 +375,7 @@
             "timeSeriesQuery": {
               "timeSeriesFilter": {
                 "aggregation": {
-                  "crossSeriesReducer": "REDUCE_MEAN",
+                  "crossSeriesReducer": "REDUCE_SUM",
                   "perSeriesAligner": "ALIGN_MEAN"
                 },
                 "filter": "metric.type=\"external.googleapis.com/vmware/vcenter.vsphere.datastores.total\" resource.type=\"generic_node\""
@@ -388,10 +395,10 @@
             "timeSeriesQuery": {
               "timeSeriesFilter": {
                 "aggregation": {
-                  "crossSeriesReducer": "REDUCE_MAX",
+                  "crossSeriesReducer": "REDUCE_SUM",
                   "perSeriesAligner": "ALIGN_MAX"
                 },
-                "filter": "metric.type=\"external.googleapis.com/vmware/vcenter.vsphere.hosts\" resource.type=\"generic_node\""
+                "filter": "metric.type=\"external.googleapis.com/vmware/vcenter.cluster.hosts\" resource.type=\"generic_node\""
               }
             }
           },
@@ -408,7 +415,7 @@
             "timeSeriesQuery": {
               "timeSeriesFilter": {
                 "aggregation": {
-                  "crossSeriesReducer": "REDUCE_MAX",
+                  "crossSeriesReducer": "REDUCE_SUM",
                   "perSeriesAligner": "ALIGN_MAX"
                 },
                 "filter": "metric.type=\"external.googleapis.com/vmware/vcenter.vsphere.virtual_machines.total\" resource.type=\"generic_node\""


### PR DESCRIPTION
The Overview dashboard provides incorrect data in case of multiple Private Clouds (vCenters) collected.

This commit provides the following changes
- On Clusters, Datastores, VMs and hosts replace REDUCE_MEAN with REDUCE_SUM
- Add a filter based on the namespace (vCenter collected)
- Use "cluster hosts" to count the Hosts instead of "vSphere Hosts". This solves