### PR TITLE
Adjust istio p95 latency alert

### DIFF
--- a/alerts/google-gke/istio-latency-entire-workload.v1.json
+++ b/alerts/google-gke/istio-latency-entire-workload.v1.json
@@ -20,11 +20,11 @@
         "aggregations": [
           {
             "alignmentPeriod": "300s",
-            "crossSeriesReducer": "REDUCE_MEAN",
+            "crossSeriesReducer": "REDUCE_PERCENTILE_95",
             "groupByFields": [
               "metric.label.request_operation"
             ],
-            "perSeriesAligner": "ALIGN_PERCENTILE_95"
+            "perSeriesAligner": "ALIGN_DELTA"
           }
         ],
         "comparison": "COMPARISON_GT",


### PR DESCRIPTION
Adjust this alert to get p95 latency of all traffic by operation.

Previously it got p95 for each label combination (e.g. each container/status code/traffic source) then took the mean of those. Image showing that the math works out differently:
![image](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/assets/509446/e7301f1d-8658-43af-a4d4-0c97d99fef50)
