### PR TITLE
Fix Elasticsearch dashboard filter for Red Status

### DIFF
--- a/dashboards/elasticsearch/elasticsearch-cluster-gce-overview.json
+++ b/dashboards/elasticsearch/elasticsearch-cluster-gce-overview.json
@@ -106,7 +106,7 @@
                   "crossSeriesReducer": "REDUCE_SUM",
                   "perSeriesAligner": "ALIGN_MEAN"
                 },
-                "filter": "metric.type=\"workload.googleapis.com/elasticsearch.cluster.health\" resource.type=\"gce_instance\" metric.label.\"status\"=\"yellow\""
+                "filter": "metric.type=\"workload.googleapis.com/elasticsearch.cluster.health\" resource.type=\"gce_instance\" metric.label.\"status\"=\"red\""
               }
             }
           },


### PR DESCRIPTION
This was filtering to `yellow` rather than `red`