### PR TITLE
Dashboard Importer - Fix Troubleshooting Tile height calculation

### DIFF
--- a/scripts/dashboard-importer/dist/dashboards/converter/converter.js
+++ b/scripts/dashboard-importer/dist/dashboards/converter/converter.js
@@ -135,7 +135,7 @@ class GrafanaDashboardConverter {
         const date = new Date();
         const dateTimeText = `Converted from ${this.fileName} on ${(0, report_1.getDateString)(date)} at ${(0, report_1.createReportId)(date)}`;
         const text = [dateTimeText, troubleshootingDocsText, warningSummary].join('\n\n');
-        const height = 4 + Math.floor(warningSummary.split("\n").length) / 2;
+        const height = 4 + Math.floor(warningSummary.split("\n").length / 2);
         this.tiles.push({
             widget: (0, text_1.createTextWidget)('Conversion info', text),
             xPos: 0,

--- a/scripts/dashboard-importer/src/dashboards/converter/converter.ts
+++ b/scripts/dashboard-importer/src/dashboards/converter/converter.ts
@@ -216,7 +216,7 @@ export default class GrafanaDashboardConverter {
     const dateTimeText = `Converted from ${this.fileName} on ${getDateString(date)} at ${createReportId(date)}`;
 
     const text = [dateTimeText, troubleshootingDocsText, warningSummary].join('\n\n');
-    const height = 4 + Math.floor(warningSummary.split("\n").length) / 2;
+    const height = 4 + Math.floor(warningSummary.split("\n").length / 2);
 
     this.tiles.push({
       widget: createTextWidget('Conversion info', text),


### PR DESCRIPTION
This Pull Request addresses the issue reported in #677: "Dashboard Importer - Validation error when uploading converted dashboard with float height."

**Changes Made**
- Adjusted the order of Math.floor operation to prevent Troubleshooting Tile height from being a float value.

**Description**
Pull Request #664 changed the calculation of the Troubleshooting Tile height in the Dashboard Importer, causing unexpected behavior with float values. The original intention of flooring the result was correct, and this PR restores the Math.floor operation to its original position
This change ensures compatibility with the expected type (<class 'int'>) for the height field, resolving the reported validation error during the dashboard upload process.

**Related Issue**
Fixes #677