### PR TITLE
Add test.sh for db importer which combines end to end flow tests with conversion tests

### DIFF
--- a/scripts/dashboard-importer/test.sh
+++ b/scripts/dashboard-importer/test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Running Dashboard Importer Test Suite..."
+read -p "Please type in the GCP project you wish to test against: " PROJECT
+
+echo "Running Converter Tests..."
+npm run test
+
+echo "Running End to End Flow Tests..."
+./import.sh ./examples $PROJECT


### PR DESCRIPTION
Previously an end to end test was not explicitly part of the dashboard importer test suite. This change creates a test.sh file that allows developers to run ./test.sh to test both the converter functionality as well as the end to end flow. 