### PR TITLE
DB Importer: Fallback for current template variable values that are string arrays

### DIFF
--- a/scripts/dashboard-importer/dist/dashboards/converter/converter_test.js
+++ b/scripts/dashboard-importer/dist/dashboards/converter/converter_test.js
@@ -53,6 +53,12 @@ function testDashboardConversion() {
             stringValue: '',
             templateVariable: 'testTv',
         },
+        {
+            filterType: 'METRIC_LABEL',
+            labelKey: 'node',
+            stringValue: '',
+            templateVariable: 'testNodeTv',
+        }
     ]);
     // Validate Tiles
     (0, assert_1.default)((0, overlap_test_utils_1.hasNoOverlap)(tiles));

--- a/scripts/dashboard-importer/dist/dashboards/converter/template_variables/interval.js
+++ b/scripts/dashboard-importer/dist/dashboards/converter/template_variables/interval.js
@@ -17,7 +17,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const result_1 = require("../../../common/result");
 function getIntervalMapping(tv) {
-    var _a, _b, _c;
+    var _a, _b, _c, _d;
     if (tv.type !== 'interval') {
         return (0, result_1.warning)([
             `getIntervalMapping received type ${tv.type} instead of interval`,
@@ -25,9 +25,10 @@ function getIntervalMapping(tv) {
     }
     const name = tv.name;
     const options = tv.options || [];
-    const selectedValue = ((_a = options.filter((option) => option.selected)[0]) === null || _a === void 0 ? void 0 : _a.value) ||
-        ((_b = tv.current) === null || _b === void 0 ? void 0 : _b.value) ||
-        ((_c = options[0]) === null || _c === void 0 ? void 0 : _c.value);
+    const tvCurrentValue = typeof ((_a = tv.current) === null || _a === void 0 ? void 0 : _a.value) === 'string' ? (_b = tv.current) === null || _b === void 0 ? void 0 : _b.value : '';
+    const selectedValue = ((_c = options.filter((option) => option.selected)[0]) === null || _c === void 0 ? void 0 : _c.value) ||
+        tvCurrentValue ||
+        ((_d = options[0]) === null || _d === void 0 ? void 0 : _d.value);
     if (selectedValue === undefined) {
         return (0, result_1.warning)([`No suitable mapping found for template variable ${name}`]);
     }

--- a/scripts/dashboard-importer/dist/dashboards/converter/template_variables/label_values.js
+++ b/scripts/dashboard-importer/dist/dashboards/converter/template_variables/label_values.js
@@ -62,7 +62,7 @@ exports.getLabelKey = getLabelKey;
  * figuring out if it's a resource or metric label
  */
 function getDashboardFilterFromLabelKey(queryString, templateVariable) {
-    var _a;
+    var _a, _b;
     const labelKeyResult = getLabelKey(queryString);
     let labelKey = labelKeyResult.result;
     if (labelKey === 'kubernetes_io_hostname') {
@@ -71,10 +71,13 @@ function getDashboardFilterFromLabelKey(queryString, templateVariable) {
     if (labelKey === null) {
         return (0, result_1.warning)(labelKeyResult.warnings);
     }
+    const stringValue = typeof ((_a = templateVariable.current) === null || _a === void 0 ? void 0 : _a.value) === 'string' ?
+        (_b = templateVariable.current) === null || _b === void 0 ? void 0 : _b.value :
+        '';
     const dashboardFilter = {
         labelKey,
         templateVariable: templateVariable.name,
-        stringValue: ((_a = templateVariable.current) === null || _a === void 0 ? void 0 : _a.value) || '',
+        stringValue,
         filterType: constants_1.RESOURCE_LABELS.includes(labelKey)
             ? 'RESOURCE_LABEL'
             : 'METRIC_LABEL',

--- a/scripts/dashboard-importer/dist/dashboards/converter/testing/test_dashboard.js
+++ b/scripts/dashboard-importer/dist/dashboards/converter/testing/test_dashboard.js
@@ -603,6 +603,34 @@ exports.TEST_GENERIC_DASHBOARD = {
                 sort: 0,
                 type: 'query',
             },
+            {
+                current: {
+                    isNone: true,
+                    selected: false,
+                    text: ['all'],
+                    value: ['$__all'],
+                },
+                datasource: {
+                    type: 'prometheus',
+                    uid: 'P1809F7CD0C75ACF3',
+                },
+                definition: 'label_values(kubernetes_io_hostname)',
+                hide: 0,
+                includeAll: false,
+                label: 'testNodeLabel',
+                multi: false,
+                name: 'testNodeTv',
+                options: [],
+                query: {
+                    query: 'label_values(kubernetes_io_hostname)',
+                    refId: 'StandardVariableQuery',
+                },
+                refresh: 1,
+                regex: '',
+                skipUrlSync: false,
+                sort: 0,
+                type: 'query',
+            }
         ],
     },
     time: {

--- a/scripts/dashboard-importer/src/common/types/grafana_types.ts
+++ b/scripts/dashboard-importer/src/common/types/grafana_types.ts
@@ -113,6 +113,12 @@ export interface TemplateVariableTextValue {
   value?: string;
 }
 
+// Typing for a Grafana's Template Variable text labels to values mapping
+export interface TemplateVariableTextArrayValue {
+  text?: string[];
+  value?: string[];
+}
+
 // Typing for Grafana's Template Variable Dropdown Option
 export interface TemplateVariableOption extends TemplateVariableTextValue {
   selected: boolean;
@@ -121,7 +127,7 @@ export interface TemplateVariableOption extends TemplateVariableTextValue {
 // Typing for Grafana's Individual Template Variable
 export interface TemplateVariable {
   allFormat: string;
-  current: TemplateVariableTextValue;
+  current: TemplateVariableTextValue | TemplateVariableTextArrayValue;
   datasource: string;
   includeAll: boolean;
   name: string;

--- a/scripts/dashboard-importer/src/dashboards/converter/converter_test.ts
+++ b/scripts/dashboard-importer/src/dashboards/converter/converter_test.ts
@@ -62,6 +62,12 @@ function testDashboardConversion() {
       stringValue: '',
       templateVariable: 'testTv',
     },
+    {
+      filterType: 'METRIC_LABEL',
+      labelKey: 'node',
+      stringValue: '',
+      templateVariable: 'testNodeTv',
+    }
   ]);
 
   // Validate Tiles

--- a/scripts/dashboard-importer/src/dashboards/converter/template_variables/interval.ts
+++ b/scripts/dashboard-importer/src/dashboards/converter/template_variables/interval.ts
@@ -26,9 +26,11 @@ function getIntervalMapping(tv: TemplateVariable): Result<[string, string]> {
 
   const name = tv.name;
   const options = tv.options || [];
+  const tvCurrentValue =
+    typeof tv.current?.value === 'string' ? tv.current?.value : '';
   const selectedValue =
     options.filter((option) => option.selected)[0]?.value ||
-    tv.current?.value ||
+    tvCurrentValue ||
     options[0]?.value;
   if (selectedValue === undefined) {
     return warning([`No suitable mapping found for template variable ${name}`]);

--- a/scripts/dashboard-importer/src/dashboards/converter/template_variables/label_values.ts
+++ b/scripts/dashboard-importer/src/dashboards/converter/template_variables/label_values.ts
@@ -79,10 +79,14 @@ export function getDashboardFilterFromLabelKey(
     return warning(labelKeyResult.warnings);
   }
 
+  const stringValue = typeof templateVariable.current?.value === 'string' ?
+      templateVariable.current?.value :
+      '';
+
   const dashboardFilter: DashboardFilter = {
     labelKey,
     templateVariable: templateVariable.name,
-    stringValue: templateVariable.current?.value || '',
+    stringValue,
     filterType: RESOURCE_LABELS.includes(labelKey)
       ? 'RESOURCE_LABEL'
       : 'METRIC_LABEL',

--- a/scripts/dashboard-importer/src/dashboards/converter/testing/test_dashboard.ts
+++ b/scripts/dashboard-importer/src/dashboards/converter/testing/test_dashboard.ts
@@ -603,6 +603,34 @@ export const TEST_GENERIC_DASHBOARD: GrafanaDashboard = {
         sort: 0,
         type: 'query',
       },
+      {
+        current: {
+          isNone: true,
+          selected: false,
+          text: ['all'],
+          value: ['$__all'],
+        },
+        datasource: {
+          type: 'prometheus',
+          uid: 'P1809F7CD0C75ACF3',
+        },
+        definition: 'label_values(kubernetes_io_hostname)',
+        hide: 0,
+        includeAll: false,
+        label: 'testNodeLabel',
+        multi: false,
+        name: 'testNodeTv',
+        options: [],
+        query: {
+          query: 'label_values(kubernetes_io_hostname)',
+          refId: 'StandardVariableQuery',
+        },
+        refresh: 1,
+        regex: '',
+        skipUrlSync: false,
+        sort: 0,
+        type: 'query',
+      }
     ],
   },
   time: {


### PR DESCRIPTION
Recently a bug came in where the some template variables had a current text value that was an array of strings.
This PR updates the typing to account for this and adds simple logic to fallback to ignoring the current text value if it is of any type other than string
The tests were also updated as part of this change. 