### PR TITLE
Add new recommended alerts for single gce vms

### DIFF
--- a/alerts/google-gce/cpu-utilization-too-high-within-vm.v1.json
+++ b/alerts/google-gce/cpu-utilization-too-high-within-vm.v1.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "VM Instance - High CPU Utilization (${INSTANCE_NAME})",
+  "documentation": {
+    "content": "This alert fires when the CPU utilization on the VM instance (${INSTANCE_NAME}) rises above 80% for 5 minutes or more.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - High CPU utilization (${INSTANCE_NAME})",
+      "conditionThreshold": {
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"compute.googleapis.com/instance/cpu/utilization\" AND metric.labels.instance_name = \"${INSTANCE_NAME}\"",
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "perSeriesAligner": "ALIGN_MEAN"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "trigger": {
+          "count": 1
+        },
+        "thresholdValue": 0.8
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true
+}

--- a/alerts/google-gce/disk-utilization-too-high-within-vm.v1.json
+++ b/alerts/google-gce/disk-utilization-too-high-within-vm.v1.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "VM Instance - High Disk Utilization (${INSTANCE_NAME})",
+  "documentation": {
+    "content": "This alert fires when the disk utilization on the VM instance ${INSTANCE_NAME} rises above 95% for 5 minutes or more.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - High disk utilization (${INSTANCE_NAME})",
+      "conditionThreshold": {
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"agent.googleapis.com/disk/percent_used\" AND metric.labels.state = \"used\" AND metadata.system_labels.name = \"${INSTANCE_NAME}\"",
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "perSeriesAligner": "ALIGN_MEAN"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "trigger": {
+          "count": 1
+        },
+        "thresholdValue": 95
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true
+}

--- a/alerts/google-gce/host-error-log-detected-within-vm.v1.json
+++ b/alerts/google-gce/host-error-log-detected-within-vm.v1.json
@@ -1,0 +1,25 @@
+{
+  "displayName": "VM Instance - Host Error Log Detected (${INSTANCE_NAME})",
+  "documentation": {
+    "content": "This alert fires when any host error is detected on the VM instance ${INSTANCE_NAME} based on system_event logs, limited to notifying once per hour.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - Host Error Log Detected (${INSTANCE_NAME})",
+      "conditionMatchedLog": {
+        "filter": "log_id(\"cloudaudit.googleapis.com/system_event\") AND operation.producer=\"compute.instances.hostError\" AND labels.\"compute.googleapis.com/resource_name\"=\"${INSTANCE_NAME}\""
+      }
+    }
+  ],
+  "alertStrategy": {
+    "notificationRateLimit": {
+      "period": "3600s"
+    },
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": []
+}

--- a/alerts/google-gce/memory-utilization-too-high-within-vm.v1.json
+++ b/alerts/google-gce/memory-utilization-too-high-within-vm.v1.json
@@ -1,0 +1,34 @@
+{
+  "displayName": "VM Instance - High Memory Utilization (${INSTANCE_NAME})",
+  "documentation": {
+    "content": "This alert fires when the memory utilization on the VM instance ${INSTANCE_NAME} rises above 90% for 5 minutes or more.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "VM Instance - High memory utilization (${INSTANCE_NAME})",
+      "conditionThreshold": {
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"agent.googleapis.com/memory/percent_used\" AND metric.labels.state = \"used\" AND metadata.system_labels.name = \"${INSTANCE_NAME}\"",
+        "aggregations": [
+          {
+            "alignmentPeriod": "300s",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "perSeriesAligner": "ALIGN_MEAN"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "0s",
+        "trigger": {
+          "count": 1
+        },
+        "thresholdValue": 90
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true
+}

--- a/alerts/google-gce/metadata.yaml
+++ b/alerts/google-gce/metadata.yaml
@@ -1,28 +1,56 @@
 alert_policy_templates:
 -
   id: cpu-utilization-too-high
-  description: "Monitor CPU utilization across all GCE VMs in the current project and will notify you if the CPU utilization on any VM instance rises above 80% for 5 minutes or more."
+  description: "Monitors CPU utilization across all GCE VMs in the current project and will notify you if the CPU utilization on any VM instance rises above 80% for 5 minutes or more."
+  version: 1
+  related_integrations:
+    - id: gce
+      platform: GCP
+-
+  id: cpu-utilization-too-high-within-vm
+  description: "Monitors CPU utilization in the specified GCE VM and will notify you if the CPU utilization rises above 80% for 5 minutes or more."
   version: 1
   related_integrations:
     - id: gce
       platform: GCP
 -
   id: disk-utilization-too-high
-  description: "Monitor disk utilization across all GCE VMs in the current project and will notify you if the disk utilization on any VM instance rises above 95% for 5 minutes or more. This requires the Ops Agent to be installed on VMs to collect the disk utilization metric."
+  description: "Monitors disk utilization across all GCE VMs in the current project and will notify you if the disk utilization on any VM instance rises above 95% for 5 minutes or more. This requires the Ops Agent to be installed on VMs to collect the disk utilization metric."
+  version: 1
+  related_integrations:
+    - id: gce
+      platform: GCP
+-
+  id: disk-utilization-too-high-within-vm
+  description: "Monitors disk utilization in the specified GCE VM and will notify you if the disk utilization rises above 95% for 5 minutes or more. This requires the Ops Agent to be installed on the VM to collect the disk utilization metric."
   version: 1
   related_integrations:
     - id: gce
       platform: GCP
 -
   id: memory-utilization-too-high
-  description: "Monitor memory utilization across all GCE VMs in the current project and will notify you if the memory utilization on any VM instance rises above 90% for 5 minutes or more. This requires the Ops Agent to be installed on VMs to collect the memory utilization metric."
+  description: "Monitors memory utilization across all GCE VMs in the current project and will notify you if the memory utilization on any VM instance rises above 90% for 5 minutes or more. This requires the Ops Agent to be installed on VMs to collect the memory utilization metric."
+  version: 1
+  related_integrations:
+    - id: gce
+      platform: GCP
+-
+  id: memory-utilization-too-high-within-vm
+  description: "Monitors memory utilization in the specified GCE VM and will notify you if the memory utilization rises above 90% for 5 minutes or more. This requires the Ops Agent to be installed on the VM to collect the memory utilization metric."
   version: 1
   related_integrations:
     - id: gce
       platform: GCP
 -
   id: host-error-log-detected
-  description: "Monitor host errors via system event logs across all GCE VMs in the current project and will notify you if a host error occurs on any VM instance, limited to notifying once per hour."
+  description: "Monitors host errors via system event logs across all GCE VMs in the current project and will notify you if a host error occurs on any VM instance, limited to notifying once per hour."
+  version: 1
+  related_integrations:
+    - id: gce
+      platform: GCP
+-
+  id: host-error-log-detected-within-vm
+  description: "Monitors host errors via system event logs in the specified GCE VM and will notify you if a host error occurs, limited to notifying once per hour."
   version: 1
   related_integrations:
     - id: gce


### PR DESCRIPTION
With the UX migration to UDF, we want to also provide recommended alerts for single VM instances