### PR TITLE
Update SAP integration to point to new integration

### DIFF
--- a/integrations/saphana/metadata.yaml
+++ b/integrations/saphana/metadata.yaml
@@ -1,7 +1,4 @@
 id: saphana
 short_name: HANA
 display_name: SAP HANA
-description: 'The SAP HANA integration collects SAP HANA metrics and logs. The metrics
-  are collected by querying
-
-  relevant monitoring views. This integration writes structured trace logs.'
+description: 'This integration is no longer actively supported. Please use the integration "Google Cloud Agent for SAP" instead.'


### PR DESCRIPTION
This is now the official recommendation in the docs as well: https://cloud.google.com/monitoring/agent/ops-agent/third-party/saphana