### PR TITLE
fix: import.sh replace grep -P with GNU param expansion for MacOS support

### DIFF
--- a/scripts/dashboard-importer/import.sh
+++ b/scripts/dashboard-importer/import.sh
@@ -35,7 +35,8 @@ then
   echo "Conversion complete. Proceeding to upload..."
 
   # Extract output directory from console output
-  DIRECTORY=$(grep -Po '(reports.*/)' <<< "$CONVERSION_OUTPUT" | sed -n '2p')
+  DIRECTORY="${CONVERSION_OUTPUT##*./upload.sh }"
+  DIRECTORY="${DIRECTORY% <PROJECT_ID>*}"
   echo
   echo -e "Now running: \033[34m./upload.sh $DIRECTORY $PROJECT\033[0m\n"
 


### PR DESCRIPTION
This makes import.sh usable on default MacOS terminal.

Without this change import.sh was erroring out:

```
To upload these dashboard(s) manually, you can run:
./upload.sh reports/2024-3-12/08:07:43/ <PROJECT_ID> END

grep: invalid option -- P
usage: grep [-abcdDEFGHhIiJLlMmnOopqRSsUVvwXxZz] [-A num] [-B num] [-C[num]]
	[-e pattern] [-f file] [--binary-files=value] [--color=when]
	[--context[=num]] [--directories=action] [--label] [--line-buffered]
	[--null] [pattern] [file ...]
```

This is due to MacOS shipping [BSD version of grep without Perl option.](https://stackoverflow.com/questions/77662026/grep-invalid-option-p-error-when-doing-regex-in-bash-script#comment136915500_77662026)

Replacing to more std way of doing this should support more envs.