### PR TITLE
Remove cloud armor integration relation

### DIFF
--- a/dashboards/google-cloud-armor/metadata.yaml
+++ b/dashboards/google-cloud-armor/metadata.yaml
@@ -6,6 +6,3 @@ sample_dashboards:
     description: |-
       This dashboard is based on Google Cloud's Cloud Armor Policies (also known as Network Security Policies) and has charts displaying Requests for each policy, as well as a table of open incidents related to your Cloud Armor Policies.
       There are also links to Cloud Armor Policies in Google Cloud Platform and docs for Observing your Cloud Armor Policies.
-    related_integrations:
-      - id: cloud_armor
-        platform: GCP


### PR DESCRIPTION
Remove until the integration is available in the cloud console.