### PR TITLE
Ops Agent DCGM integration: Manually generate DCGM metadata with V1 and V2 metrics

### DIFF
--- a/integrations/dcgm/ops_agent_metadata.yaml
+++ b/integrations/dcgm/ops_agent_metadata.yaml
@@ -64,7 +64,7 @@ platforms:
   agent_requirement:
     metrics_minimum_supported_version:
       major: 2
-      minor: 38
+      minor: 51
       patch: 0
   detections:
   - characteristic_metric:

--- a/integrations/dcgm/ops_agent_metadata.yaml
+++ b/integrations/dcgm/ops_agent_metadata.yaml
@@ -1,6 +1,7 @@
 platforms:
 - type: GCE
   launch_stage: GA
+  version: '1'
   install_documentation_url: https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party-nvidia
   agent_requirement:
     metrics_minimum_supported_version:
@@ -53,6 +54,123 @@ platforms:
     kind: GAUGE
     labels:
     - direction
+    - gpu_number
+    - model
+    - uuid
+- type: GCE
+  launch_stage: GA
+  version: '2'
+  install_documentation_url: https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/third-party-nvidia
+  agent_requirement:
+    metrics_minimum_supported_version:
+      major: 2
+      minor: 38
+      patch: 0
+  detections:
+  - characteristic_metric:
+      metric_type: workload.googleapis.com/gpu.dcgm.memory.bytes_used
+  default_metrics:
+  - name: workload.googleapis.com/gpu.dcgm.utilization
+    value_type: DOUBLE
+    kind: GAUGE
+    labels:
+    - gpu_number
+    - model
+    - uuid
+  - name: workload.googleapis.com/gpu.dcgm.sm.utilization
+    value_type: DOUBLE
+    kind: GAUGE
+    labels:
+    - gpu_number
+    - model
+    - uuid
+  - name: workload.googleapis.com/gpu.dcgm.pipe.utilization
+    value_type: DOUBLE
+    kind: GAUGE
+    labels:
+    - gpu_number
+    - model
+    - pipe
+    - uuid
+  - name: workload.googleapis.com/gpu.dcgm.codec.encoder.utilization
+    value_type: DOUBLE
+    kind: GAUGE
+    labels:
+    - gpu_number
+    - model
+    - uuid
+  - name: workload.googleapis.com/gpu.dcgm.codec.decoder.utilization
+    value_type: DOUBLE
+    kind: GAUGE
+    labels:
+    - gpu_number
+    - model
+    - uuid
+  - name: workload.googleapis.com/gpu.dcgm.memory.bytes_used
+    value_type: INT64
+    kind: GAUGE
+    labels:
+    - gpu_number
+    - model
+    - state
+    - uuid
+  - name: workload.googleapis.com/gpu.dcgm.memory.bandwidth_utilization
+    value_type: DOUBLE
+    kind: GAUGE
+    labels:
+    - gpu_number
+    - model
+    - uuid
+  - name: workload.googleapis.com/gpu.dcgm.pcie.io
+    value_type: INT64
+    kind: CUMULATIVE
+    labels:
+    - direction
+    - gpu_number
+    - model
+    - uuid
+  - name: workload.googleapis.com/gpu.dcgm.nvlink.io
+    value_type: INT64
+    kind: CUMULATIVE
+    labels:
+    - direction
+    - gpu_number
+    - model
+    - uuid
+  - name: workload.googleapis.com/gpu.dcgm.energy_consumption
+    value_type: DOUBLE
+    kind: CUMULATIVE
+    labels:
+    - gpu_number
+    - model
+    - uuid
+  - name: workload.googleapis.com/gpu.dcgm.temperature
+    value_type: DOUBLE
+    kind: GAUGE
+    labels:
+    - gpu_number
+    - model
+    - uuid
+  - name: workload.googleapis.com/gpu.dcgm.clock.frequency
+    value_type: DOUBLE
+    kind: GAUGE
+    labels:
+    - gpu_number
+    - model
+    - uuid
+  - name: workload.googleapis.com/gpu.dcgm.clock.throttle_duration.time
+    value_type: DOUBLE
+    kind: CUMULATIVE
+    labels:
+    - gpu_number
+    - model
+    - uuid
+    - violation
+  - name: workload.googleapis.com/gpu.dcgm.ecc_errors
+    value_type: INT64
+    kind: CUMULATIVE
+    labels:
+    - error_type
     - gpu_number
     - model
     - uuid


### PR DESCRIPTION
[b/384728870](http:/b/384728870)
- DCGM is now a versioned integration (similar to `iis` and `mssql`). The metadata gen script can't handle versioned integration yet, so PRs like #875 are not correct for DCGM.
- This PR updates the DCGM integration by manually handle the metadata file, to include both V1 and V2 metrics. 
- Local testing [screenshot](https://screenshot.googleplex.com/v5ztEdxvRtGmStU). 
- Once this is merged, I will close outdated PRs and skip DCGM auto gen in the future. 