### PR TITLE
Fix mismatched quoting in tgi/metadata.yaml

### DIFF
--- a/integrations/tgi/metadata.yaml
+++ b/integrations/tgi/metadata.yaml
@@ -1,4 +1,4 @@
 id: tgi
 short_name: tgi
 display_name: TGI
-description: 'The Text Generation Inference (TGI) serving framework from Hugging Face is a toolkit for deploying and serving Large Language Models (LLMs). This integration provides metrics for inference request throughput, tokens throughput, latency and batching behavior.
+description: 'The Text Generation Inference (TGI) serving framework from Hugging Face is a toolkit for deploying and serving Large Language Models (LLMs). This integration provides metrics for inference request throughput, tokens throughput, latency and batching behavior.'


### PR DESCRIPTION
Looks like the mismatched quotes caused a YAML parsing error in the ingestion pipeline: sponge2/59bdb211-7fd6-425e-a850-9aba620dfe95