### PR TITLE
Drop unexpected field from internal-tcp-lb-rule.json

### DIFF
--- a/dashboards/google-internal-tcp-lb-rule/internal-tcp-lb-rule.json
+++ b/dashboards/google-internal-tcp-lb-rule/internal-tcp-lb-rule.json
@@ -307,7 +307,6 @@
       }
     ]
   },
-  "legacyCategory": "integration",
   "dashboardFilters": [
     {
       "labelKey": "project_id",


### PR DESCRIPTION
Delete field that was breaking dashboard validation during the copybara ingestion pipeline