### PR TITLE
Add documentation yamls for common GKE AI workloads

### DIFF
--- a/integrations/nvidia-triton/documentation.yaml
+++ b/integrations/nvidia-triton/documentation.yaml
@@ -1,0 +1,44 @@
+exporter_type: included
+app_name_short: NVIDIA Triton
+app_name: {{app_name_short}}
+app_site_name: {{app_name_short}}
+app_site_url: https://developer.nvidia.com/triton-inference-server
+exporter_name: the {{app_name_short}} exporter
+exporter_pkg_name: NVIDIA Triton
+exporter_repo_url: https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/user_guide/metrics.html
+additional_prereq_info: |
+  {{app_site_name}} exposes Prometheus-format metrics automatically; you do not
+  have to install it separately. To verify that {{exporter_name}} is emitting
+  metrics on the expected endpoints, do the following:
+
+  1. Set up port forwarding by using the following command:
+
+  <pre class="devsite-click-to-copy">
+  kubectl -n {{namespace_name}} port-forward {{pod_name}} 8002:8002
+  </pre>
+
+  2. Access the endpoint `localhost:8002/metrics` by using the browser
+  or the `curl` utility in another terminal session.
+dashboard_available: true
+multiple_dashboards: false
+dashboard_display_name: {{app_name_short}} Prometheus Overview
+podmonitoring_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: PodMonitoring
+  metadata:
+    name: triton
+    labels:
+      app.kubernetes.io/name: triton
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    endpoints:
+    - port: 8002
+      scheme: http
+      interval: 30s
+      path: /metrics
+    selector:
+      matchLabels:
+        app: triton
+additional_podmonitoring_info: |
+  Ensure that the values of the `port` and `matchLabels` fields match those of the {{app_name_short}} pods you want to monitor.
+sample_promql_query: up{job="triton", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}

--- a/integrations/tgi/documentation.yaml
+++ b/integrations/tgi/documentation.yaml
@@ -1,0 +1,44 @@
+exporter_type: included
+app_name_short: TGI
+app_name: Text Generation Inference
+app_site_name: {{app_name_short}}
+app_site_url: https://huggingface.co/docs/text-generation-inference/en/index
+exporter_name: the {{app_name_short}} exporter
+exporter_pkg_name: vLLM
+exporter_repo_url: https://huggingface.co/docs/text-generation-inference/en/reference/metrics
+additional_prereq_info: |
+  {{app_site_name}} exposes Prometheus-format metrics automatically; you do not
+  have to install it separately. To verify that {{exporter_name}} is emitting
+  metrics on the expected endpoints, do the following:
+
+  1. Set up port forwarding by using the following command:
+
+  <pre class="devsite-click-to-copy">
+  kubectl -n {{namespace_name}} port-forward {{pod_name}} 8080:8080
+  </pre>
+
+  2. Access the endpoint `localhost:8080/metrics` by using the browser
+  or the `curl` utility in another terminal session.
+dashboard_available: true
+multiple_dashboards: false
+dashboard_display_name: {{app_name_short}} Prometheus Overview
+podmonitoring_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: PodMonitoring
+  metadata:
+    name: tgi
+    labels:
+      app.kubernetes.io/name: tgi
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    endpoints:
+    - port: 8080
+      scheme: http
+      interval: 30s
+      path: /metrics
+    selector:
+      matchLabels:
+        app: tgi-gemma-server
+additional_podmonitoring_info: |
+  Ensure that the values of the `port` and `matchLabels` fields match those of the {{app_name_short}} pods you want to monitor.
+sample_promql_query: up{job="tgi", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}

--- a/integrations/vllm/documentation.yaml
+++ b/integrations/vllm/documentation.yaml
@@ -1,0 +1,44 @@
+exporter_type: included
+app_name_short: vLLM
+app_name: {{app_name_short}}
+app_site_name: {{app_name_short}}
+app_site_url: https://docs.vllm.ai/en/latest/
+exporter_name: the {{app_name_short}} exporter
+exporter_pkg_name: vLLM
+exporter_repo_url: https://docs.vllm.ai/en/stable/serving/metrics.html
+additional_prereq_info: |
+  {{app_site_name}} exposes Prometheus-format metrics automatically; you do not
+  have to install it separately. To verify that {{exporter_name}} is emitting
+  metrics on the expected endpoints, do the following:
+
+  1. Set up port forwarding by using the following command:
+
+  <pre class="devsite-click-to-copy">
+  kubectl -n {{namespace_name}} port-forward {{pod_name}} 8000
+  </pre>
+
+  2. Access the endpoint `localhost:8000/metrics` by using the browser
+  or the `curl` utility in another terminal session.
+dashboard_available: true
+multiple_dashboards: false
+dashboard_display_name: {{app_name_short}} Prometheus Overview
+podmonitoring_config: |
+  apiVersion: monitoring.googleapis.com/v1
+  kind: PodMonitoring
+  metadata:
+    name: vllm
+    labels:
+      app.kubernetes.io/name: vllm
+      app.kubernetes.io/part-of: google-cloud-managed-prometheus
+  spec:
+    endpoints:
+    - port: 8000
+      scheme: http
+      interval: 30s
+      path: /metrics
+    selector:
+      matchLabels:
+        app: vllm-gemma-server
+additional_podmonitoring_info: |
+  Ensure that the values of the `port` and `matchLabels` fields match those of the {{app_name_short}} pods you want to monitor.
+sample_promql_query: up{job="vllm", cluster="{{cluster_name}}", namespace="{{namespace_name}}"}


### PR DESCRIPTION
These will be used to generate GMP documentation at https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/introduction . We will need this documentation to exist before we can publish the corresponding integrations that point to them.