### PR TITLE
Fix Vertex AI latency chart

### DIFF
--- a/dashboards/google-vertex-ai/vertex-ai-model-garden.json
+++ b/dashboards/google-vertex-ai/vertex-ai-model-garden.json
@@ -702,7 +702,7 @@
                     "aggregation": {
                       "alignmentPeriod": "60s",
                       "perSeriesAligner": "ALIGN_DELTA",
-                      "crossSeriesReducer": "REDUCE_PERCENTILE_95",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_50",
                       "groupByFields": [
                         "resource.label.\"model_user_id\""
                       ]


### PR DESCRIPTION
Chart title was p50 but the actual query was for p95 latency