### PR TITLE
Add gke_setup_url to GKE AI model server docs

### DIFF
--- a/integrations/jetstream/documentation.yaml
+++ b/integrations/jetstream/documentation.yaml
@@ -5,6 +5,7 @@ app_site_name: {{app_name_short}}
 app_site_url: https://github.com/AI-Hypercomputer/JetStream
 exporter_name: {{app_name_short}}
 exporter_repo_url: https://github.com/AI-Hypercomputer/JetStream/blob/main/docs/observability-prometheus-metrics-in-jetstream-server.md
+gke_setup_url: /kubernetes-engine/docs/tutorials/serve-gemma-tpu-jetstream
 additional_prereq_info: |
   To collect Prometheus-format metrics from {{app_name_short}}, you must first [build and upload a {{app_name_short}} PyTorch server image](https://github.com/AI-Hypercomputer/jetstream-pytorch/tree/main/docker/jetstream-pytorch-server).
 additional_install_info: |

--- a/integrations/nvidia-triton/documentation.yaml
+++ b/integrations/nvidia-triton/documentation.yaml
@@ -4,8 +4,8 @@ app_name: {{app_name_short}}
 app_site_name: {{app_name_short}}
 app_site_url: https://developer.nvidia.com/triton-inference-server
 exporter_name: the {{app_name_short}} exporter
-exporter_pkg_name: NVIDIA Triton
 exporter_repo_url: https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/user_guide/metrics.html
+gke_setup_url: /kubernetes-engine/docs/tutorials/online-ml-inference
 additional_prereq_info: |
   {{app_site_name}} exposes Prometheus-format metrics automatically; you do not
   have to install it separately. To verify that {{exporter_name}} is emitting

--- a/integrations/tgi/documentation.yaml
+++ b/integrations/tgi/documentation.yaml
@@ -4,8 +4,8 @@ app_name: Text Generation Inference
 app_site_name: {{app_name_short}}
 app_site_url: https://huggingface.co/docs/text-generation-inference/en/index
 exporter_name: the {{app_name_short}} exporter
-exporter_pkg_name: vLLM
 exporter_repo_url: https://huggingface.co/docs/text-generation-inference/en/reference/metrics
+gke_setup_url: /kubernetes-engine/docs/tutorials/serve-gemma-gpu-tgi
 additional_prereq_info: |
   {{app_site_name}} exposes Prometheus-format metrics automatically; you do not
   have to install it separately. To verify that {{exporter_name}} is emitting

--- a/integrations/vllm/documentation.yaml
+++ b/integrations/vllm/documentation.yaml
@@ -4,8 +4,8 @@ app_name: {{app_name_short}}
 app_site_name: {{app_name_short}}
 app_site_url: https://docs.vllm.ai/en/latest/
 exporter_name: the {{app_name_short}} exporter
-exporter_pkg_name: vLLM
 exporter_repo_url: https://docs.vllm.ai/en/stable/serving/metrics.html
+gke_setup_url: /kubernetes-engine/docs/tutorials/serve-gemma-gpu-vllm
 additional_prereq_info: |
   {{app_site_name}} exposes Prometheus-format metrics automatically; you do not
   have to install it separately. To verify that {{exporter_name}} is emitting


### PR DESCRIPTION
These docs (e.g. https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/vllm ) cover how to observe your model server with GMP, but contain links to the corresponding GKE docs on how to set up the model server itself.

Also, clean up exporter_pkg_name, because it's unused in these "type: included" documentation templates.