### PR TITLE
Fix invalid vllm dashboard JSON

### DIFF
--- a/dashboards/vllm/vllm-prometheus.json
+++ b/dashboards/vllm/vllm-prometheus.json
@@ -97,7 +97,7 @@
                 }
               },
               "outputFullDuration": true
-            },
+            }
           },
           "title": "Prompt tokens / request"
         }


### PR DESCRIPTION
Found this when I noticed that the recurring import cl/725908495 was stalled.