### PR TITLE
Add missing prometheus_name to TF Serving integration

### DIFF
--- a/integrations/tensorflow-serving/prometheus_metadata.yaml
+++ b/integrations/tensorflow-serving/prometheus_metadata.yaml
@@ -18,6 +18,7 @@ platforms:
         value_type: DOUBLE
         kind: CUMULATIVE
       - name: prometheus.googleapis.com/:tensorflow:cc:saved_model:load_latency_by_stage/histogram
+        prometheus_name: :tensorflow:cc:saved_model:load_latency_by_stage
         value_type: DISTRIBUTION
         kind: CUMULATIVE
       - name: prometheus.googleapis.com/:tensorflow:core:direct_session_runs/counter
@@ -37,12 +38,15 @@ platforms:
         value_type: DOUBLE
         kind: CUMULATIVE
       - name: prometheus.googleapis.com/:tensorflow:core:graph_pending_queue_length_histogram/histogram
+        prometheus_name: :tensorflow:core:graph_pending_queue_length_histogram
         value_type: DISTRIBUTION
         kind: CUMULATIVE
       - name: prometheus.googleapis.com/:tensorflow:core:graph_run_input_tensor_bytes/histogram
+        prometheus_name: :tensorflow:core:graph_run_input_tensor_bytes
         value_type: DISTRIBUTION
         kind: CUMULATIVE
       - name: prometheus.googleapis.com/:tensorflow:core:graph_run_output_tensor_bytes/histogram
+        prometheus_name: :tensorflow:core:graph_run_output_tensor_bytes
         value_type: DISTRIBUTION
         kind: CUMULATIVE
       - name: prometheus.googleapis.com/:tensorflow:core:graph_run_time_usecs/counter
@@ -50,6 +54,7 @@ platforms:
         value_type: DOUBLE
         kind: CUMULATIVE
       - name: prometheus.googleapis.com/:tensorflow:core:graph_run_time_usecs_histogram/histogram
+        prometheus_name: :tensorflow:core:graph_run_time_usecs_histogram
         value_type: DISTRIBUTION
         kind: CUMULATIVE
       - name: prometheus.googleapis.com/:tensorflow:core:graph_runs/counter
@@ -69,9 +74,11 @@ platforms:
         value_type: DOUBLE
         kind: CUMULATIVE
       - name: prometheus.googleapis.com/:tensorflow:core:saved_model:read:path/gauge
+        prometheus_name: :tensorflow:core:saved_model:read:path
         value_type: DOUBLE
         kind: GAUGE
       - name: prometheus.googleapis.com/:tensorflow:core:session_created/gauge
+        prometheus_name: :tensorflow:core:session_created
         value_type: DOUBLE
         kind: GAUGE
       - name: prometheus.googleapis.com/:tensorflow:serving:request_count/counter
@@ -79,9 +86,11 @@ platforms:
         value_type: DOUBLE
         kind: CUMULATIVE
       - name: prometheus.googleapis.com/:tensorflow:serving:request_latency/histogram
+        prometheus_name: :tensorflow:serving:request_latency
         value_type: DISTRIBUTION
         kind: CUMULATIVE
       - name: prometheus.googleapis.com/:tensorflow:serving:runtime_latency/histogram
+        prometheus_name: :tensorflow:serving:runtime_latency
         value_type: DISTRIBUTION
         kind: CUMULATIVE
     install_documentation_url: https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/tf-serving


### PR DESCRIPTION
These were causing the presubmit to fail validation (correctly).

TESTED=sponge2/e8db60f5-e29d-4fa1-b6c7-fd0d8a1c566b (after patching change locally)