### PR TITLE
Mark TF Serving and Torchserve integrations as public

### DIFF
--- a/integrations/tensorflow-serving/prometheus_metadata.yaml
+++ b/integrations/tensorflow-serving/prometheus_metadata.yaml
@@ -1,6 +1,6 @@
 platforms:
   - type: GKE
-    launch_stage: HIDDEN
+    launch_stage: GA
     detections:
       - characteristic_metric:
           metric_type: prometheus.googleapis.com/:tensorflow:serving:request_count/counter

--- a/integrations/torchserve/prometheus_metadata.yaml
+++ b/integrations/torchserve/prometheus_metadata.yaml
@@ -1,6 +1,6 @@
 platforms:
   - type: GKE
-    launch_stage: HIDDEN
+    launch_stage: GA
     detections:
       - characteristic_metric:
           metric_type: prometheus.googleapis.com/Requests2XX/counter


### PR DESCRIPTION
Tested that they display correctly, the detection via characteristic metric works, and they link to the intended dashboard and docs behind an experiment.

![image](https://github.com/user-attachments/assets/6fc58888-46cb-444e-a816-7720606532f2)
