### PR TITLE
Make GKE Inference Gateway integration public

### DIFF
--- a/integrations/gateway-api-inference-extension/prometheus_metadata.yaml
+++ b/integrations/gateway-api-inference-extension/prometheus_metadata.yaml
@@ -1,6 +1,6 @@
 platforms:
   - type: GKE
-    launch_stage: HIDDEN
+    launch_stage: GA
     detections:
       - characteristic_metric:
           metric_type: prometheus.googleapis.com/inference_model_request_total/counter


### PR DESCRIPTION
Tested in my own project.

![image](https://github.com/user-attachments/assets/1e27d291-9fb0-4bd5-a3eb-4302a0b3447b)
