### PR TITLE
Remove the related cloudaicompanion integration

### DIFF
--- a/dashboards/google-gemini-code-assist/metadata.yaml
+++ b/dashboards/google-gemini-code-assist/metadata.yaml
@@ -5,6 +5,3 @@ sample_dashboards:
     display_name: Gemini Code Assist Overview from Metadata Logs
     description: |-
       This dashboard has charts for Gemini Code Assist using Gemini for Google Cloud Logging logs, including Daily Active Users, Chat Exposures, Code Suggestions, Code Suggestions Accepted, Acceptance Rate, and Lines of Code Accepted. [Gemini for Google Cloud Logging metadata logs](https://cloud.google.com/gemini/docs/log-gemini#metadata) must be enabled.
-    related_integrations:
-      - id: cloudaicompanion
-        platform: GCP


### PR DESCRIPTION
Unlink this dashboard from the cloudaicompanion integration so that it does not appear with it in the GCP UI. 