### PR TITLE
Switch to use ClusterPodMonitoring with secret in inference gateway

### DIFF
--- a/integrations/gateway-api-inference-extension/documentation.yaml
+++ b/integrations/gateway-api-inference-extension/documentation.yaml
@@ -24,7 +24,7 @@ multiple_dashboards: false
 dashboard_display_name: {{app_name_short}} Prometheus Overview
 podmonitoring_config: |
   apiVersion: monitoring.googleapis.com/v1
-  kind: PodMonitoring
+  kind: ClusterPodMonitoring
   metadata:
     name: inference-extension
     labels:
@@ -36,9 +36,17 @@ podmonitoring_config: |
       scheme: http
       interval: 5s
       path: /metrics
+      authorization:
+      type: Bearer
+      credentials:
+        secret:
+          name: inference-gateway-sa-metrics-reader-secret
+          key: token
+          namespace: default
     selector:
       matchLabels:
         app: inference-gateway-ext-proc
 additional_podmonitoring_info: |
-  Ensure that the values of the `port` and `matchLabels` fields match those of the {{app_name_short}} pods you want to monitor.
+  Ensure that the values of the `port` and `matchLabels` fields match those of the {{app_name_short}} pods you want to monitor. For how to install the secret
+  `inference-gateway-sa-metrics-reader-secret`, please follow the [instruction](https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/inference-optimized-gateway).
 sample_promql_query: inference_model_request_total{cluster="{{cluster_name}}", namespace="{{namespace_name}}"}


### PR DESCRIPTION
The secret is required because the metrics endpoint is protected.