### PR TITLE
Remove legendTemplate for Requests Rate chart

### DIFF
--- a/dashboards/nginx/overview.json
+++ b/dashboards/nginx/overview.json
@@ -13,7 +13,6 @@
             },
             "dataSets": [
               {
-                "legendTemplate": "Request Rate",
                 "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",


### PR DESCRIPTION
This legend caused an issue where all chart timeseries would have the same name in the chart legend.