### PR TITLE
Fix "MalformedJsonException" error in nginx dashboard

### DIFF
--- a/dashboards/nginx/overview.json
+++ b/dashboards/nginx/overview.json
@@ -82,7 +82,7 @@
             },
             "dataSets": [
               {
-                "legendTemplate": "Accepted ${metadata.system_labels\.name}",
+                "legendTemplate": "Accepted ${metadata.system_labels\\.name}",
                 "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
@@ -100,7 +100,7 @@
                 }
               },
               {
-                "legendTemplate": "Handled ${metadata.system_labels\.name}",
+                "legendTemplate": "Handled ${metadata.system_labels\\.name}",
                 "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",


### PR DESCRIPTION
The sample pipeline got stuck with error "MalformedJsonException: Invalid escape sequence at line 85 column 71 path $.mosaicLayout.tiles[2].widget.xyChart.dataSets[0].legendTemplate"

I tested in dashboards builder that this syntax seems to work instead.