### PR TITLE
Bindplane secops exporter metrics

### DIFF
--- a/dashboards/secops/README.md
+++ b/dashboards/secops/README.md
@@ -1,0 +1,19 @@
+### Dashboards for Bindplane SecOps Exporter
+
+#### Notes
+
+- This dashboard is based on the [Bindplane Collector source](https://bindplane.com/docs/resources/sources/bindplane-agent) and
+  [Google Cloud destination](https://bindplane.com/docs/resources/destinations/google-cloud) Bindplane resources.
+
+|Bindplane SecOps Exporter|
+|:------------------|
+|Filename: [secops.json](secops.json)|
+|This dashboard has charts displaying: `Request latency`, `Request batch size`, `Request payload size`, `Log sent rate`, `Log failure rate`, `Exporter sending queue utilization`, `Exporter sending queue size`, `Exporter sending queue latency`, `Exporter sending queue batch size`, `Exporter sending queue payload size`, and `Exporter sending queue utilization`|
+
+#### Usage
+
+1. Configure the [Bindplane Collector source](https://bindplane.com/docs/resources/sources/bindplane-agent) and ensure Exporter metrics are enabled.
+2. Configure the [Google Cloud destination](https://bindplane.com/docs/resources/destinations/google-cloud).
+3. Import the dashboard into your Google Cloud Monitoring workspace.
+
+

--- a/dashboards/secops/metadata.yaml
+++ b/dashboards/secops/metadata.yaml
@@ -1,0 +1,6 @@
+sample_dashboards:
+  -
+    category: Bindplane SecOps Exporter
+    id: bindplane-secops-exporter
+    display_name: Bindplane SecOps Exporter Overview
+    description: "This dashboard has charts displaying: Request latency, Request batch size, Request payload size, Log sent rate, Log failure rate, Exporter sending queue utilization, Exporter sending queue size, Exporter sending queue latency, Exporter sending queue batch size, Exporter sending queue payload size, and Exporter sending queue utilization"

--- a/dashboards/secops/secops.json
+++ b/dashboards/secops/secops.json
@@ -1,0 +1,407 @@
+{
+  "displayName": "SecOps Exporter",
+  "dashboardFilters": [],
+  "labels": {},
+  "mosaicLayout": {
+    "columns": 48,
+    "tiles": [
+      {
+        "height": 15,
+        "width": 48,
+        "widget": {
+          "title": "SecOps Request Latency P99, P95, P50",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_99",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"prometheus.googleapis.com/otelcol_exporter_request_latency_milliseconds/histogram\" resource.type=\"prometheus_target\" metric.label.\"otel_scope_name\"=\"github.com/observiq/bindplane-otel-collector/exporter/chronicleexporter\""
+                  },
+                  "unitOverride": ""
+                }
+              },
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_95",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"prometheus.googleapis.com/otelcol_exporter_request_latency_milliseconds/histogram\" resource.type=\"prometheus_target\" metric.label.\"otel_scope_name\"=\"github.com/observiq/bindplane-otel-collector/exporter/chronicleexporter\""
+                  },
+                  "unitOverride": ""
+                }
+              },
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_50",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"prometheus.googleapis.com/otelcol_exporter_request_latency_milliseconds/histogram\" resource.type=\"prometheus_target\" metric.label.\"otel_scope_name\"=\"github.com/observiq/bindplane-otel-collector/exporter/chronicleexporter\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [
+              {
+                "color": "COLOR_UNSPECIFIED",
+                "direction": "DIRECTION_UNSPECIFIED",
+                "label": "",
+                "targetAxis": "Y1",
+                "value": 1000
+              }
+            ],
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 15,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "SecOps Batch Size P99 P95",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_99",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"prometheus.googleapis.com/otelcol_exporter_batch_size/histogram\" resource.type=\"prometheus_target\" metric.label.\"otel_scope_name\"=\"github.com/observiq/bindplane-otel-collector/exporter/chronicleexporter\""
+                  },
+                  "unitOverride": ""
+                }
+              },
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_95",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"prometheus.googleapis.com/otelcol_exporter_batch_size/histogram\" resource.type=\"prometheus_target\" metric.label.\"otel_scope_name\"=\"github.com/observiq/bindplane-otel-collector/exporter/chronicleexporter\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 15,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "SecOps Payload Size P99 P95",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_99",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"prometheus.googleapis.com/otelcol_exporter_payload_size/histogram\" resource.type=\"prometheus_target\" metric.label.\"otel_scope_name\"=\"github.com/observiq/bindplane-otel-collector/exporter/chronicleexporter\""
+                  },
+                  "unitOverride": ""
+                }
+              },
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_50",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"prometheus.googleapis.com/otelcol_exporter_payload_size/histogram\" resource.type=\"prometheus_target\" metric.label.\"otel_scope_name\"=\"github.com/observiq/bindplane-otel-collector/exporter/chronicleexporter\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [
+              {
+                "color": "COLOR_UNSPECIFIED",
+                "direction": "DIRECTION_UNSPECIFIED",
+                "label": "",
+                "targetAxis": "Y1",
+                "value": 3000000
+              },
+              {
+                "color": "COLOR_UNSPECIFIED",
+                "direction": "DIRECTION_UNSPECIFIED",
+                "label": "",
+                "targetAxis": "Y1",
+                "value": 800000
+              }
+            ],
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 31,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "SecOps Logs Sent",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"prometheus.googleapis.com/otelcol_exporter_sent_log_records_total/counter\" resource.type=\"prometheus_target\" metric.label.\"otel_scope_name\"=\"go.opentelemetry.io/collector/exporter/exporterhelper\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 31,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "SecOps Failed Log Records",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"prometheus.googleapis.com/otelcol_exporter_enqueue_failed_log_records_total/counter\" resource.type=\"prometheus_target\" metric.label.\"otel_scope_name\"=\"go.opentelemetry.io/collector/exporter/exporterhelper\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 47,
+        "height": 11,
+        "width": 48,
+        "widget": {
+          "title": "SecOps Queue Percentage",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilterRatio": {
+                    "numerator": {
+                      "aggregation": {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_SUM",
+                        "groupByFields": [],
+                        "perSeriesAligner": "ALIGN_MEAN"
+                      },
+                      "filter": "metric.type=\"prometheus.googleapis.com/otelcol_exporter_queue_size/gauge\" resource.type=\"prometheus_target\" metric.label.\"otel_scope_name\"=\"go.opentelemetry.io/collector/exporter/exporterhelper\""
+                    },
+                    "denominator": {
+                      "aggregation": {
+                        "crossSeriesReducer": "REDUCE_SUM",
+                        "groupByFields": [],
+                        "perSeriesAligner": "ALIGN_MEAN"
+                      },
+                      "filter": "metric.type=\"prometheus.googleapis.com/otelcol_exporter_queue_capacity/gauge\" resource.type=\"prometheus_target\" metric.label.\"otel_scope_name\"=\"go.opentelemetry.io/collector/exporter/exporterhelper\""
+                    }
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [
+              {
+                "color": "COLOR_UNSPECIFIED",
+                "direction": "DIRECTION_UNSPECIFIED",
+                "label": "",
+                "targetAxis": "Y1",
+                "value": 1
+              }
+            ],
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Added a dashboard with [SecOps Exporter](https://github.com/observIQ/bindplane-otel-collector/tree/main/exporter/chronicleexporter).

![Screenshot From 2025-05-01 16-06-36](https://github.com/user-attachments/assets/62851584-0abb-4716-8f3b-3cbdb4f26524)

I based this on the [Verlo dashboard](https://github.com/jsirianni/monitoring-dashboard-samples/tree/master/dashboards/velero).