### PR TITLE
Inference Gateway: Use active metric for dashboard detection

### DIFF
--- a/integrations/gateway-api-inference-extension/prometheus_metadata.yaml
+++ b/integrations/gateway-api-inference-extension/prometheus_metadata.yaml
@@ -3,7 +3,7 @@ platforms:
     launch_stage: GA
     detections:
       - characteristic_metric:
-          metric_type: prometheus.googleapis.com/inference_model_request_total/counter
+          metric_type: prometheus.googleapis.com/inference_model_request_duration_seconds/histogram
     exporter_metadata:
       name: GKE Inference Gateway Metrics Overview
       doc_url: https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/site-src/guides/metrics.md


### PR DESCRIPTION
Request total might be inactive if there is no request to the server, which will take down the dashboard. Switch to the request duration metric which remains active even though the inference gateway doesn't have any running requests.