### PR TITLE
Update review-assignment.yaml

### DIFF
--- a/.github/workflows/review-assignment.yaml
+++ b/.github/workflows/review-assignment.yaml
@@ -4,12 +4,12 @@ on:
     types: [opened, ready_for_review]
     paths: ["dashboards/**", "integrations/**"]
 
+permissions: write-all
+
 jobs:
   add-owner:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
+    permissions: write-all
     steps:
       - name: run
         uses: kentaro-m/auto-assign-action@v1.2.3


### PR DESCRIPTION
Grant more permissive permissions to PR assignment github action (following [this](https://stackoverflow.com/questions/70435286/resource-not-accessible-by-integration-on-github-post-repos-owner-repo-ac/70448851#70448851))