### PR TITLE
PromQL: Kafka

### DIFF
--- a/dashboards/flink/flink-gce-overview.json
+++ b/dashboards/flink/flink-gce-overview.json
@@ -1,1099 +1,880 @@
 {
-  "displayName": "Flink GCE Overview - PromQL",
-  "dashboardFilters": [],
-  "labels": {},
-  "mosaicLayout": {
-    "columns": 48,
-    "tiles": [
-      {
-        "height": 16,
-        "width": 16,
-        "widget": {
-          "title": "CPU Load",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_MEAN"
+    "category": "CUSTOM",
+    "displayName": "Flink GCE Overview",
+    "mosaicLayout": {
+      "columns": 12,
+      "tiles": [
+        {
+          "height": 4,
+          "widget": {
+            "title": "CPU Load",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "minAlignmentPeriod": "60s",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "apiSource": "DEFAULT_CLOUD",
+                    "timeSeriesFilter": {
+                      "aggregation": {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_NONE"
+                      },
+                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.cpu.load\" resource.type=\"gce_instance\""
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.cpu.load\" resource.type=\"gce_instance\""
-                  },
-                  "unitOverride": ""
+                    "unitOverride": "%"
+                  }
                 }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
               }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
             }
-          }
-        }
-      },
-      {
-        "xPos": 16,
-        "height": 16,
-        "width": 16,
-        "widget": {
-          "title": "CPU Time",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_RATE"
+          },
+          "width": 4,
+          "xPos": 0,
+          "yPos": 0
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "CPU Time",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "minAlignmentPeriod": "60s",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "apiSource": "DEFAULT_CLOUD",
+                    "timeSeriesFilter": {
+                      "aggregation": {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_RATE"
+                      },
+                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.cpu.time\" resource.type=\"gce_instance\""
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.cpu.time\" resource.type=\"gce_instance\""
-                  },
-                  "unitOverride": ""
+                    "unitOverride": "ns"
+                  }
                 }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
               }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
             }
-          }
-        }
-      },
-      {
-        "xPos": 32,
-        "height": 16,
-        "width": 16,
-        "widget": {
-          "title": "Threads",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_MEAN"
+          },
+          "width": 4,
+          "xPos": 4,
+          "yPos": 0
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "Threads",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "minAlignmentPeriod": "60s",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "apiSource": "DEFAULT_CLOUD",
+                    "timeSeriesFilter": {
+                      "aggregation": {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_NONE"
+                      },
+                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.threads.count\" resource.type=\"gce_instance\""
+                    }
+                  }
+                }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
+              }
+            }
+          },
+          "width": 4,
+          "xPos": 8,
+          "yPos": 0
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "Heap Used",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "minAlignmentPeriod": "60s",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "apiSource": "DEFAULT_CLOUD",
+                    "timeSeriesFilter": {
+                      "aggregation": {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_NONE"
+                      },
+                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.heap.used\" resource.type=\"gce_instance\""
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.threads.count\" resource.type=\"gce_instance\""
-                  },
-                  "unitOverride": ""
+                    "unitOverride": "By"
+                  }
                 }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
               }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
             }
-          }
-        }
-      },
-      {
-        "yPos": 16,
-        "height": 16,
-        "width": 16,
-        "widget": {
-          "title": "Heap Used",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_MEAN"
+          },
+          "width": 4,
+          "xPos": 0,
+          "yPos": 4
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "Heap Committed",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "minAlignmentPeriod": "60s",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "apiSource": "DEFAULT_CLOUD",
+                    "timeSeriesFilter": {
+                      "aggregation": {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_NONE"
+                      },
+                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.heap.committed\" resource.type=\"gce_instance\""
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.heap.used\" resource.type=\"gce_instance\""
-                  },
-                  "unitOverride": ""
+                    "unitOverride": "By"
+                  }
                 }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
               }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
             }
-          }
-        }
-      },
-      {
-        "yPos": 16,
-        "xPos": 16,
-        "height": 16,
-        "width": 16,
-        "widget": {
-          "title": "Heap Committed",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_MEAN"
+          },
+          "width": 4,
+          "xPos": 4,
+          "yPos": 4
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "Heap Max",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "minAlignmentPeriod": "60s",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "apiSource": "DEFAULT_CLOUD",
+                    "timeSeriesFilter": {
+                      "aggregation": {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_NONE"
+                      },
+                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.heap.max\" resource.type=\"gce_instance\""
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.heap.committed\" resource.type=\"gce_instance\""
-                  },
-                  "unitOverride": ""
+                    "unitOverride": "By"
+                  }
                 }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
               }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
             }
-          }
-        }
-      },
-      {
-        "yPos": 16,
-        "xPos": 32,
-        "height": 16,
-        "width": 16,
-        "widget": {
-          "title": "Heap Max",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_MEAN"
+          },
+          "width": 4,
+          "xPos": 8,
+          "yPos": 4
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "Nonheap Used",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "minAlignmentPeriod": "60s",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "apiSource": "DEFAULT_CLOUD",
+                    "timeSeriesFilter": {
+                      "aggregation": {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_NONE"
+                      },
+                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.nonheap.used\" resource.type=\"gce_instance\""
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.heap.max\" resource.type=\"gce_instance\""
-                  },
-                  "unitOverride": ""
+                    "unitOverride": "By"
+                  }
                 }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
               }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
             }
-          }
-        }
-      },
-      {
-        "yPos": 32,
-        "height": 16,
-        "width": 16,
-        "widget": {
-          "title": "Nonheap Used",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_MEAN"
+          },
+          "width": 4,
+          "xPos": 0,
+          "yPos": 8
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "Nonheap Committed",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "minAlignmentPeriod": "60s",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "apiSource": "DEFAULT_CLOUD",
+                    "timeSeriesFilter": {
+                      "aggregation": {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_NONE"
+                      },
+                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.nonheap.committed\" resource.type=\"gce_instance\""
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.nonheap.used\" resource.type=\"gce_instance\""
-                  },
-                  "unitOverride": ""
+                    "unitOverride": "By"
+                  }
                 }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
               }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
             }
-          }
-        }
-      },
-      {
-        "yPos": 32,
-        "xPos": 16,
-        "height": 16,
-        "width": 16,
-        "widget": {
-          "title": "Nonheap Committed",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_MEAN"
+          },
+          "width": 4,
+          "xPos": 4,
+          "yPos": 8
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "Nonheap Max",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "minAlignmentPeriod": "60s",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "apiSource": "DEFAULT_CLOUD",
+                    "timeSeriesFilter": {
+                      "aggregation": {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_NONE"
+                      },
+                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.nonheap.max\" resource.type=\"gce_instance\""
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.nonheap.committed\" resource.type=\"gce_instance\""
-                  },
-                  "unitOverride": ""
+                    "unitOverride": "By"
+                  }
                 }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
               }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
             }
-          }
-        }
-      },
-      {
-        "yPos": 32,
-        "xPos": 32,
-        "height": 16,
-        "width": 16,
-        "widget": {
-          "title": "Nonheap Max",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_MEAN"
+          },
+          "width": 4,
+          "xPos": 8,
+          "yPos": 8
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "Metaspace used",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "minAlignmentPeriod": "60s",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "apiSource": "DEFAULT_CLOUD",
+                    "timeSeriesFilter": {
+                      "aggregation": {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_NONE"
+                      },
+                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.metaspace.used\" resource.type=\"gce_instance\""
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.nonheap.max\" resource.type=\"gce_instance\""
-                  },
-                  "unitOverride": ""
+                    "unitOverride": "By"
+                  }
                 }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
               }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
             }
-          }
-        }
-      },
-      {
-        "yPos": 48,
-        "height": 16,
-        "width": 16,
-        "widget": {
-          "title": "Metaspace used",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_MEAN"
+          },
+          "width": 4,
+          "xPos": 0,
+          "yPos": 12
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "Metaspace Committed",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "minAlignmentPeriod": "60s",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "apiSource": "DEFAULT_CLOUD",
+                    "timeSeriesFilter": {
+                      "aggregation": {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_NONE"
+                      },
+                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.metaspace.committed\" resource.type=\"gce_instance\""
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.metaspace.used\" resource.type=\"gce_instance\""
-                  },
-                  "unitOverride": ""
+                    "unitOverride": "By"
+                  }
                 }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
               }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
             }
-          }
-        }
-      },
-      {
-        "yPos": 48,
-        "xPos": 16,
-        "height": 16,
-        "width": 16,
-        "widget": {
-          "title": "Metaspace Committed",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_MEAN"
+          },
+          "width": 4,
+          "xPos": 4,
+          "yPos": 12
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "Metaspace Max",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "minAlignmentPeriod": "60s",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "apiSource": "DEFAULT_CLOUD",
+                    "timeSeriesFilter": {
+                      "aggregation": {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_NONE"
+                      },
+                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.metaspace.max\" resource.type=\"gce_instance\""
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.metaspace.committed\" resource.type=\"gce_instance\""
-                  },
-                  "unitOverride": ""
+                    "unitOverride": "By"
+                  }
                 }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
               }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
             }
-          }
-        }
-      },
-      {
-        "yPos": 48,
-        "xPos": 32,
-        "height": 16,
-        "width": 16,
-        "widget": {
-          "title": "Metaspace Max",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_MEAN"
+          },
+          "width": 4,
+          "xPos": 8,
+          "yPos": 12
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "Direct Used",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "minAlignmentPeriod": "60s",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "apiSource": "DEFAULT_CLOUD",
+                    "timeSeriesFilter": {
+                      "aggregation": {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_NONE"
+                      },
+                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.direct.used\" resource.type=\"gce_instance\""
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.metaspace.max\" resource.type=\"gce_instance\""
-                  },
-                  "unitOverride": ""
+                    "unitOverride": "By"
+                  }
                 }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
               }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
             }
-          }
-        }
-      },
-      {
-        "yPos": 64,
-        "height": 16,
-        "width": 24,
-        "widget": {
-          "title": "Direct Used",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_MEAN"
+          },
+          "width": 6,
+          "xPos": 0,
+          "yPos": 16
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "Direct Total Capacity",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "minAlignmentPeriod": "60s",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "apiSource": "DEFAULT_CLOUD",
+                    "timeSeriesFilter": {
+                      "aggregation": {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_NONE"
+                      },
+                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.direct.total_capacity\" resource.type=\"gce_instance\""
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.direct.used\" resource.type=\"gce_instance\""
-                  },
-                  "unitOverride": ""
+                    "unitOverride": "By"
+                  }
                 }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
               }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
             }
-          }
-        }
-      },
-      {
-        "yPos": 64,
-        "xPos": 24,
-        "height": 16,
-        "width": 24,
-        "widget": {
-          "title": "Direct Total Capacity",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_MEAN"
+          },
+          "width": 6,
+          "xPos": 6,
+          "yPos": 16
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "Mapped used",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "minAlignmentPeriod": "60s",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "apiSource": "DEFAULT_CLOUD",
+                    "timeSeriesFilter": {
+                      "aggregation": {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_NONE"
+                      },
+                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.mapped.used\" resource.type=\"gce_instance\""
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.direct.total_capacity\" resource.type=\"gce_instance\""
-                  },
-                  "unitOverride": ""
+                    "unitOverride": "By"
+                  }
                 }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
               }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
             }
-          }
-        }
-      },
-      {
-        "yPos": 80,
-        "height": 16,
-        "width": 24,
-        "widget": {
-          "title": "Mapped used",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_MEAN"
+          },
+          "width": 6,
+          "xPos": 0,
+          "yPos": 20
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "Mapped Total Capacity",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "minAlignmentPeriod": "60s",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "apiSource": "DEFAULT_CLOUD",
+                    "timeSeriesFilter": {
+                      "aggregation": {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_NONE"
+                      },
+                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.mapped.total_capacity\" resource.type=\"gce_instance\""
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.mapped.used\" resource.type=\"gce_instance\""
-                  },
-                  "unitOverride": ""
+                    "unitOverride": "By"
+                  }
                 }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
               }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
             }
-          }
-        }
-      },
-      {
-        "yPos": 80,
-        "xPos": 24,
-        "height": 16,
-        "width": 24,
-        "widget": {
-          "title": "Mapped Total Capacity",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_MEAN"
+          },
+          "width": 6,
+          "xPos": 6,
+          "yPos": 20
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "Garbage Collector Time",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "minAlignmentPeriod": "60s",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "apiSource": "DEFAULT_CLOUD",
+                    "timeSeriesFilter": {
+                      "aggregation": {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_RATE"
+                      },
+                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.gc.collections.time\" resource.type=\"gce_instance\""
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.mapped.total_capacity\" resource.type=\"gce_instance\""
-                  },
-                  "unitOverride": ""
+                    "unitOverride": "ms"
+                  }
                 }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
               }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
             }
-          }
-        }
-      },
-      {
-        "yPos": 96,
-        "height": 16,
-        "width": 24,
-        "widget": {
-          "title": "Garbage Collector Time",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_RATE"
+          },
+          "width": 6,
+          "xPos": 0,
+          "yPos": 24
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "Garbage Collector Count",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "minAlignmentPeriod": "60s",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "apiSource": "DEFAULT_CLOUD",
+                    "timeSeriesFilter": {
+                      "aggregation": {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_RATE"
+                      },
+                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.gc.collections.count\" resource.type=\"gce_instance\""
+                    }
+                  }
+                }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
+              }
+            }
+          },
+          "width": 6,
+          "xPos": 6,
+          "yPos": 24
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "Flink Memory Managed Used",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "minAlignmentPeriod": "60s",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "apiSource": "DEFAULT_CLOUD",
+                    "timeSeriesFilter": {
+                      "aggregation": {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_NONE"
+                      },
+                      "filter": "metric.type=\"workload.googleapis.com/flink.memory.managed.used\" resource.type=\"gce_instance\""
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.gc.collections.time\" resource.type=\"gce_instance\""
-                  },
-                  "unitOverride": ""
+                    "unitOverride": "By"
+                  }
                 }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
               }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
             }
-          }
-        }
-      },
-      {
-        "yPos": 96,
-        "xPos": 24,
-        "height": 16,
-        "width": 24,
-        "widget": {
-          "title": "Garbage Collector Count",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_RATE"
+          },
+          "width": 4,
+          "xPos": 0,
+          "yPos": 28
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "Flink Memory Managed Total",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "minAlignmentPeriod": "60s",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "apiSource": "DEFAULT_CLOUD",
+                    "timeSeriesFilter": {
+                      "aggregation": {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_NONE"
+                      },
+                      "filter": "metric.type=\"workload.googleapis.com/flink.memory.managed.total\" resource.type=\"gce_instance\""
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.gc.collections.count\" resource.type=\"gce_instance\""
-                  },
-                  "unitOverride": ""
+                    "unitOverride": "By"
+                  }
                 }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
               }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
             }
-          }
-        }
-      },
-      {
-        "yPos": 112,
-        "height": 16,
-        "width": 16,
-        "widget": {
-          "title": "Flink Memory Managed Used",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
+          },
+          "width": 4,
+          "xPos": 4,
+          "yPos": 28
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "Class Loader",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "minAlignmentPeriod": "60s",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "apiSource": "DEFAULT_CLOUD",
+                    "timeSeriesFilter": {
+                      "aggregation": {
+                        "alignmentPeriod": "60s",
+                        "crossSeriesReducer": "REDUCE_NONE",
+                        "perSeriesAligner": "ALIGN_RATE"
+                      },
+                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.class_loader.classes_loaded\" resource.type=\"gce_instance\""
+                    }
+                  }
+                }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
+              }
+            }
+          },
+          "width": 4,
+          "xPos": 8,
+          "yPos": 28
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "CPU % Top 5 VMs",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "legendTemplate": "${labels.metric\\.instance_name} (${labels.resource\\.zone})",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "timeSeriesQueryLanguage": "def top_5_cpu_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_cpu: metric 'compute.googleapis.com/instance/cpu/utilization'; \n  t_filter_metric: metric $filter_metric }\n  | join\n  | value t_cpu.value.utilization\n  | group_by [resource.project_id, resource.zone, metric.instance_name], 1m,\n      [value_utilization_mean: mean(t_cpu.value.utilization)]\n  | top 5\n  | every 1m;\n\n@top_5_cpu_filtered_by_metric 'workload.googleapis.com/flink.jvm.cpu.load'\n"
+                  }
+                }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
+              }
+            }
+          },
+          "width": 4,
+          "xPos": 0,
+          "yPos": 32
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "Memory % Top 5 VMs",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "legendTemplate": "${labels.metadata\\.system\\.name} (${labels.resource\\.zone})",
+                  "plotType": "LINE",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "timeSeriesQueryLanguage": "def top_5_memory_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/memory/percent_used'\n        | filter metric.state = 'used'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n  @top_5_memory_filtered_by_metric 'workload.googleapis.com/flink.jvm.cpu.load'"
+                  }
+                }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
+              }
+            }
+          },
+          "width": 4,
+          "xPos": 4,
+          "yPos": 32
+        },
+        {
+          "height": 4,
+          "widget": {
+            "title": "Hosts by Region",
+            "xyChart": {
+              "chartOptions": {
+                "mode": "COLOR"
+              },
+              "dataSets": [
+                {
+                  "legendTemplate": "${labels.region}",
+                  "plotType": "STACKED_AREA",
+                  "targetAxis": "Y1",
+                  "timeSeriesQuery": {
+                    "timeSeriesQueryLanguage": "def vms_with_metric_count_by_region metric =\n  fetch gce_instance\n  | metric $metric\n  # Shift points forward from the past 2 minutes so a VM that misses a point\n  # won't temporarily shift down the number of VMs.\n  | align next_older(2m)\n  | group_by [resource.project_id, resource.zone, resource.instance_id], 1m, .pick_any\n  | group_by [resource.project_id, resource.zone], 1m, .count\n  | map\n      add[\n        region: re_extract(resource.zone, '([^-]+-[^-]+)-[^-]+', '\\\\1')]\n  | group_by [region], .sum\n  | every 1m;\n\n@vms_with_metric_count_by_region 'workload.googleapis.com/flink.jvm.cpu.load'"
+                  }
+                }
+              ],
+              "timeshiftDuration": "0s",
+              "yAxis": {
+                "scale": "LINEAR"
+              }
+            }
+          },
+          "width": 4,
+          "xPos": 8,
+          "yPos": 32
+        },
+        {
+          "height": 4,
+          "widget": {
+            "text": {
+              "content": "[How to configure flink Monitoring](https://cloud.google.com/monitoring/agent/ops-agent/third-party/flink)\n\n[View Flink Logs](https://console.cloud.google.com/logs/query?query=logName:%22flink%22%0Aresource.type%3D%22gce_instance%22)\n\n",
+              "format": "MARKDOWN"
             },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_MEAN"
-                    },
-                    "filter": "metric.type=\"workload.googleapis.com/flink.memory.managed.used\" resource.type=\"gce_instance\""
-                  },
-                  "unitOverride": ""
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
-            }
-          }
+            "title": "flink Monitoring Links"
+          },
+          "width": 4,
+          "xPos": 0,
+          "yPos": 36
         }
-      },
-      {
-        "yPos": 112,
-        "xPos": 16,
-        "height": 16,
-        "width": 16,
-        "widget": {
-          "title": "Flink Memory Managed Total",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_MEAN"
-                    },
-                    "filter": "metric.type=\"workload.googleapis.com/flink.memory.managed.total\" resource.type=\"gce_instance\""
-                  },
-                  "unitOverride": ""
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
-            }
-          }
-        }
-      },
-      {
-        "yPos": 112,
-        "xPos": 32,
-        "height": 16,
-        "width": 16,
-        "widget": {
-          "title": "Class Loader",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_RATE"
-                    },
-                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.class_loader.classes_loaded\" resource.type=\"gce_instance\""
-                  },
-                  "unitOverride": ""
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
-            }
-          }
-        }
-      },
-      {
-        "yPos": 128,
-        "height": 16,
-        "width": 16,
-        "widget": {
-          "title": "CPU % Top 5 VMs",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "prometheusQuery": "topk(5, 100 *\n  avg by (project_id, zone, instance_name) (\n    avg_over_time(\n      compute_googleapis_com:instance_cpu_utilization{monitored_resource=\"gce_instance\"}[1m]\n    )\n    and\n    on(instance_id, project_id, zone)\n    (workload_googleapis_com:flink_jvm_cpu_load{monitored_resource=\"gce_instance\"})\n  )\n)",
-                  "unitOverride": "%"
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
-            }
-          }
-        }
-      },
-      {
-        "yPos": 128,
-        "xPos": 16,
-        "height": 16,
-        "width": 16,
-        "widget": {
-          "title": "Memory % Top 5 VMs",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "prometheusQuery": "topk(5,\n  avg by (project_id, zone, instance_id) (\n    avg_over_time(\n      agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n    )\n  )\n  and on(instance_id, project_id, zone) (\n    workload_googleapis_com:flink_jvm_cpu_load{monitored_resource=\"gce_instance\"}\n  )\n)",
-                  "unitOverride": "%"
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
-            }
-          }
-        }
-      },
-      {
-        "yPos": 128,
-        "xPos": 32,
-        "height": 16,
-        "width": 16,
-        "widget": {
-          "title": "Hosts by Region",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "plotType": "STACKED_AREA",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "prometheusQuery": "count by (region) (\n  label_replace(\n    sum by (project_id, zone, instance_id) (\n      count_over_time(workload_googleapis_com:flink_jvm_cpu_load{monitored_resource=\"gce_instance\"}[2m])\n    ),\n    \"region\",\n    \"$1\",\n    \"zone\",\n    \"([^-]+-[^-]+)-.*\"\n  )\n)",
-                  "unitOverride": ""
-                }
-              }
-            ],
-            "thresholds": [],
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
-            }
-          }
-        }
-      },
-      {
-        "yPos": 144,
-        "height": 16,
-        "width": 16,
-        "widget": {
-          "title": "flink Monitoring Links",
-          "id": "",
-          "text": {
-            "content": "[How to configure flink Monitoring](https://cloud.google.com/monitoring/agent/ops-agent/third-party/flink)\n\n[View Flink Logs](https://console.cloud.google.com/logs/query?query=logName:%22flink%22%0Aresource.type%3D%22gce_instance%22)\n\n",
-            "format": "MARKDOWN",
-            "style": {
-              "backgroundColor": "",
-              "fontSize": "FONT_SIZE_UNSPECIFIED",
-              "horizontalAlignment": "H_LEFT",
-              "padding": "PADDING_SIZE_UNSPECIFIED",
-              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
-              "textColor": "",
-              "verticalAlignment": "V_TOP"
-            }
-          }
-        }
-      }
-    ]
+      ]
+    }
   }
-}

--- a/dashboards/flink/flink-gce-overview.json
+++ b/dashboards/flink/flink-gce-overview.json
@@ -1,880 +1,1091 @@
 {
-    "category": "CUSTOM",
-    "displayName": "Flink GCE Overview",
-    "mosaicLayout": {
-      "columns": 12,
-      "tiles": [
-        {
-          "height": 4,
-          "widget": {
-            "title": "CPU Load",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_NONE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.cpu.load\" resource.type=\"gce_instance\""
-                    },
-                    "unitOverride": "%"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 0,
-          "yPos": 0
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "CPU Time",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_RATE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.cpu.time\" resource.type=\"gce_instance\""
-                    },
-                    "unitOverride": "ns"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 4,
-          "yPos": 0
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Threads",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_NONE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.threads.count\" resource.type=\"gce_instance\""
-                    }
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 8,
-          "yPos": 0
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Heap Used",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_NONE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.heap.used\" resource.type=\"gce_instance\""
-                    },
-                    "unitOverride": "By"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 0,
-          "yPos": 4
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Heap Committed",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_NONE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.heap.committed\" resource.type=\"gce_instance\""
-                    },
-                    "unitOverride": "By"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 4,
-          "yPos": 4
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Heap Max",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_NONE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.heap.max\" resource.type=\"gce_instance\""
-                    },
-                    "unitOverride": "By"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 8,
-          "yPos": 4
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Nonheap Used",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_NONE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.nonheap.used\" resource.type=\"gce_instance\""
-                    },
-                    "unitOverride": "By"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 0,
-          "yPos": 8
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Nonheap Committed",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_NONE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.nonheap.committed\" resource.type=\"gce_instance\""
-                    },
-                    "unitOverride": "By"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 4,
-          "yPos": 8
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Nonheap Max",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_NONE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.nonheap.max\" resource.type=\"gce_instance\""
-                    },
-                    "unitOverride": "By"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 8,
-          "yPos": 8
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Metaspace used",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_NONE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.metaspace.used\" resource.type=\"gce_instance\""
-                    },
-                    "unitOverride": "By"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 0,
-          "yPos": 12
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Metaspace Committed",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_NONE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.metaspace.committed\" resource.type=\"gce_instance\""
-                    },
-                    "unitOverride": "By"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 4,
-          "yPos": 12
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Metaspace Max",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_NONE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.metaspace.max\" resource.type=\"gce_instance\""
-                    },
-                    "unitOverride": "By"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 8,
-          "yPos": 12
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Direct Used",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_NONE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.direct.used\" resource.type=\"gce_instance\""
-                    },
-                    "unitOverride": "By"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 6,
-          "xPos": 0,
-          "yPos": 16
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Direct Total Capacity",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_NONE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.direct.total_capacity\" resource.type=\"gce_instance\""
-                    },
-                    "unitOverride": "By"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 6,
-          "xPos": 6,
-          "yPos": 16
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Mapped used",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_NONE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.mapped.used\" resource.type=\"gce_instance\""
-                    },
-                    "unitOverride": "By"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 6,
-          "xPos": 0,
-          "yPos": 20
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Mapped Total Capacity",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_NONE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.mapped.total_capacity\" resource.type=\"gce_instance\""
-                    },
-                    "unitOverride": "By"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 6,
-          "xPos": 6,
-          "yPos": 20
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Garbage Collector Time",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_RATE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.gc.collections.time\" resource.type=\"gce_instance\""
-                    },
-                    "unitOverride": "ms"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 6,
-          "xPos": 0,
-          "yPos": 24
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Garbage Collector Count",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_RATE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.gc.collections.count\" resource.type=\"gce_instance\""
-                    }
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 6,
-          "xPos": 6,
-          "yPos": 24
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Flink Memory Managed Used",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_NONE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/flink.memory.managed.used\" resource.type=\"gce_instance\""
-                    },
-                    "unitOverride": "By"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 0,
-          "yPos": 28
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Flink Memory Managed Total",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_NONE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/flink.memory.managed.total\" resource.type=\"gce_instance\""
-                    },
-                    "unitOverride": "By"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 4,
-          "yPos": 28
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Class Loader",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "apiSource": "DEFAULT_CLOUD",
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_RATE"
-                      },
-                      "filter": "metric.type=\"workload.googleapis.com/flink.jvm.class_loader.classes_loaded\" resource.type=\"gce_instance\""
-                    }
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 8,
-          "yPos": 28
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "CPU % Top 5 VMs",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "legendTemplate": "${labels.metric\\.instance_name} (${labels.resource\\.zone})",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "def top_5_cpu_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_cpu: metric 'compute.googleapis.com/instance/cpu/utilization'; \n  t_filter_metric: metric $filter_metric }\n  | join\n  | value t_cpu.value.utilization\n  | group_by [resource.project_id, resource.zone, metric.instance_name], 1m,\n      [value_utilization_mean: mean(t_cpu.value.utilization)]\n  | top 5\n  | every 1m;\n\n@top_5_cpu_filtered_by_metric 'workload.googleapis.com/flink.jvm.cpu.load'\n"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 0,
-          "yPos": 32
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Memory % Top 5 VMs",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "legendTemplate": "${labels.metadata\\.system\\.name} (${labels.resource\\.zone})",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "def top_5_memory_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/memory/percent_used'\n        | filter metric.state = 'used'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n  @top_5_memory_filtered_by_metric 'workload.googleapis.com/flink.jvm.cpu.load'"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 4,
-          "yPos": 32
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Hosts by Region",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "legendTemplate": "${labels.region}",
-                  "plotType": "STACKED_AREA",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "def vms_with_metric_count_by_region metric =\n  fetch gce_instance\n  | metric $metric\n  # Shift points forward from the past 2 minutes so a VM that misses a point\n  # won't temporarily shift down the number of VMs.\n  | align next_older(2m)\n  | group_by [resource.project_id, resource.zone, resource.instance_id], 1m, .pick_any\n  | group_by [resource.project_id, resource.zone], 1m, .count\n  | map\n      add[\n        region: re_extract(resource.zone, '([^-]+-[^-]+)-[^-]+', '\\\\1')]\n  | group_by [region], .sum\n  | every 1m;\n\n@vms_with_metric_count_by_region 'workload.googleapis.com/flink.jvm.cpu.load'"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 8,
-          "yPos": 32
-        },
-        {
-          "height": 4,
-          "widget": {
-            "text": {
-              "content": "[How to configure flink Monitoring](https://cloud.google.com/monitoring/agent/ops-agent/third-party/flink)\n\n[View Flink Logs](https://console.cloud.google.com/logs/query?query=logName:%22flink%22%0Aresource.type%3D%22gce_instance%22)\n\n",
-              "format": "MARKDOWN"
+  "displayName": "Flink GCE Overview - PromQL",
+  "dashboardFilters": [],
+  "labels": {},
+  "mosaicLayout": {
+    "columns": 48,
+    "tiles": [
+      {
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "CPU Load",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
-            "title": "flink Monitoring Links"
-          },
-          "width": 4,
-          "xPos": 0,
-          "yPos": 36
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.cpu.load\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
         }
-      ]
-    }
+      },
+      {
+        "xPos": 16,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "CPU Time",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.cpu.time\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "xPos": 32,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "Threads",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.threads.count\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 16,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "Heap Used",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.heap.used\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 16,
+        "xPos": 16,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "Heap Committed",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.heap.committed\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 16,
+        "xPos": 32,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "Heap Max",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.heap.max\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 32,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "Nonheap Used",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.nonheap.used\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 32,
+        "xPos": 16,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "Nonheap Committed",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.nonheap.committed\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 32,
+        "xPos": 32,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "Nonheap Max",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.nonheap.max\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 48,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "Metaspace used",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.metaspace.used\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 48,
+        "xPos": 16,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "Metaspace Committed",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.metaspace.committed\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 48,
+        "xPos": 32,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "Metaspace Max",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.metaspace.max\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 64,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Direct Used",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.direct.used\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 64,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Direct Total Capacity",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.direct.total_capacity\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 80,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Mapped used",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.mapped.used\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 80,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Mapped Total Capacity",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.memory.mapped.total_capacity\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 96,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Garbage Collector Time",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.gc.collections.time\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 96,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Garbage Collector Count",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.gc.collections.count\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 112,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "Flink Memory Managed Used",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/flink.memory.managed.used\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 112,
+        "xPos": 16,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "Flink Memory Managed Total",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/flink.memory.managed.total\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 112,
+        "xPos": 32,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "Class Loader",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/flink.jvm.class_loader.classes_loaded\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 128,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "CPU % Top 5 VMs",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "prometheusQuery": "topk(5, 100 * avg_over_time(compute_googleapis_com:instance_cpu_utilization{monitored_resource=\"gce_instance\"}[30s]))\n  and on(project_id, zone, instance_id)\n  (workload_googleapis_com:flink_jvm_cpu_load{monitored_resource=\"gce_instance\"})",
+                  "unitOverride": "%"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 128,
+        "xPos": 16,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "Memory % Top 5 VMs",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "topk(5, avg_over_time(agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]))\n  and on (name, project_id, zone)\n  (workload_googleapis_com:flink_jvm_cpu_load{monitored_resource=\"gce_instance\"})",
+                  "unitOverride": "%"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 128,
+        "xPos": 32,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "Hosts by Region",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "count by (region) (\n  label_replace(\n    sum by (project_id, zone, instance_id) (\n      count_over_time(workload_googleapis_com:flink_jvm_cpu_load{monitored_resource=\"gce_instance\"}[2m])\n    ),\n    \"region\",\n    \"$1\",\n    \"zone\",\n    \"([^-]+-[^-]+)-.*\"\n  )\n)",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 144,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "flink Monitoring Links",
+          "id": "",
+          "text": {
+            "content": "[How to configure flink Monitoring](https://cloud.google.com/monitoring/agent/ops-agent/third-party/flink)\n\n[View Flink Logs](https://console.cloud.google.com/logs/query?query=logName:%22flink%22%0Aresource.type%3D%22gce_instance%22)\n\n",
+            "format": "MARKDOWN",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "H_LEFT",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "V_TOP"
+            }
+          }
+        }
+      }
+    ]
   }
+}

--- a/dashboards/flink/flink-gce-overview.json
+++ b/dashboards/flink/flink-gce-overview.json
@@ -966,17 +966,24 @@
         "width": 16,
         "widget": {
           "title": "CPU % Top 5 VMs",
+          "id": "",
           "xyChart": {
             "chartOptions": {
               "displayHorizontal": false,
-              "mode": "COLOR"
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "topk(5, 100 * avg_over_time(compute_googleapis_com:instance_cpu_utilization{monitored_resource=\"gce_instance\"}[30s]))\n  and on(project_id, zone, instance_id)\n  (workload_googleapis_com:flink_jvm_cpu_load{monitored_resource=\"gce_instance\"})",
+                  "outputFullDuration": false,
+                  "prometheusQuery": "topk(5, 100 *\n  avg by (project_id, zone, instance_name) (\n    avg_over_time(\n      compute_googleapis_com:instance_cpu_utilization{monitored_resource=\"gce_instance\"}[1m]\n    )\n    and\n    on(instance_id, project_id, zone)\n    (workload_googleapis_com:flink_jvm_cpu_load{monitored_resource=\"gce_instance\"})\n  )\n)",
                   "unitOverride": "%"
                 }
               }
@@ -984,6 +991,7 @@
             "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
@@ -1013,7 +1021,7 @@
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
                   "outputFullDuration": false,
-                  "prometheusQuery": "topk(5, avg_over_time(agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]))\n  and on (name, project_id, zone)\n  (workload_googleapis_com:flink_jvm_cpu_load{monitored_resource=\"gce_instance\"})",
+                  "prometheusQuery": "topk(5,\n  avg by (project_id, zone, instance_id) (\n    avg_over_time(\n      agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n    )\n  )\n  and on(instance_id, project_id, zone) (\n    workload_googleapis_com:flink_jvm_cpu_load{monitored_resource=\"gce_instance\"}\n  )\n)",
                   "unitOverride": "%"
                 }
               }

--- a/dashboards/kafka/kafka-gce-overview.json
+++ b/dashboards/kafka/kafka-gce-overview.json
@@ -1,66 +1,93 @@
 {
-  "displayName": "Kafka GCE Overview",
+  "displayName": "Kafka GCE Overview - PromQL",
+  "dashboardFilters": [],
+  "labels": {},
   "mosaicLayout": {
-    "columns": 12,
+    "columns": 48,
     "tiles": [
       {
-        "height": 4,
+        "height": 16,
+        "width": 24,
         "widget": {
           "title": "Messages",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
                 "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "60s",
+                      "groupByFields": [],
                       "perSeriesAligner": "ALIGN_RATE"
                     },
                     "filter": "metric.type=\"workload.googleapis.com/kafka.message.count\" resource.type=\"gce_instance\"",
                     "secondaryAggregation": {
                       "alignmentPeriod": "60s",
+                      "groupByFields": [],
                       "perSeriesAligner": "ALIGN_MEAN"
                     }
-                  }
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 6
+        }
       },
       {
-        "height": 4,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
         "widget": {
           "title": "Network IO",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
                 "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "60s",
+                      "groupByFields": [],
                       "perSeriesAligner": "ALIGN_RATE"
                     },
                     "filter": "metric.type=\"workload.googleapis.com/kafka.network.io\" resource.type=\"gce_instance\"",
                     "secondaryAggregation": {
                       "alignmentPeriod": "60s",
+                      "groupByFields": [],
                       "perSeriesAligner": "ALIGN_MEAN"
                     }
                   },
@@ -68,370 +95,483 @@
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 6,
-        "xPos": 6
+        }
       },
       {
-        "height": 4,
+        "yPos": 16,
+        "height": 16,
+        "width": 16,
         "widget": {
           "title": "Requests",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
                 "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "60s",
+                      "groupByFields": [],
                       "perSeriesAligner": "ALIGN_RATE"
                     },
                     "filter": "metric.type=\"workload.googleapis.com/kafka.request.count\" resource.type=\"gce_instance\"",
                     "secondaryAggregation": {
                       "alignmentPeriod": "60s",
+                      "groupByFields": [],
                       "perSeriesAligner": "ALIGN_MEAN"
                     }
-                  }
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 4,
-        "yPos": 4
+        }
       },
       {
-        "height": 4,
+        "yPos": 16,
+        "xPos": 16,
+        "height": 16,
+        "width": 16,
         "widget": {
           "title": "Failed Requests",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
                 "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "60s",
+                      "groupByFields": [],
                       "perSeriesAligner": "ALIGN_RATE"
                     },
                     "filter": "metric.type=\"workload.googleapis.com/kafka.request.failed\" resource.type=\"gce_instance\"",
                     "secondaryAggregation": {
                       "alignmentPeriod": "60s",
+                      "groupByFields": [],
                       "perSeriesAligner": "ALIGN_MEAN"
                     }
-                  }
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 4,
-        "xPos": 4,
-        "yPos": 4
+        }
       },
       {
-        "height": 4,
+        "yPos": 16,
+        "xPos": 32,
+        "height": 16,
+        "width": 16,
         "widget": {
           "title": "Purgatory",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
                 "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "60s",
+                      "groupByFields": [],
                       "perSeriesAligner": "ALIGN_MEAN"
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/kafka.purgatory.size\" resource.type=\"gce_instance\"",
-                    "secondaryAggregation": {
-                      "alignmentPeriod": "60s"
-                    }
-                  }
+                    "filter": "metric.type=\"workload.googleapis.com/kafka.purgatory.size\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 4,
-        "xPos": 8,
-        "yPos": 4
+        }
       },
       {
-        "height": 4,
+        "yPos": 32,
+        "height": 16,
+        "width": 16,
         "widget": {
           "title": "Partitions",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
                 "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "60s",
+                      "groupByFields": [],
                       "perSeriesAligner": "ALIGN_MEAN"
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/kafka.partition.count\" resource.type=\"gce_instance\"",
-                    "secondaryAggregation": {
-                      "alignmentPeriod": "60s"
-                    }
-                  }
+                    "filter": "metric.type=\"workload.googleapis.com/kafka.partition.count\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 4,
-        "yPos": 8
+        }
       },
       {
-        "height": 4,
+        "yPos": 32,
+        "xPos": 16,
+        "height": 16,
+        "width": 16,
         "widget": {
           "title": "Offline Partitions",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
                 "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "60s",
+                      "groupByFields": [],
                       "perSeriesAligner": "ALIGN_MEAN"
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/kafka.partition.offline\" resource.type=\"gce_instance\"",
-                    "secondaryAggregation": {
-                      "alignmentPeriod": "60s"
-                    }
-                  }
+                    "filter": "metric.type=\"workload.googleapis.com/kafka.partition.offline\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 4,
-        "xPos": 4,
-        "yPos": 8
+        }
       },
       {
-        "height": 4,
+        "yPos": 32,
+        "xPos": 32,
+        "height": 16,
+        "width": 16,
         "widget": {
           "title": "Under Replicated Partitions",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
                 "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "60s",
+                      "groupByFields": [],
                       "perSeriesAligner": "ALIGN_MEAN"
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/kafka.partition.under_replicated\" resource.type=\"gce_instance\"",
-                    "secondaryAggregation": {
-                      "alignmentPeriod": "60s"
-                    }
-                  }
+                    "filter": "metric.type=\"workload.googleapis.com/kafka.partition.under_replicated\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 4,
-        "xPos": 8,
-        "yPos": 8
+        }
       },
       {
-        "height": 4,
+        "yPos": 48,
+        "height": 16,
+        "width": 16,
         "widget": {
-          "title": "ISR Operations",
+          "title": "CPU % Top 5 VMs",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "topk(5, 100 *\n  avg by (project_id, zone, instance_name) (\n    avg_over_time(\n      compute_googleapis_com:instance_cpu_utilization{monitored_resource=\"gce_instance\"}[1m]\n    )\n    and\n    on(instance_id, project_id, zone)\n    (workload_googleapis_com:kafka_message_count{monitored_resource=\"gce_instance\"})\n  )\n)",
+                  "unitOverride": "%"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 48,
+        "xPos": 16,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "Memory % Top 5 VMs",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "topk(5,\n  avg by (project_id, zone, instance_id) (\n    avg_over_time(\n      agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n    )\n    and on(project_id, zone, instance_id) (\n      workload_googleapis_com:kafka_message_count{monitored_resource=\"gce_instance\"}\n    )\n  )\n)",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 48,
+        "xPos": 32,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "Hosts by Region",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "count by (region) (\n  label_replace(\n    sum by (project_id, zone, instance_id) (\n      count_over_time(workload_googleapis_com:kafka_message_count{monitored_resource=\"gce_instance\"}[2m])\n    ),\n    \"region\",\n    \"$1\",\n    \"zone\",\n    \"([^-]+-[^-]+)-.*\"\n  )\n)",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 64,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "ISR Operations",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
                 "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "60s",
+                      "groupByFields": [],
                       "perSeriesAligner": "ALIGN_RATE"
                     },
                     "filter": "metric.type=\"workload.googleapis.com/kafka.isr.operation.count\" resource.type=\"gce_instance\"",
                     "secondaryAggregation": {
                       "alignmentPeriod": "60s",
+                      "groupByFields": [],
                       "perSeriesAligner": "ALIGN_MEAN"
                     }
-                  }
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 6,
-        "yPos": 16
-      },
-
-      {
-        "height": 4,
-        "widget": {
-          "title": "CPU % Top 5 VMs",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "legendTemplate": "${labels.metric\\.instance_name} (${labels.resource\\.zone})",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "def top_5_cpu_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_cpu: metric 'compute.googleapis.com/instance/cpu/utilization'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value t_cpu.value.utilization\n  | group_by [resource.project_id, resource.zone, metric.instance_name], 1m,\n      [value_utilization_mean: mean(t_cpu.value.utilization)]\n  | top 5\n  | every 1m;\n\n@top_5_cpu_filtered_by_metric 'workload.googleapis.com/kafka.message.count'"
-                }
-              }
-            ],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "scale": "LINEAR"
-            }
-          }
-        },
-        "width": 4,
-        "yPos": 12
+        }
       },
       {
-        "height": 4,
+        "yPos": 64,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
         "widget": {
-          "title": "Memory % Top 5 VMs",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "legendTemplate": "${labels.metadata\\.system\\.name} (${labels.resource\\.zone})",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "def top_5_memory_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/memory/percent_used'\n        | filter metric.state = 'used'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n  @top_5_memory_filtered_by_metric 'workload.googleapis.com/kafka.message.count'"
-                }
-              }
-            ],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "scale": "LINEAR"
-            }
-          }
-        },
-        "width": 4,
-        "xPos": 4,
-        "yPos": 12
-      },
-      {
-        "height": 4,
-        "widget": {
-          "title": "Hosts by Region",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "legendTemplate": "${labels.region}",
-                "plotType": "STACKED_AREA",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "def vms_with_metric_count_by_region metric =\n  fetch gce_instance\n  | metric $metric\n  # Shift points forward from the past 2 minutes so a VM that misses a point\n  # won't temporarily shift down the number of VMs.\n  | align next_older(2m)\n  | group_by [resource.project_id, resource.zone, resource.instance_id], 1m, .pick_any\n  | group_by [resource.project_id, resource.zone], 1m, .count\n  | map\n      add[\n        region: re_extract(resource.zone, '([^-]+-[^-]+)-[^-]+', '\\\\1')]\n  | group_by [region], .sum\n  | every 1m;\n\n@vms_with_metric_count_by_region 'workload.googleapis.com/kafka.message.count'"
-                }
-              }
-            ],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "scale": "LINEAR"
-            }
-          }
-        },
-        "width": 4,
-        "xPos": 8,
-        "yPos": 12
-      },
-      {
-        "height": 4,
-        "widget": {
+          "title": "Kafka Monitoring Links",
+          "id": "",
           "text": {
             "content": "[How to configure Kafka Monitoring](https://cloud.google.com/monitoring/agent/ops-agent/third-party/kafka)\n\n[View Kafka Logs](https://console.cloud.google.com/logs/query?query=logName:%22kafka%22%0Aresource.type%3D%22gce_instance%22)",
-            "format": "MARKDOWN"
-          },
-          "title": "Kafka Monitoring Links"
-        },
-        "width": 6,
-        "xPos": 6,
-        "yPos": 16
+            "format": "MARKDOWN",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "H_LEFT",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "V_TOP"
+            }
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
This PR updates the Apache GCE Overview Dashboard to use PromQL instead of the deprecated MQL.

To prove equivalence, here are screenshots of two different versions of the dashboard over the same time period. The former is the previous version of the dashboard, the latter the updated version of the dashboard.

Before: 
<img width="1654" alt="image" src="https://github.com/user-attachments/assets/dd445c63-fadc-4655-bcbb-90fbcec0af12" />

After: 
<img width="1656" alt="image" src="https://github.com/user-attachments/assets/98331e20-0b66-4fd4-ae0b-94c91ac19b40" />

Conversion Issues:
Small problem converting the Memory % Top 5 VMs panel - the legend is different, since we're using instance_id instead of metadata_system_name. The reason for this is because metadata labels appear to not survive joins in PromQL - not sure if that's a quirk of the language itself or just of GCM, but this seemed the best workaround.