### PR TITLE
PromQL: NGINX

### DIFF
--- a/dashboards/nginx/overview.json
+++ b/dashboards/nginx/overview.json
@@ -1,237 +1,314 @@
 {
-  "displayName": "Nginx Overview",
+  "displayName": "NGINX Overview",
+  "dashboardFilters": [],
+  "labels": {},
   "mosaicLayout": {
-    "columns": 12,
+    "columns": 48,
     "tiles": [
       {
-        "height": 4,
+        "height": 16,
+        "width": 16,
         "widget": {
           "title": "Requests Rate",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
                 "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "60s",
+                      "groupByFields": [],
                       "perSeriesAligner": "ALIGN_RATE"
                     },
                     "filter": "metric.type=\"workload.googleapis.com/nginx.requests\" resource.type=\"gce_instance\"",
                     "secondaryAggregation": {
                       "alignmentPeriod": "60s",
+                      "groupByFields": [],
                       "perSeriesAligner": "ALIGN_MEAN"
                     }
-                  }
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 4
+        }
       },
       {
-        "height": 4,
+        "xPos": 16,
+        "height": 16,
+        "width": 16,
         "widget": {
           "title": "Current Connections",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
                 "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "60s",
+                      "groupByFields": [],
                       "perSeriesAligner": "ALIGN_MEAN"
                     },
                     "filter": "metric.type=\"workload.googleapis.com/nginx.connections_current\" resource.type=\"gce_instance\""
-                  }
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 4,
-        "xPos": 4
+        }
       },
       {
-        "height": 4,
+        "xPos": 32,
+        "height": 16,
+        "width": 16,
         "widget": {
           "title": "Connection Rate",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
                 "legendTemplate": "Accepted ${metadata.system_labels\\.name}",
+                "measures": [],
                 "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
-                   "aggregation": {
-                      "perSeriesAligner": "ALIGN_RATE",
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
                       "crossSeriesReducer": "REDUCE_MEAN",
                       "groupByFields": [
                         "metadata.system_labels.\"name\""
-                      ]
+                      ],
+                      "perSeriesAligner": "ALIGN_RATE"
                     },
                     "filter": "metric.type=\"workload.googleapis.com/nginx.connections_accepted\" resource.type=\"gce_instance\""
-                  }
+                  },
+                  "unitOverride": ""
                 }
               },
               {
+                "breakdowns": [],
+                "dimensions": [],
                 "legendTemplate": "Handled ${metadata.system_labels\\.name}",
+                "measures": [],
                 "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
-                      "perSeriesAligner": "ALIGN_RATE",
+                      "alignmentPeriod": "60s",
                       "crossSeriesReducer": "REDUCE_MEAN",
                       "groupByFields": [
                         "metadata.system_labels.\"name\""
-                      ]
+                      ],
+                      "perSeriesAligner": "ALIGN_RATE"
                     },
                     "filter": "metric.type=\"workload.googleapis.com/nginx.connections_handled\" resource.type=\"gce_instance\""
-                  }
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 4,
-        "xPos": 8
+        }
       },
       {
-        "height": 4,
+        "yPos": 16,
+        "height": 16,
+        "width": 16,
         "widget": {
           "title": "CPU % Top 5 VMs",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
-                "legendTemplate": "${labels.metric\\.instance_name} (${labels.resource\\.zone})",
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch gce_instance\n| { t_cpu:\n      metric 'compute.googleapis.com/instance/cpu/utilization'\n      | align mean_aligner()\n  ; t_filter_metric:\n      metric 'workload.googleapis.com/nginx.requests'\n      | align delta() }\n| join\n| value [t_cpu.value.utilization]\n| group_by [resource.project_id, resource.zone, metric.instance_name], 1m,\n    [value_utilization_mean: mean(t_cpu.value.utilization)]\n| top 5\n| every 1m"
+                  "outputFullDuration": false,
+                  "prometheusQuery": "topk(5, 100 *\n  avg by (project_id, zone, instance_name) (\n    avg_over_time(\n      compute_googleapis_com:instance_cpu_utilization{monitored_resource=\"gce_instance\"}[1m]\n    )\n    and\n    on(instance_id, project_id, zone)\n    (workload_googleapis_com:nginx_requests{monitored_resource=\"gce_instance\"})\n  )\n)",
+                  "unitOverride": "%"
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 4,
-        "yPos": 4
+        }
       },
       {
-        "height": 4,
+        "yPos": 16,
+        "xPos": 16,
+        "height": 16,
+        "width": 16,
         "widget": {
           "title": "Memory % Top 5 VMs",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
-                "legendTemplate": "${labels.metadata\\.system\\.name} (${labels.resource\\.zone})",
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch gce_instance\n| { t_memory:\n      metric 'agent.googleapis.com/memory/percent_used'\n      | filter metric.state = 'used'\n      | align mean_aligner()\n  ; t_filter_metric:\n      metric 'workload.googleapis.com/nginx.requests'\n      | align delta() }\n| join\n| value [t_memory.value.percent_used]\n| group_by\n    [metadata.system.name: metadata.system_labels.name, resource.project_id,\n     resource.zone],\n    1m, [t_memory_value_percent_used_mean: mean(t_memory.value.percent_used)]\n| top 5\n| every 1m"
+                  "outputFullDuration": false,
+                  "prometheusQuery": "topk(5,\n  avg by (project_id, zone, instance_id) (\n    avg_over_time(\n      agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n    )\n    and on(project_id, zone, instance_id) (\n      workload_googleapis_com:nginx_requests{monitored_resource=\"gce_instance\"}\n    )\n  )\n)",
+                  "unitOverride": "%"
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 4,
-        "xPos": 4,
-        "yPos": 4
+        }
       },
       {
-        "height": 4,
+        "yPos": 16,
+        "xPos": 32,
+        "height": 16,
+        "width": 16,
         "widget": {
           "title": "NGINX VMs by Region",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
-                "legendTemplate": "${labels.region}",
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch gce_instance\n| metric 'workload.googleapis.com/nginx.requests'\n| align next_older(2m)\n| group_by [resource.project_id, resource.zone, resource.instance_id], 1m,\n    [value_requests_pick_any: pick_any(value.requests)]\n| group_by [resource.project_id, resource.zone], 1m,\n    [value_requests_pick_any_count: count(value_requests_pick_any)]\n| map add[region: re_extract(resource.zone, '([^-]+-[^-]+)-[^-]+', '\\\\1')]\n| group_by [region],\n    [value_requests_pick_any_count_sum: sum(value_requests_pick_any_count)]\n| every 1m"
+                  "outputFullDuration": false,
+                  "prometheusQuery": "count by (region) (\n  label_replace(\n    sum by (project_id, zone, instance_id) (\n      count_over_time(workload_googleapis_com:nginx_requests{monitored_resource=\"gce_instance\"}[2m])\n    ),\n    \"region\",\n    \"$1\",\n    \"zone\",\n    \"([^-]+-[^-]+)-.*\"\n  )\n)",
+                  "unitOverride": ""
                 }
               }
             ],
-            "timeshiftDuration": "0s",
+            "thresholds": [],
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 4,
-        "xPos": 8,
-        "yPos": 4
+        }
       },
       {
-        "height": 4,
+        "yPos": 32,
+        "height": 16,
+        "width": 24,
         "widget": {
+          "title": "NGINX Access Logs",
+          "id": "",
           "logsPanel": {
-            "filter": "(\n  labels.\"logging.googleapis.com/instrumentation_source\"=\"agent.googleapis.com/nginx_access\"\n  OR log_id(\"nginx_access\")\n)\nresource.type=\"gce_instance\""
-          },
-          "title": "NGINX Access Logs"
-        },
-        "width": 6,
-        "yPos": 8
+            "filter": "(\n  labels.\"logging.googleapis.com/instrumentation_source\"=\"agent.googleapis.com/nginx_access\"\n  OR log_id(\"nginx_access\")\n)\nresource.type=\"gce_instance\"",
+            "resourceNames": []
+          }
+        }
       },
       {
-        "height": 4,
+        "yPos": 32,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
         "widget": {
+          "title": "NGINX Error Logs",
+          "id": "",
           "logsPanel": {
-            "filter": "(\n  labels.\"logging.googleapis.com/instrumentation_source\"=\"agent.googleapis.com/nginx_error\"\n  OR log_id(\"nginx_error\")\n)\nresource.type=\"gce_instance\""
-          },
-          "title": "NGINX Error Logs"
-        },
-        "width": 6,
-        "xPos": 6,
-        "yPos": 8
+            "filter": "(\n  labels.\"logging.googleapis.com/instrumentation_source\"=\"agent.googleapis.com/nginx_error\"\n  OR log_id(\"nginx_error\")\n)\nresource.type=\"gce_instance\"",
+            "resourceNames": []
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
This PR updates the NGINX Overview Dashboard to use PromQL instead of the deprecated MQL.

To prove equivalence, here are screenshots of two different versions of the dashboard over the same time period. The former is the previous version of the dashboard, the latter the updated version of the dashboard.

Before:
<img width="1651" alt="image" src="https://github.com/user-attachments/assets/c570756d-5398-411b-b6d3-ca87d7e46b8d" />

After:
<img width="1654" alt="image" src="https://github.com/user-attachments/assets/e74843c1-6005-416a-80dc-cb321d2e2189" />

Conversion Issues:
Small problem converting the Memory % Top 5 VMs panel - the legend is different, since we're using instance_id instead of metadata_system_name. The reason for this is because metadata labels appear to not survive joins in PromQL - not sure if that's a quirk of the language itself or just of GCM, but this seemed the best workaround.