### PR TITLE
Dashboard Importer - Update max tile count to 99, and move warning message

### DIFF
--- a/scripts/dashboard-importer/dist/common/report.js
+++ b/scripts/dashboard-importer/dist/common/report.js
@@ -69,7 +69,10 @@ function generateWarningSummary(warnings, numPanels) {
         }
         else if (curr.includes('skipped as the maximum number of tiles')) {
             if (!hasMaxTileWarning) {
-                acc.push([`- Cloud Monitoring only supports up to 40 tiles, ${numPanels - constants_1.MAX_TILE_COUNT} tiles have been skipped`, 1]);
+                acc.push([
+                    `- Cloud Monitoring only supports up to ${constants_1.MAX_TILE_COUNT + 1} tiles, ${numPanels - constants_1.MAX_TILE_COUNT} tiles have been skipped`,
+                    1
+                ]);
                 hasMaxTileWarning = true;
             }
         }

--- a/scripts/dashboard-importer/dist/dashboards/converter/converter.js
+++ b/scripts/dashboard-importer/dist/dashboards/converter/converter.js
@@ -67,10 +67,11 @@ class GrafanaDashboardConverter {
     // converts panels to tiles by looping through panels and subpanels
     convertPanel(panel) {
         const targets = panel.targets || [];
-        if (panel.type === 'row') {
-            this.warnings.push(`Panel '${panel.title}': Collapsible groups currently are not yet fully supported. Charts will be unnested`);
-        }
         if (panel.panels && panel.panels.length > 0) {
+            if (panel.type === 'row') {
+                this.warnings.push(`Panel '${panel
+                    .title}': Collapsible groups currently are not yet fully supported. Charts will be unnested`);
+            }
             const panels = panel.panels || [];
             for (const subpanel of panels) {
                 this.convertPanel(subpanel);
@@ -78,7 +79,7 @@ class GrafanaDashboardConverter {
         }
         else {
             const tile = this.constructTile(panel, targets);
-            // Monitoring dashboard API has a hard cap of 40 tiles per dashboard
+            // Monitoring dashboard API has a hard cap of 100 tiles per dashboard
             if (this.tiles.length === constants_1.MAX_TILE_COUNT) {
                 this.warnings.push(`Panel '${panel.title}' was skipped as the maximum number of tiles: ${constants_1.MAX_TILE_COUNT} has been reached`);
             }

--- a/scripts/dashboard-importer/dist/dashboards/converter/layout/constants.js
+++ b/scripts/dashboard-importer/dist/dashboards/converter/layout/constants.js
@@ -22,6 +22,6 @@ exports.DEFAULT_HEIGHT = 3;
 exports.DEFAULT_COLS = 24;
 // Cloud ops tiles must have a height of 2 or more
 exports.MIN_HEIGHT = 2;
-// Maximum number of tiles for cloud ops
-exports.MAX_TILE_COUNT = 39;
+// Maximum number of tiles for cloud ops (-1 for the import info tile)
+exports.MAX_TILE_COUNT = 99;
 //# sourceMappingURL=constants.js.map

--- a/scripts/dashboard-importer/src/common/report.ts
+++ b/scripts/dashboard-importer/src/common/report.ts
@@ -89,7 +89,12 @@ export function generateWarningSummary(warnings: string[], numPanels: number): s
         }
       } else if (curr.includes('skipped as the maximum number of tiles')) {
         if (!hasMaxTileWarning) {
-          acc.push([`- Cloud Monitoring only supports up to 40 tiles, ${numPanels - MAX_TILE_COUNT} tiles have been skipped`, 1]);
+          acc.push([
+            `- Cloud Monitoring only supports up to ${
+                MAX_TILE_COUNT + 1} tiles, ${
+                numPanels - MAX_TILE_COUNT} tiles have been skipped`,
+            1
+          ]);
           hasMaxTileWarning = true;
         }
       } else {

--- a/scripts/dashboard-importer/src/dashboards/converter/converter.ts
+++ b/scripts/dashboard-importer/src/dashboards/converter/converter.ts
@@ -124,19 +124,21 @@ export default class GrafanaDashboardConverter {
   convertPanel(panel: Panel) {
     const targets = panel.targets || [];
 
-    if (panel.type === 'row') {
-      this.warnings.push(
-        `Panel '${panel.title}': Collapsible groups currently are not yet fully supported. Charts will be unnested`,
-      );
-    }
     if (panel.panels && panel.panels.length > 0) {
+      if (panel.type === 'row') {
+        this.warnings.push(
+            `Panel '${
+                panel
+                    .title}': Collapsible groups currently are not yet fully supported. Charts will be unnested`,
+        );
+      }
       const panels = panel.panels || [];
       for (const subpanel of panels) {
         this.convertPanel(subpanel);
       }
     } else {
       const tile = this.constructTile(panel, targets);
-      // Monitoring dashboard API has a hard cap of 40 tiles per dashboard
+      // Monitoring dashboard API has a hard cap of 100 tiles per dashboard
       if (this.tiles.length === MAX_TILE_COUNT) {
         this.warnings.push(
           `Panel '${panel.title}' was skipped as the maximum number of tiles: ${MAX_TILE_COUNT} has been reached`,

--- a/scripts/dashboard-importer/src/dashboards/converter/layout/constants.ts
+++ b/scripts/dashboard-importer/src/dashboards/converter/layout/constants.ts
@@ -23,5 +23,5 @@ export const DEFAULT_COLS = 24;
 // Cloud ops tiles must have a height of 2 or more
 export const MIN_HEIGHT = 2;
 
-// Maximum number of tiles for cloud ops
-export const MAX_TILE_COUNT = 39;
+// Maximum number of tiles for cloud ops (-1 for the import info tile)
+export const MAX_TILE_COUNT = 99;


### PR DESCRIPTION
This change updates the max number of tiles to 100 based on a recent update from MVS
It also moves the warning message for collapsible groups so that it only appears if there are panels.