### PR TITLE
PromQL: Google Cloud SQL

### DIFF
--- a/dashboards/google-cloudsql/cloudsql-general.json
+++ b/dashboards/google-cloudsql/cloudsql-general.json
@@ -1,83 +1,100 @@
 {
+  "displayName": "Cloud SQL - General",
   "dashboardFilters": [
     {
       "filterType": "RESOURCE_LABEL",
-      "labelKey": "region"
+      "labelKey": "region",
+      "templateVariable": "",
+      "valueType": "STRING"
     },
     {
       "filterType": "RESOURCE_LABEL",
-      "labelKey": "project_id"
+      "labelKey": "project_id",
+      "templateVariable": "",
+      "valueType": "STRING"
     },
     {
       "filterType": "RESOURCE_LABEL",
-      "labelKey": "database_id"
+      "labelKey": "database_id",
+      "templateVariable": "",
+      "valueType": "STRING"
     }
   ],
-  "displayName": "Cloud SQL - General",
+  "labels": {},
   "mosaicLayout": {
-    "columns": 12,
+    "columns": 48,
     "tiles": [
       {
-        "height": 4,
-        "widget": {
-          "title": "Replication States",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "minAlignmentPeriod": "60s",
-                "plotType": "STACKED_AREA",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "crossSeriesReducer": "REDUCE_NONE",
-                      "perSeriesAligner": "ALIGN_COUNT_TRUE"
-                    },
-                    "filter": "metric.type=\"cloudsql.googleapis.com/database/replication/state\" resource.type=\"cloudsql_database\"",
-                    "secondaryAggregation": {
-                      "alignmentPeriod": "60s",
-                      "crossSeriesReducer": "REDUCE_SUM",
-                      "groupByFields": [
-                        "metric.label.\"state\""
-                      ],
-                      "perSeriesAligner": "ALIGN_MEAN"
-                    }
-                  }
-                }
-              }
-            ],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "scale": "LINEAR"
-            }
-          }
-        },
-        "width": 6,
-        "xPos": 6,
-        "yPos": 2
-      },
-      {
-        "height": 4,
+        "height": 8,
+        "width": 24,
         "widget": {
           "title": "Instance States",
+          "id": "",
+          "text": {
+            "content": "The below chart gives a count of how many Cloud SQL instances are in each state. ",
+            "format": "RAW",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
+            }
+          }
+        }
+      },
+      {
+        "xPos": 24,
+        "height": 8,
+        "width": 24,
+        "widget": {
+          "title": "Replication States",
+          "id": "",
+          "text": {
+            "content": "The below chart gives a count of how many replications are in each state.",
+            "format": "RAW",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 8,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Instance States",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
                 "minAlignmentPeriod": "60s",
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "60s",
-                      "crossSeriesReducer": "REDUCE_NONE",
+                      "groupByFields": [],
                       "perSeriesAligner": "ALIGN_COUNT_TRUE"
                     },
                     "filter": "metric.type=\"cloudsql.googleapis.com/database/instance_state\" resource.type=\"cloudsql_database\"",
@@ -89,65 +106,239 @@
                       ],
                       "perSeriesAligner": "ALIGN_MEAN"
                     }
-                  }
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 6,
-        "xPos": 0,
-        "yPos": 2
+        }
       },
       {
-        "height": 4,
+        "yPos": 8,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
         "widget": {
-          "logsPanel": {
-            "filter": "resource.type=\"cloudsql_database\"",
-            "resourceNames": []
-          },
-          "title": "All - Cloud SQL Logs"
-        },
-        "width": 4,
-        "xPos": 4,
-        "yPos": 8
+          "title": "Replication States",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_COUNT_TRUE"
+                    },
+                    "filter": "metric.type=\"cloudsql.googleapis.com/database/replication/state\" resource.type=\"cloudsql_database\"",
+                    "secondaryAggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [
+                        "metric.label.\"state\""
+                      ],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
       },
       {
-        "height": 4,
+        "yPos": 24,
+        "height": 8,
+        "width": 16,
         "widget": {
-          "logsPanel": {
-            "filter": "resource.type=\"cloudsql_database\"\nlogName=~\".*cloudsql.googleapis.com.*\"\nseverity>=ERROR",
-            "resourceNames": []
-          },
-          "title": "All - Cloud SQL Database Error Logs"
-        },
-        "width": 4,
-        "xPos": 8,
-        "yPos": 8
+          "title": "Back Up Failure Logs ",
+          "id": "",
+          "text": {
+            "content": "This logs widget shows the logs from when a backup has an error and can't back up.",
+            "format": "RAW",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
+            }
+          }
+        }
       },
       {
-        "height": 4,
+        "yPos": 24,
+        "xPos": 16,
+        "height": 8,
+        "width": 16,
         "widget": {
+          "title": "All - Cloud SQL Logs",
+          "id": "",
+          "text": {
+            "content": "This logs widget shows all the logs relating to Cloud SQL database instances.",
+            "format": "RAW",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 24,
+        "xPos": 32,
+        "height": 8,
+        "width": 16,
+        "widget": {
+          "title": "All - Cloud SQL Database Error Logs",
+          "id": "",
+          "text": {
+            "content": "This logs widget shows all the logs relating to Cloud SQL database instances at the error severity level.",
+            "format": "RAW",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 32,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "Back Up Failure Logs ",
+          "id": "",
           "logsPanel": {
             "filter": "logName=~\"projects/.*/logs/cloudaudit.googleapis.com%2Factivity\"\nprotoPayload.methodName=\"cloudsql.backupRuns.create\"\nseverity=ERROR",
             "resourceNames": []
-          },
-          "title": "Back Up Failure Logs "
-        },
-        "width": 4,
-        "xPos": 0,
-        "yPos": 8
+          }
+        }
       },
       {
-        "height": 4,
+        "yPos": 32,
+        "xPos": 16,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "All - Cloud SQL Logs",
+          "id": "",
+          "logsPanel": {
+            "filter": "resource.type=\"cloudsql_database\"",
+            "resourceNames": []
+          }
+        }
+      },
+      {
+        "yPos": 32,
+        "xPos": 32,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "All - Cloud SQL Database Error Logs",
+          "id": "",
+          "logsPanel": {
+            "filter": "resource.type=\"cloudsql_database\"\nlogName=~\".*cloudsql.googleapis.com.*\"\nseverity>=ERROR",
+            "resourceNames": []
+          }
+        }
+      },
+      {
+        "yPos": 48,
+        "xPos": 16,
+        "height": 8,
+        "width": 16,
+        "widget": {
+          "title": "Top 5 Highest Network Received Bytes",
+          "id": "",
+          "text": {
+            "content": "This chart shows Cloud SQL instances with the top 5 highest throughput received bytes.",
+            "format": "RAW",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 48,
+        "xPos": 32,
+        "height": 8,
+        "width": 16,
+        "widget": {
+          "title": "Top 5 Highest Network Sent Bytes",
+          "id": "",
+          "text": {
+            "content": "This chart shows Cloud SQL instances with the top 5 highest throughput received bytes.",
+            "format": "RAW",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 56,
+        "xPos": 16,
+        "height": 16,
+        "width": 16,
         "widget": {
           "title": "Top 5 Highest Network Received Bytes",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -155,26 +346,29 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch cloudsql_database\n| metric 'cloudsql.googleapis.com/database/network/received_bytes_count'\n| align rate(1m)\n| top 5\n| every 1m\n"
+                  "prometheusQuery": "topk(5, rate(cloudsql_googleapis_com:database_network_received_bytes_count{monitored_resource=\"cloudsql_database\"}[1m]))",
+                  "unitOverride": "By/s"
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 4,
-        "xPos": 4,
-        "yPos": 14
+        }
       },
       {
-        "height": 4,
+        "yPos": 56,
+        "xPos": 32,
+        "height": 16,
+        "width": 16,
         "widget": {
           "title": "Top 5 Highest Network Sent Bytes",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -182,110 +376,18 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch cloudsql_database\n| metric 'cloudsql.googleapis.com/database/network/sent_bytes_count'\n| align rate(1m)\n| top 5\n| every 1m\n"
+                  "prometheusQuery": "topk(5, rate(cloudsql_googleapis_com:database_network_sent_bytes_count{monitored_resource=\"cloudsql_database\"}[1m]))\n",
+                  "unitOverride": "By/s"
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 4,
-        "xPos": 8,
-        "yPos": 14
-      },
-      {
-        "height": 2,
-        "widget": {
-          "text": {
-            "content": "The below chart gives a count of how many Cloud SQL instances are in each state. ",
-            "format": "RAW"
-          },
-          "title": "Instance States"
-        },
-        "width": 6,
-        "xPos": 0,
-        "yPos": 0
-      },
-      {
-        "height": 2,
-        "widget": {
-          "text": {
-            "content": "The below chart gives a count of how many replications are in each state.",
-            "format": "RAW"
-          },
-          "title": "Replication States"
-        },
-        "width": 6,
-        "xPos": 6,
-        "yPos": 0
-      },
-      {
-        "height": 2,
-        "widget": {
-          "text": {
-            "content": "This logs widget shows the logs from when a backup has an error and can't back up.",
-            "format": "RAW"
-          },
-          "title": "Back Up Failure Logs "
-        },
-        "width": 4,
-        "xPos": 0,
-        "yPos": 6
-      },
-      {
-        "height": 2,
-        "widget": {
-          "text": {
-            "content": "This logs widget shows all the logs relating to Cloud SQL database instances.",
-            "format": "RAW"
-          },
-          "title": "All - Cloud SQL Logs"
-        },
-        "width": 4,
-        "xPos": 4,
-        "yPos": 6
-      },
-      {
-        "height": 2,
-        "widget": {
-          "text": {
-            "content": "This logs widget shows all the logs relating to Cloud SQL database instances at the error severity level.",
-            "format": "RAW"
-          },
-          "title": "All - Cloud SQL Database Error Logs"
-        },
-        "width": 4,
-        "xPos": 8,
-        "yPos": 6
-      },
-      {
-        "height": 2,
-        "widget": {
-          "text": {
-            "content": "This chart shows Cloud SQL instances with the top 5 highest throughput received bytes.",
-            "format": "RAW"
-          },
-          "title": "Top 5 Highest Network Received Bytes"
-        },
-        "width": 4,
-        "xPos": 4,
-        "yPos": 12
-      },
-      {
-        "height": 2,
-        "widget": {
-          "text": {
-            "content": "This chart shows Cloud SQL instances with the top 5 highest throughput received bytes.",
-            "format": "RAW"
-          },
-          "title": "Top 5 Highest Network Sent Bytes"
-        },
-        "width": 4,
-        "xPos": 8,
-        "yPos": 12
+        }
       }
     ]
   }

--- a/dashboards/google-cloudsql/cloudsql-replication.json
+++ b/dashboards/google-cloudsql/cloudsql-replication.json
@@ -1,238 +1,307 @@
 {
-    "dashboardFilters": [
-      {
-        "filterType": "RESOURCE_LABEL",
-        "labelKey": "region"
-      },
-      {
-        "filterType": "RESOURCE_LABEL",
-        "labelKey": "database_id"
-      },
-      {
-        "filterType": "RESOURCE_LABEL",
-        "labelKey": "zone"
-      }
-    ],
-    "displayName": "Cloud SQL - Replication",
-    "mosaicLayout": {
-      "columns": 12,
-      "tiles": [
-        {
-          "height": 4,
-          "widget": {
-            "title": "Replication States",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_NONE",
-                        "perSeriesAligner": "ALIGN_COUNT_TRUE"
-                      },
-                      "filter": "metric.type=\"cloudsql.googleapis.com/database/replication/state\" resource.type=\"cloudsql_database\"",
-                      "secondaryAggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_SUM",
-                        "groupByFields": [
-                          "metric.label.\"state\""
-                        ],
-                        "perSeriesAligner": "ALIGN_MEAN"
-                      }
-                    }
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 6,
-          "xPos": 0,
-          "yPos": 2
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Top 5 Replications with Highest CPU Usage",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "def top_5_memory_filtered_by_metric filter_metric =\n  fetch cloudsql_database\n  | { t_memory:\n        metric 'cloudsql.googleapis.com/database/cpu/utilization'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n  @top_5_memory_filtered_by_metric 'cloudsql.googleapis.com/database/replication/state'"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 6,
-          "xPos": 0,
-          "yPos": 8
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Top 5 Replications with Highest Memory Usage",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "def top_5_memory_filtered_by_metric filter_metric =\n  fetch cloudsql_database\n  | { t_memory:\n        metric 'cloudsql.googleapis.com/database/memory/utilization'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id]\n  | top 5\n  | every 1m;\n\n  @top_5_memory_filtered_by_metric 'cloudsql.googleapis.com/database/replication/state'"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 6,
-          "xPos": 6,
-          "yPos": 8
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Top 5 Replications with Highest Replica Lag",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "def top_5_memory_filtered_by_metric filter_metric =\n  fetch cloudsql_database\n  | { t_memory:\n        metric 'cloudsql.googleapis.com/database/replication/replica_lag'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n  @top_5_memory_filtered_by_metric 'cloudsql.googleapis.com/database/replication/state'"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 6,
-          "xPos": 0,
-          "yPos": 14
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Top 5 Replications with Highest Log Archive Failures",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "def top_5_memory_filtered_by_metric filter_metric =\n  fetch cloudsql_database\n  | { t_memory:\n        metric 'cloudsql.googleapis.com/database/replication/log_archive_failure_count'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n  @top_5_memory_filtered_by_metric 'cloudsql.googleapis.com/database/replication/state'"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 6,
-          "xPos": 6,
-          "yPos": 14
-        },
-        {
-          "height": 2,
-          "widget": {
-            "text": {
-              "content": "Count of replications in each state that indicates whether they are running correctly or not.",
-              "format": "RAW"
-            },
-            "title": "Replication States"
-          },
-          "width": 6,
-          "xPos": 0,
-          "yPos": 0
-        },
-        {
-          "height": 2,
-          "widget": {
-            "text": {
-              "content": "Top 5 replication instances with the highest CPU usage that indicates what replications are under the most load.",
-              "format": "RAW"
-            },
-            "title": "Top 5 Replications with Highest CPU Usage"
-          },
-          "width": 6,
-          "xPos": 0,
-          "yPos": 6
-        },
-        {
-          "height": 2,
-          "widget": {
-            "text": {
-              "content": "Top 5 replication instances with the highest memory usage that indicates what replications are under the most load.",
-              "format": "RAW"
-            },
-            "title": "Top 5 Replications with Highest Memory Usage"
-          },
-          "width": 6,
-          "xPos": 6,
-          "yPos": 6
-        },
-        {
-          "height": 2,
-          "widget": {
-            "text": {
-              "content": "Top 5 replicas that are the furthest behind the master node, in seconds.",
-              "format": "RAW"
-            },
-            "title": "Top 5 Replications with Highest Replica Lag"
-          },
-          "width": 6,
-          "xPos": 0,
-          "yPos": 12
-        },
-        {
-          "height": 2,
-          "widget": {
-            "text": {
-              "content": "Top 5 replicas that are the furthest behind the master node, in seconds.",
-              "format": "RAW"
-            },
-            "title": "Top 5 Replications with Highest Log Archive Failures"
-          },
-          "width": 6,
-          "xPos": 6,
-          "yPos": 12
-        }
-      ]
+  "displayName": "Cloud SQL - Replication - PromQL",
+  "dashboardFilters": [
+    {
+      "filterType": "RESOURCE_LABEL",
+      "labelKey": "region",
+      "templateVariable": "",
+      "valueType": "STRING"
+    },
+    {
+      "filterType": "RESOURCE_LABEL",
+      "labelKey": "database_id",
+      "templateVariable": "",
+      "valueType": "STRING"
+    },
+    {
+      "filterType": "RESOURCE_LABEL",
+      "labelKey": "zone",
+      "templateVariable": "",
+      "valueType": "STRING"
     }
+  ],
+  "labels": {},
+  "mosaicLayout": {
+    "columns": 48,
+    "tiles": [
+      {
+        "height": 8,
+        "width": 24,
+        "widget": {
+          "title": "Replication States",
+          "id": "",
+          "text": {
+            "content": "Count of replications in each state that indicates whether they are running correctly or not.",
+            "format": "RAW",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
+            }
+          }
+        }
+      },
+      {
+        "xPos": 24,
+        "height": 8,
+        "width": 24,
+        "widget": {
+          "title": "Top 5 Replications with Highest Memory Usage",
+          "id": "",
+          "text": {
+            "content": "Top 5 replication instances with the highest memory usage that indicates what replications are under the most load.",
+            "format": "RAW",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 8,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Replication States",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_COUNT_TRUE"
+                    },
+                    "filter": "metric.type=\"cloudsql.googleapis.com/database/replication/state\" resource.type=\"cloudsql_database\"",
+                    "secondaryAggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [
+                        "metric.label.\"state\""
+                      ],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 8,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Top 5 Replications with Highest Memory Usage",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "prometheusQuery": "topk(5,\n  label_replace(\n    avg by (project_id, database_id, region) (\n      avg_over_time(\n        cloudsql_googleapis_com:database_memory_utilization{monitored_resource=\"cloudsql_database\"}[1m]\n      )\n      and\n      on(project_id, database_id, region)\n      (\n        cloudsql_googleapis_com:database_replication_state{monitored_resource=\"cloudsql_database\"}\n      )\n    ),\n    \"database_id\", \"$1\", \"database_id\", \".*:(.*)\"\n  )\n)\n\n"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 24,
+        "height": 8,
+        "width": 24,
+        "widget": {
+          "title": "Top 5 Replications with Highest CPU Usage",
+          "id": "",
+          "text": {
+            "content": "Top 5 replication instances with the highest CPU usage that indicates what replications are under the most load.",
+            "format": "RAW",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 24,
+        "xPos": 24,
+        "height": 8,
+        "width": 24,
+        "widget": {
+          "title": "Top 5 Replications with Highest Log Archive Failures",
+          "id": "",
+          "text": {
+            "content": "Top 5 replicas that are the furthest behind the master node, in seconds.",
+            "format": "RAW",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 32,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Top 5 Replications with Highest CPU Usage",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "prometheusQuery": "topk(5,100*\n  label_replace(\n    avg by (project_id, database_id, region) (\n      avg_over_time(\n        cloudsql_googleapis_com:database_cpu_utilization{monitored_resource=\"cloudsql_database\"}[1m]\n      )\n      and on(project_id, database_id, region)\n      (\n        cloudsql_googleapis_com:database_replication_state{monitored_resource=\"cloudsql_database\"}\n      )\n    ),\n    \"database_id\", \"$1\", \"database_id\", \".*:(.*)\"\n  )\n)\n",
+                  "unitOverride": "%"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 32,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Top 5 Replications with Highest Log Archive Failures",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "prometheusQuery": "topk(5,\n  label_replace(\n    avg by (project_id, database_id, region) (\n      avg_over_time(\n        cloudsql_googleapis_com:database_replication_log_archive_failure_count{monitored_resource=\"cloudsql_database\"}[1m]\n      )\n      and on(project_id, database_id, region)\n      (\n        cloudsql_googleapis_com:database_replication_state{monitored_resource=\"cloudsql_database\"}\n      )\n    ),\n    \"database_id\", \"$1\", \"database_id\", \".*:(.*)\"\n  )\n)\n"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 48,
+        "height": 8,
+        "width": 24,
+        "widget": {
+          "title": "Top 5 Replications with Highest Replica Lag",
+          "id": "",
+          "text": {
+            "content": "Top 5 replicas that are the furthest behind the master node, in seconds.",
+            "format": "RAW",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 56,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Top 5 Replications with Highest Replica Lag",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "prometheusQuery": "topk(5,\n  label_replace(\n    avg by (project_id, database_id) (\n      avg_over_time(\n        cloudsql_googleapis_com:database_replication_replica_lag{monitored_resource=\"cloudsql_database\"}[1m]\n      )\n      and on(project_id, database_id)\n      (\n        cloudsql_googleapis_com:database_replication_state{monitored_resource=\"cloudsql_database\"}\n      )\n    ),\n    \"database_id\", \"$1\", \"database_id\", \".*:(.*)\"\n  )\n)\n"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      }
+    ]
   }
+}

--- a/dashboards/google-cloudsql/cloudsql-transactions.json
+++ b/dashboards/google-cloudsql/cloudsql-transactions.json
@@ -1,302 +1,390 @@
 {
-    "dashboardFilters": [
-      {
-        "filterType": "RESOURCE_LABEL",
-        "labelKey": "region"
-      },
-      {
-        "filterType": "RESOURCE_LABEL",
-        "labelKey": "project_id"
-      },
-      {
-        "filterType": "RESOURCE_LABEL",
-        "labelKey": "database_id"
-      }
-    ],
-    "displayName": "Cloud SQL - Transactions",
-    "mosaicLayout": {
-      "columns": 12,
-      "tiles": [
-        {
-          "height": 4,
-          "widget": {
-            "title": "Top 5 Highest Network Received Bytes",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "fetch cloudsql_database\n| metric 'cloudsql.googleapis.com/database/network/received_bytes_count'\n| align rate(1m)\n| top 5\n| every 1m\n"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 6,
-          "xPos": 0,
-          "yPos": 8
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Top 5 Highest Network Sent Bytes",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "fetch cloudsql_database\n| metric 'cloudsql.googleapis.com/database/network/sent_bytes_count'\n| align rate(1m)\n| top 5\n| every 1m\n"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 6,
-          "xPos": 6,
-          "yPos": 8
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "PostgreSQL - Top 5 Highest DB Rows Affected",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "fetch cloudsql_database\n| metric 'cloudsql.googleapis.com/database/postgresql/tuples_processed_count'\n| align rate(1m)\n| group_by[resource.database_id, metric.operation_type]\n| top 5\n| every 1m"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 8,
-          "yPos": 14
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "MySQL/SQL Server - Top 5 Highest Connections",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "fetch cloudsql_database\n| metric 'cloudsql.googleapis.com/database/network/connections'\n| top 5\n| every 1m\n"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 6,
-          "xPos": 6,
-          "yPos": 2
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "PostgreSQL - Top 5 Highest Connections",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "fetch cloudsql_database\n| metric 'cloudsql.googleapis.com/database/postgresql/num_backends'\n| top 5\n| every 1m\n"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 6,
-          "xPos": 0,
-          "yPos": 2
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "PostgreSQL - Top 5 Highest Transactions",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "fetch cloudsql_database\n| metric 'cloudsql.googleapis.com/database/postgresql/transaction_count'\n| align rate(1m)\n| group_by [resource.database_id]\n| top 5\n| every 1m\n"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 4,
-          "yPos": 14
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "MySQL - Top 5 Highest Queries",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "plotType": "LINE",
-                  "targetAxis": "Y1",
-                  "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "fetch cloudsql_database\n| metric 'cloudsql.googleapis.com/database/mysql/queries'\n| align rate(1m)\n| top 5\n| every 1m\n"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 4,
-          "xPos": 0,
-          "yPos": 14
-        },
-        {
-          "height": 2,
-          "widget": {
-            "text": {
-              "content": "The top 5 highest connections on PostgreSQL instances",
-              "format": "RAW"
-            },
-            "title": "PostgreSQL - Top 5 Highest Connections"
-          },
-          "width": 6,
-          "xPos": 0,
-          "yPos": 0
-        },
-        {
-          "height": 2,
-          "widget": {
-            "text": {
-              "content": "The top 5 highest connections on MySQL/SQL Server instances",
-              "format": "RAW"
-            },
-            "title": "MySQL/SQL Server - Top 5 Highest Connections"
-          },
-          "width": 6,
-          "xPos": 6,
-          "yPos": 0
-        },
-        {
-          "height": 2,
-          "widget": {
-            "text": {
-              "content": "The top 5 instances with the highest received bytes.",
-              "format": "RAW"
-            },
-            "title": "Top 5 Highest Network Received Bytes"
-          },
-          "width": 6,
-          "xPos": 0,
-          "yPos": 6
-        },
-        {
-          "height": 2,
-          "widget": {
-            "text": {
-              "content": "The top 5 instances with the highest sent bytes",
-              "format": "RAW"
-            },
-            "title": "Top 5 Highest Network Sent Bytes"
-          },
-          "width": 6,
-          "xPos": 6,
-          "yPos": 6
-        },
-        {
-          "height": 2,
-          "widget": {
-            "text": {
-              "content": "The top 5 PostgreSQL instances with highest number of rows being altered.",
-              "format": "RAW"
-            },
-            "title": "PostgreSQL - Top 5 Highest DB Rows Affected"
-          },
-          "width": 4,
-          "xPos": 8,
-          "yPos": 12
-        },
-        {
-          "height": 2,
-          "widget": {
-            "text": {
-              "content": "The top 5 PostgreSQL instances with the highest transaction count to see which instance has the most activity",
-              "format": "RAW"
-            },
-            "title": "PostgreSQL - Top 5 Highest Transactions"
-          },
-          "width": 4,
-          "xPos": 4,
-          "yPos": 12
-        },
-        {
-          "height": 2,
-          "widget": {
-            "text": {
-              "content": "Top 5 instances that have the highest number of queries executed against the db.",
-              "format": "RAW"
-            },
-            "title": "MySQL - Top 5 Highest Queries"
-          },
-          "width": 4,
-          "xPos": 0,
-          "yPos": 12
-        }
-      ]
+  "displayName": "Cloud SQL - Transactions",
+  "dashboardFilters": [
+    {
+      "filterType": "RESOURCE_LABEL",
+      "labelKey": "region",
+      "templateVariable": "",
+      "valueType": "STRING"
+    },
+    {
+      "filterType": "RESOURCE_LABEL",
+      "labelKey": "project_id",
+      "templateVariable": "",
+      "valueType": "STRING"
+    },
+    {
+      "filterType": "RESOURCE_LABEL",
+      "labelKey": "database_id",
+      "templateVariable": "",
+      "valueType": "STRING"
     }
+  ],
+  "labels": {},
+  "mosaicLayout": {
+    "columns": 48,
+    "tiles": [
+      {
+        "height": 8,
+        "width": 24,
+        "widget": {
+          "title": "PostgreSQL - Top 5 Highest Connections",
+          "id": "",
+          "text": {
+            "content": "The top 5 highest connections on PostgreSQL instances",
+            "format": "RAW",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
+            }
+          }
+        }
+      },
+      {
+        "xPos": 24,
+        "height": 8,
+        "width": 24,
+        "widget": {
+          "title": "MySQL/SQL Server - Top 5 Highest Connections",
+          "id": "",
+          "text": {
+            "content": "The top 5 highest connections on MySQL/SQL Server instances",
+            "format": "RAW",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 8,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "PostgreSQL - Top 5 Highest Connections",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "prometheusQuery": "topk(5, cloudsql_googleapis_com:database_postgresql_num_backends{monitored_resource=\"cloudsql_database\"})\n"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 8,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "MySQL/SQL Server - Top 5 Highest Connections",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "prometheusQuery": "topk(5, cloudsql_googleapis_com:database_network_connections{monitored_resource=\"cloudsql_database\"})\n"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 24,
+        "height": 8,
+        "width": 24,
+        "widget": {
+          "title": "Top 5 Highest Network Received Bytes",
+          "id": "",
+          "text": {
+            "content": "The top 5 instances with the highest received bytes.",
+            "format": "RAW",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 24,
+        "xPos": 24,
+        "height": 8,
+        "width": 24,
+        "widget": {
+          "title": "Top 5 Highest Network Sent Bytes",
+          "id": "",
+          "text": {
+            "content": "The top 5 instances with the highest sent bytes",
+            "format": "RAW",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 32,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Top 5 Highest Network Received Bytes",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "prometheusQuery": "topk(5, rate(cloudsql_googleapis_com:database_network_received_bytes_count{monitored_resource=\"cloudsql_database\"}[1m]))\n",
+                  "unitOverride": "By/s"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 32,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Top 5 Highest Network Sent Bytes",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "prometheusQuery": "topk(5, rate(cloudsql_googleapis_com:database_network_sent_bytes_count{monitored_resource=\"cloudsql_database\"}[1m]))\n",
+                  "unitOverride": "By/s"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 48,
+        "height": 8,
+        "width": 16,
+        "widget": {
+          "title": "MySQL - Top 5 Highest Queries",
+          "id": "",
+          "text": {
+            "content": "Top 5 instances that have the highest number of queries executed against the db.",
+            "format": "RAW",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 48,
+        "xPos": 16,
+        "height": 8,
+        "width": 16,
+        "widget": {
+          "title": "PostgreSQL - Top 5 Highest Transactions",
+          "id": "",
+          "text": {
+            "content": "The top 5 PostgreSQL instances with the highest transaction count to see which instance has the most activity",
+            "format": "RAW",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 48,
+        "xPos": 32,
+        "height": 8,
+        "width": 16,
+        "widget": {
+          "title": "PostgreSQL - Top 5 Highest DB Rows Affected",
+          "id": "",
+          "text": {
+            "content": "The top 5 PostgreSQL instances with highest number of rows being altered.",
+            "format": "RAW",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 56,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "MySQL - Top 5 Highest Queries",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "prometheusQuery": "topk(5, rate(cloudsql_googleapis_com:database_mysql_queries{monitored_resource=\"cloudsql_database\"}[1m]))\n",
+                  "unitOverride": "1/s"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 56,
+        "xPos": 16,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "PostgreSQL - Top 5 Highest Transactions",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "prometheusQuery": "topk(5, sum by (database_id) (\n  rate(cloudsql_googleapis_com:database_postgresql_transaction_count{monitored_resource=\"cloudsql_database\"}[1m])\n))\n",
+                  "unitOverride": "1/s"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 56,
+        "xPos": 32,
+        "height": 16,
+        "width": 16,
+        "widget": {
+          "title": "PostgreSQL - Top 5 Highest DB Rows Affected",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "prometheusQuery": "topk(5, sum by (database_id, operation_type) (\n  rate(cloudsql_googleapis_com:database_postgresql_tuples_processed_count{monitored_resource=\"cloudsql_database\"}[1m])\n))\n",
+                  "unitOverride": "1/s"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      }
+    ]
   }
+}


### PR DESCRIPTION
This PR updates the Google Cloud SQL Dashboards to use PromQL instead of the deprecated MQL.

To prove equivalence*, here are screenshots of two different versions of the dashboards over the same time period. The former is the previous version of the dashboard, the latter the updated version of the dashboards.

General - Before (updated panels only):
![image](https://github.com/user-attachments/assets/cef3ca61-cadf-4a26-a493-eb3db3c58f6a)

General - After (updated panels only):
![image](https://github.com/user-attachments/assets/219eac0f-5405-44d0-b6ca-74b76292871b)

Replication - Before:
![image](https://github.com/user-attachments/assets/3b36f51b-923d-492e-98c3-402e33a27ed5)

Replication - After:
![image](https://github.com/user-attachments/assets/8fc4eab3-109d-4335-a78c-48cd40def41e)

Transactions - Before:
![image](https://github.com/user-attachments/assets/cf7bf20b-368e-4981-a053-168239331a9f)
![image](https://github.com/user-attachments/assets/9f35a9ce-5d89-4511-ac71-31d31f72b381)

Transactions - After:
![image](https://github.com/user-attachments/assets/bdc49b1c-c63b-4032-aa12-29dc219665ee)
![image](https://github.com/user-attachments/assets/65a0eb9c-1522-4176-bb6f-f94c33ede1b9)

*one small exception to equivalence applies, see below.

1) In the Replication dashboard, the "Top 5 Replications with Highest Memory Usage" panel's y-axis scale is different between before and after. This is because there was something of a bug with the old version - basically, the MQL `join` resulted in five identical time series per replica, only differentiated by their `state` label - the PromQL `and on` clause does not result in this same fan out behavior. When these time series were aggregated on a per-replica basis, this resulted in the value being 5x higher than it should have been, unless I'm expected to believe that both of my recently-created replicas were already over 200% CPU usage.
