### PR TITLE
PromQL: GKE Enterprise Cluster CPU

### DIFF
--- a/dashboards/google-kubernetes-engine-enterprise/gke-enterprise-cluster-observability-cpu.json
+++ b/dashboards/google-kubernetes-engine-enterprise/gke-enterprise-cluster-observability-cpu.json
@@ -1,16 +1,18 @@
 {
-  "category": "CUSTOM",
   "displayName": "GKE Enterprise Cluster Observability CPU",
+  "dashboardFilters": [],
+  "labels": {},
   "mosaicLayout": {
     "columns": 48,
     "tiles": [
       {
-        "width": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "CPU Request % Used (Top 5 Clusters)",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -18,14 +20,13 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { { metric kubernetes.io/container/cpu/core_usage_time\n    ; metric kubernetes.io/anthos/container/cpu/core_usage_time }\n    | union\n    | rate\n    | every 1m\n    | align next_older(2m)\n  ; { metric kubernetes.io/container/cpu/request_cores\n    ; metric kubernetes.io/anthos/container/cpu/request_cores }\n    | union\n    | align next_older(2m) }\n| group_by [resource.location, resource.cluster_name], .sum()\n| map\n    update[\n      resource.cluster_name: re_extract(resource.cluster_name, '(?:.+/|^)(.+)')]\n| outer_join 0\n| div\n| top 5\n| scale \"%\"",
-                  "unitOverride": ""
+                  "prometheusQuery": "topk(5, 100 *\n    label_replace(\n        sum by (location, cluster_name) (\n            (\n                rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\"}[1m])\n                or \n                rate(kubernetes_io:anthos_container_cpu_core_usage_time{monitored_resource=\"k8s_container\"}[1m])\n            )\n        )\n        /\n        sum by (location, cluster_name) (\n            (\n                kubernetes_io:container_cpu_request_cores{monitored_resource=\"k8s_container\"}\n                or \n                kubernetes_io:anthos_container_cpu_request_cores{monitored_resource=\"k8s_container\"}\n            )\n        ),\n        \"cluster_name\", \"$1\", \"cluster_name\", \"(?:.+/|^)(.+)\"\n    )\n)",
+                  "unitOverride": "%"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
@@ -33,12 +34,13 @@
       },
       {
         "xPos": 24,
-        "width": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Cores Used (Top 5 Clusters)",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -46,14 +48,12 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { metric kubernetes.io/container/cpu/core_usage_time\n  ; metric kubernetes.io/anthos/container/cpu/core_usage_time }\n| union\n| align rate(1m)\n| every 1m\n| group_by [resource.location, resource.cluster_name], .sum()\n| map\n    update[\n      resource.cluster_name: re_extract(resource.cluster_name, '(?:.+/|^)(.+)')]\n| top 5",
-                  "unitOverride": ""
+                  "prometheusQuery": "topk(5,\n    label_replace(\n            sum by (location, cluster_name) (\n            (\n                rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\"}[1m])\n                or \n                rate(kubernetes_io:anthos_container_cpu_core_usage_time{monitored_resource=\"k8s_container\"}[1m])\n            )\n        ),\n        \"cluster_name\", \"$1\", \"cluster_name\", \"(?:.+/|^)(.+)\"\n    )\n)"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
@@ -61,12 +61,13 @@
       },
       {
         "yPos": 16,
-        "width": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Requested Cores (Top 5 Clusters)",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -74,28 +75,27 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { metric kubernetes.io/container/cpu/request_cores\n  ; metric kubernetes.io/anthos/container/cpu/request_cores }\n| union\n| align next_older(1m)\n| every 1m\n| group_by [resource.location, resource.cluster_name], .sum()\n| map\n    update[\n      resource.cluster_name: re_extract(resource.cluster_name, '(?:.+/|^)(.+)')]\n| top 5",
-                  "unitOverride": ""
+                  "prometheusQuery": "topk(5,\n    label_replace(\n        sum by (location, cluster_name) (\n            (\n                kubernetes_io:container_cpu_request_cores{monitored_resource=\"k8s_container\"}\n                or \n                kubernetes_io:anthos_container_cpu_request_cores{monitored_resource=\"k8s_container\"}\n            )\n        ),\n        \"cluster_name\", \"$1\", \"cluster_name\", \"(?:.+/|^)(.+)\"\n    )\n)"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
         }
       },
       {
-        "xPos": 24,
         "yPos": 16,
-        "width": 24,
+        "xPos": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Requested Cores Unused (Top 5 Clusters)",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -103,14 +103,12 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { { metric kubernetes.io/container/cpu/request_cores\n    ; metric kubernetes.io/anthos/container/cpu/request_cores }\n    | union\n  ; { metric kubernetes.io/container/cpu/core_usage_time\n    ; metric kubernetes.io/anthos/container/cpu/core_usage_time }\n    | union\n    | rate\n    | every 1m }\n| align next_older(2m)\n| group_by [resource.location, resource.cluster_name], .sum()\n| map\n    update[\n      resource.cluster_name: re_extract(resource.cluster_name, '(?:.+/|^)(.+)')]\n| join\n| sub\n| top 5",
-                  "unitOverride": ""
+                  "prometheusQuery": "topk(5,\n    label_replace(\n        sum by (location, cluster_name) (\n            (\n                kubernetes_io:container_cpu_request_cores{monitored_resource=\"k8s_container\"}\n                or \n                kubernetes_io:anthos_container_cpu_request_cores{monitored_resource=\"k8s_container\"}\n            )\n        )\n        -\n        sum by (location, cluster_name) (\n            (\n                rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\"}[1m])\n                or \n                rate(kubernetes_io:anthos_container_cpu_core_usage_time{monitored_resource=\"k8s_container\"}[1m])\n            )\n        ),\n        \"cluster_name\", \"$1\", \"cluster_name\", \"(?:.+/|^)(.+)\"\n    )\n)"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
@@ -118,12 +116,13 @@
       },
       {
         "yPos": 32,
-        "width": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Cluster CPU % Used (Top 5 Clusters)",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -131,28 +130,28 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| { { metric kubernetes.io/node/cpu/core_usage_time\n    ; metric kubernetes.io/anthos/node/cpu/core_usage_time }\n    | union\n    | rate\n    | every 1m\n    | align next_older(2m)\n  ; { metric kubernetes.io/node/cpu/total_cores\n    ; metric kubernetes.io/anthos/node/cpu/total_cores }\n    | union\n    | align next_older(2m) }\n| group_by [resource.location, resource.cluster_name], .sum()\n| map\n    update[\n      resource.cluster_name: re_extract(resource.cluster_name, '(?:.+/|^)(.+)')]\n| join\n| div\n| top 5\n| scale \"%\"",
-                  "unitOverride": ""
+                  "prometheusQuery": "topk(5, 100 *\n    label_replace(\n        sum by (location, cluster_name) (\n            (\n                rate(kubernetes_io:node_cpu_core_usage_time{monitored_resource=\"k8s_node\"}[1m])\n                or \n                rate(kubernetes_io:anthos_node_cpu_core_usage_time{monitored_resource=\"k8s_node\"}[1m])\n            )\n        )\n        /\n        sum by (location, cluster_name) (\n            (\n                kubernetes_io:node_cpu_total_cores{monitored_resource=\"k8s_node\"}\n                or \n                kubernetes_io:anthos_node_cpu_total_cores{monitored_resource=\"k8s_node\"}\n            )\n        ),\n        \"cluster_name\", \"$1\", \"cluster_name\", \"(?:.+/|^)(.+)\"\n    )\n)",
+                  "unitOverride": "%"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
         }
       },
       {
-        "xPos": 24,
         "yPos": 32,
-        "width": 24,
+        "xPos": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Cluster Cores Unused (Top 5 Clusters)",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -160,14 +159,12 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "{ fetch k8s_node\n  | { metric kubernetes.io/node/cpu/total_cores\n      | align next_older(2m)\n    ; metric kubernetes.io/node/cpu/core_usage_time\n      | rate\n      | every 1m\n      | align next_older(2m) }\n  | group_by [resource.location, resource.cluster_name], .sum()\n  | join\n  | sub\n; fetch k8s_node\n  | { metric kubernetes.io/anthos/node/cpu/total_cores\n      | align next_older(2m)\n    ; metric kubernetes.io/anthos/node/cpu/core_usage_time\n      | rate\n      | every 1m\n      | align next_older(2m) }\n  | group_by [resource.location, resource.cluster_name], .sum()\n  | join\n  | sub }\n| union\n| map\n    update[\n      resource.cluster_name: re_extract(resource.cluster_name, '(?:.+/|^)(.+)')]\n| top 5",
-                  "unitOverride": ""
+                  "prometheusQuery": "topk(5,\n    label_replace(\n        (\n            sum by (location, cluster_name) (\n                kubernetes_io:node_cpu_total_cores{monitored_resource=\"k8s_node\"}\n            )\n            -\n            sum by (location, cluster_name) (\n                rate(kubernetes_io:node_cpu_core_usage_time{monitored_resource=\"k8s_node\"}[1m])\n            )\n        )\n        or\n        (\n            sum by (location, cluster_name) (\n                kubernetes_io:anthos_node_cpu_total_cores{monitored_resource=\"k8s_node\"}\n            )\n            -\n            sum by (location, cluster_name) (\n                rate(kubernetes_io:anthos_node_cpu_core_usage_time{monitored_resource=\"k8s_node\"}[1m])\n            )\n        ),\n        \"cluster_name\", \"$1\", \"cluster_name\", \"(?:.+/|^)(.+)\"\n    )\n)"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
@@ -175,12 +172,13 @@
       },
       {
         "yPos": 48,
-        "width": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Cluster CPU % Requested (Top 5 Clusters)",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -188,28 +186,28 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "{ fetch k8s_container\n  | { metric kubernetes.io/container/cpu/request_cores\n    ; metric kubernetes.io/anthos/container/cpu/request_cores }\n  | union\n; fetch k8s_node\n  | { metric kubernetes.io/node/cpu/allocatable_cores\n    ; metric kubernetes.io/anthos/node/cpu/allocatable_cores }\n  | union }\n| align next_older(2m)\n| group_by [resource.location, resource.cluster_name], .sum()\n| map\n    update[\n      resource.cluster_name: re_extract(resource.cluster_name, '(?:.+/|^)(.+)')]\n| join\n| div\n| top 5\n| scale \"%\"",
-                  "unitOverride": ""
+                  "prometheusQuery": "topk(5, 100 *\n    label_replace(\n        sum by (location, cluster_name) (\n            (\n                kubernetes_io:container_cpu_request_cores{monitored_resource=\"k8s_container\"}\n                or \n                kubernetes_io:anthos_container_cpu_request_cores{monitored_resource=\"k8s_container\"}\n            )\n        )\n        /\n        sum by (location, cluster_name) (\n            (\n                kubernetes_io:node_cpu_allocatable_cores{monitored_resource=\"k8s_node\"}\n                or \n                kubernetes_io:anthos_node_cpu_allocatable_cores{monitored_resource=\"k8s_node\"}\n            )\n        ),\n        \"cluster_name\", \"$1\", \"cluster_name\", \"(?:.+/|^)(.+)\"\n    )\n)",
+                  "unitOverride": "%"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
         }
       },
       {
-        "xPos": 24,
         "yPos": 48,
-        "width": 24,
+        "xPos": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Cluster Unrequested Cores (Top 5 Clusters)",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -217,14 +215,12 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| { { metric kubernetes.io/node/cpu/total_cores\n    ; metric kubernetes.io/anthos/node/cpu/total_cores }\n    | union\n    | align next_older(2m)\n  ; { metric kubernetes.io/node/cpu/core_usage_time\n    ; metric kubernetes.io/anthos/node/cpu/core_usage_time }\n    | union\n    | rate\n    | every 1m\n    | align next_older(2m) }\n| group_by [resource.location, resource.cluster_name], .sum()\n| map\n    update[\n      resource.cluster_name: re_extract(resource.cluster_name, '(?:.+/|^)(.+)')]\n| join\n| sub\n| top 5",
-                  "unitOverride": ""
+                  "prometheusQuery": "topk(5,\n    label_replace(\n        sum by (location, cluster_name) (\n            (\n                kubernetes_io:node_cpu_total_cores{monitored_resource=\"k8s_node\"}\n                or \n                kubernetes_io:anthos_node_cpu_total_cores{monitored_resource=\"k8s_node\"}\n            )\n        )\n        -\n        sum by (location, cluster_name) (\n            (\n                rate(kubernetes_io:node_cpu_core_usage_time{monitored_resource=\"k8s_node\"}[1m])\n                or \n                rate(kubernetes_io:anthos_node_cpu_core_usage_time{monitored_resource=\"k8s_node\"}[1m])\n            )\n        ),\n        \"cluster_name\", \"$1\", \"cluster_name\", \"(?:.+/|^)(.+)\"\n    )\n)"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
@@ -232,12 +228,13 @@
       },
       {
         "yPos": 64,
-        "width": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Cluster Total Cores (Top 5 Clusters)",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -245,28 +242,27 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| { metric kubernetes.io/node/cpu/total_cores\n  ; metric kubernetes.io/anthos/node/cpu/total_cores }\n| union\n| align next_older(2m)\n| every 2m\n| group_by [resource.location, resource.cluster_name], .sum()\n| map\n    update[\n      resource.cluster_name: re_extract(resource.cluster_name, '(?:.+/|^)(.+)')]\n| top 5",
-                  "unitOverride": ""
+                  "prometheusQuery": "topk(5,\n    label_replace(\n        sum by (location, cluster_name) (\n            (\n                kubernetes_io:node_cpu_total_cores{monitored_resource=\"k8s_node\"}\n                or \n                kubernetes_io:anthos_node_cpu_total_cores{monitored_resource=\"k8s_node\"}\n            )\n        ),\n        \"cluster_name\", \"$1\", \"cluster_name\", \"(?:.+/|^)(.+)\"\n    )\n)"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
         }
       },
       {
-        "xPos": 24,
         "yPos": 64,
-        "width": 24,
+        "xPos": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Cluster Allocatable Cores (Top 5 Clusters)",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -274,21 +270,17 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| { metric kubernetes.io/node/cpu/allocatable_cores\n  ; metric kubernetes.io/anthos/node/cpu/allocatable_cores }\n| union\n| align next_older(2m)\n| every 2m\n| group_by [resource.location, resource.cluster_name], .sum()\n| map\n    update[\n      resource.cluster_name: re_extract(resource.cluster_name, '(?:.+/|^)(.+)')]\n| top 5",
-                  "unitOverride": ""
+                  "prometheusQuery": "topk(5,\n    label_replace(\n        sum by (location, cluster_name) (\n            (\n                kubernetes_io:node_cpu_allocatable_cores{monitored_resource=\"k8s_node\"}\n                or \n                kubernetes_io:anthos_node_cpu_allocatable_cores{monitored_resource=\"k8s_node\"}\n            )\n        ),\n        \"cluster_name\", \"$1\", \"cluster_name\", \"(?:.+/|^)(.+)\"\n    )\n)"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
         }
       }
     ]
-  },
-  "dashboardFilters": [],
-  "labels": {}
+  }
 }


### PR DESCRIPTION
This PR updates the GKE Enterprise Cluster Observability CPU Dashboard to use PromQL instead of the deprecated MQL.

To prove equivalence, here are screenshots of two different versions of the dashboard over the same time period. The former is the previous version of the dashboard, the latter the updated version of the dashboard.

MQL:
![image](https://github.com/user-attachments/assets/29a334fe-9a84-4ca7-b6f6-217eed07f8ae)
![image](https://github.com/user-attachments/assets/afc77969-331f-4411-b75b-deea7595a2bf)

PromQL:
![image](https://github.com/user-attachments/assets/d63e6ef8-5cf0-4e6f-95ce-6196cc98b720)
![image](https://github.com/user-attachments/assets/477c6748-edc3-46ef-9ea0-60d9a43ef69a)
