### PR TITLE
PromQL: GKE Enterprise Cluster Kubernetes Events

### DIFF
--- a/dashboards/google-kubernetes-engine-enterprise/gke-enterprise-cluster-observability-kubernetes-events.json
+++ b/dashboards/google-kubernetes-engine-enterprise/gke-enterprise-cluster-observability-kubernetes-events.json
@@ -1,15 +1,18 @@
 {
-  "category": "CUSTOM",
   "displayName": "GKE Enterprise Cluster Observability Kubernetes Events",
   "dashboardFilters": [],
+  "labels": {},
   "mosaicLayout": {
     "columns": 48,
     "tiles": [
       {
+        "height": 16,
+        "width": 24,
         "widget": {
           "title": "Container Error Logs/Sec. (Top 5 Clusters)",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -17,22 +20,18 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| metric 'logging.googleapis.com/log_entry_count'\n| filter metric.severity =~ 'ERROR|CRITICAL|ALERT|EMERGENCY'\n| align rate(1m)\n| every 1m\n| group_by [resource.location, resource.cluster_name], .sum()\n| map\n    update[\n      resource.cluster_name:\n        re_extract(resource.cluster_name, '(?:.+/|^)(.+)', '\\\\1')]\n| top 5",
-                  "unitOverride": ""
+                  "prometheusQuery": "topk(5, \n    sum by (location, cluster_name) (\n        rate(logging_googleapis_com:log_entry_count{monitored_resource=\"k8s_container\", severity=\"ERROR\"}[1m])\n        or\n        rate(logging_googleapis_com:log_entry_count{monitored_resource=\"k8s_container\", severity=\"CRITICAL\"}[1m])\n        or\n        rate(logging_googleapis_com:log_entry_count{monitored_resource=\"k8s_container\", severity=\"ALERT\"}[1m])\n        or\n        rate(logging_googleapis_com:log_entry_count{monitored_resource=\"k8s_container\", severity=\"EMERGENCY\"}[1m])\n    )\n)",
+                  "unitOverride": "1/s"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "height": 16,
-        "width": 24
+        }
       }
     ]
-  },
-  "labels": {}
+  }
 }


### PR DESCRIPTION
This PR updates the GKE Enterprise Cluster Observability Kubernetes Events Dashboard to use PromQL instead of the deprecated MQL.

To prove equivalence, here are screenshots of two different versions of the dashboard over the same time period. The former is the previous version of the dashboard, the latter the updated version of the dashboard.

MQL:
![image](https://github.com/user-attachments/assets/f296dd5c-3105-4973-910b-1bafe8d3c18e)

PromQL:
![image](https://github.com/user-attachments/assets/49bd7efb-9935-433e-be33-32ce93977143)
