### PR TITLE
PromQL: GKE Enterprise Cluster Overview

### DIFF
--- a/dashboards/google-kubernetes-engine-enterprise/gke-enterprise-cluster-observability-overview.json
+++ b/dashboards/google-kubernetes-engine-enterprise/gke-enterprise-cluster-observability-overview.json
@@ -10,16 +10,23 @@
         "width": 24,
         "widget": {
           "title": "CPU Request % Used (Top 5 Clusters)",
+          "id": "",
           "xyChart": {
             "chartOptions": {
               "displayHorizontal": false,
-              "mode": "COLOR"
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "prometheusQuery": "topk(5, 100 *\n    label_replace(\n        sum by (location, cluster_name) (\n            rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\"}[1m])\n            or\n            rate(kubernetes_io:anthos_container_cpu_core_usage_time{monitored_resource=\"k8s_container\"}[1m])\n        )\n        /\n        sum by (location, cluster_name) (\n            kubernetes_io:container_cpu_request_cores\n            or\n            kubernetes_io:anthos_container_cpu_request_cores\n        ),\n        \"cluster_name\", \"$1\", \"cluster_name\", \"(?:.+/|^)(.+)\"\n    )\n)",
                   "unitOverride": "%"
                 }
@@ -27,6 +34,7 @@
             ],
             "thresholds": [],
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
@@ -38,16 +46,23 @@
         "width": 24,
         "widget": {
           "title": "Memory Request % Used (Top 5 Clusters)",
+          "id": "",
           "xyChart": {
             "chartOptions": {
               "displayHorizontal": false,
-              "mode": "COLOR"
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "prometheusQuery": "topk(5, 100 *\n    label_replace(\n        sum by (location, cluster_name) (\n            kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\"}\n            or\n            kubernetes_io:anthos_container_memory_used_bytes{monitored_resource=\"k8s_container\"}\n        )\n        /\n        sum by (location, cluster_name) (\n            kubernetes_io:container_memory_request_bytes\n            or\n            kubernetes_io:anthos_container_memory_request_bytes\n        ),\n        \"cluster_name\", \"$1\", \"cluster_name\", \"(?:.+/|^)(.+)\"\n    )\n)",
                   "unitOverride": "%"
                 }
@@ -55,6 +70,7 @@
             ],
             "thresholds": [],
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
@@ -76,7 +92,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "topk(5, \n    label_replace(\n        sum by (location, cluster_name) (\n            increase(kubernetes_io:container_restart_count{monitored_resource=\"k8s_container\", namespace_name=\"default\"}[1m])\n            or\n            increase(kubernetes_io:anthos_container_restart_count{monitored_resource=\"k8s_container\"}[1m])\n        ),\n        \"cluster_name\", \"$1\", \"cluster_name\", \"(?:.+/|^)(.+)\"\n    )\n)"
+                  "prometheusQuery": "topk(5, \n    label_replace(\n        sum by (location, cluster_name) (\n            increase(kubernetes_io:container_restart_count{monitored_resource=\"k8s_container\"}[1m])\n            or\n            increase(kubernetes_io:anthos_container_restart_count{monitored_resource=\"k8s_container\"}[1m])\n        ),\n        \"cluster_name\", \"$1\", \"cluster_name\", \"(?:.+/|^)(.+)\"\n    )\n)"
                 }
               }
             ],
@@ -94,16 +110,23 @@
         "width": 24,
         "widget": {
           "title": "Container Error Logs/Sec. (Top 5 Clusters)",
+          "id": "",
           "xyChart": {
             "chartOptions": {
               "displayHorizontal": false,
-              "mode": "COLOR"
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "prometheusQuery": "topk(5,\n    label_replace(\n        sum by (location, cluster_name) (\n            rate(\n            logging_googleapis_com:log_entry_count{monitored_resource=\"k8s_container\", severity=~\"ERROR|CRITICAL|ALERT|EMERGENCY\"}[1m]\n            )\n        ),\n        \"cluster_name\", \"$1\", \"cluster_name\", \"(?:.+/|^)(.+)\"\n    )\n)",
                   "unitOverride": "1/s"
                 }
@@ -111,6 +134,7 @@
             ],
             "thresholds": [],
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }


### PR DESCRIPTION
This PR updates the GKE Enterprise Cluster Observability Overview Dashboard to use PromQL instead of the deprecated MQL.

To prove equivalence, here are screenshots of two different versions of the dashboard over the same time period. The former is the previous version of the dashboard, the latter the updated version of the dashboard.

MQL:
![image](https://github.com/user-attachments/assets/73779742-3299-46eb-b7c5-f1c1d021cad0)

PromQL:
![image](https://github.com/user-attachments/assets/77142f64-c682-4bd6-aab1-0e2ade426a97)
