### PR TITLE
PromQL: GKE Enterprise Namespace Observability Kubernetes Events

### DIFF
--- a/dashboards/google-kubernetes-engine-enterprise/gke-enterprise-namespace-observability-kubernetes-events.json
+++ b/dashboards/google-kubernetes-engine-enterprise/gke-enterprise-namespace-observability-kubernetes-events.json
@@ -1,15 +1,18 @@
 {
-  "category": "CUSTOM",
   "displayName": "GKE Enterprise Namespace Observability Kubernetes Events",
   "dashboardFilters": [],
+  "labels": {},
   "mosaicLayout": {
     "columns": 48,
     "tiles": [
       {
+        "height": 16,
+        "width": 24,
         "widget": {
           "title": "Container Error Logs/Sec. (Top 5 Namespaces)",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -17,22 +20,18 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| metric logging.googleapis.com/log_entry_count\n| filter metric.severity =~ \"ERROR|CRITICAL|ALERT|EMERGENCY\"\n| align rate(1m)\n| every 1m\n| group_by [resource.namespace_name], .sum()\n| top 5",
-                  "unitOverride": ""
+                  "prometheusQuery": "topk(5,\n  sum by (namespace_name) (\n    rate(logging_googleapis_com:log_entry_count{\n      monitored_resource=\"k8s_container\",\n      severity=~\"ERROR|CRITICAL|ALERT|EMERGENCY\"\n    }[1m])\n  )\n)\n",
+                  "unitOverride": "1/s"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "height": 16,
-        "width": 24
+        }
       }
     ]
-  },
-  "labels": {}
+  }
 }


### PR DESCRIPTION
This PR updates the GKE Enterprise Namespace Observability Kubernetes Events Dashboard to use PromQL instead of the deprecated MQL.

To prove equivalence, here are screenshots of two different versions of the dashboard over the same time period. The former is the previous version of the dashboard, the latter the updated version of the dashboard.

MQL:
![image](https://github.com/user-attachments/assets/47ccb10f-fc6f-494b-886e-df983d4ff881)

PromQL:
![image](https://github.com/user-attachments/assets/aa09ac6b-8c17-4dda-8b84-32f8feb79361)
