### PR TITLE
PromQL: GKE Enterprise Namespace Observability Memory

### DIFF
--- a/dashboards/google-kubernetes-engine-enterprise/gke-enterprise-namespace-observability-memory.json
+++ b/dashboards/google-kubernetes-engine-enterprise/gke-enterprise-namespace-observability-memory.json
@@ -1,15 +1,18 @@
 {
-  "category": "CUSTOM",
   "displayName": "GKE Enterprise Namespace Observability Memory",
   "dashboardFilters": [],
+  "labels": {},
   "mosaicLayout": {
     "columns": 48,
     "tiles": [
       {
+        "height": 16,
+        "width": 24,
         "widget": {
           "title": "Memory Request % Used (Top 5 Namespaces)",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -17,26 +20,27 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { { metric kubernetes.io/container/memory/used_bytes\n    ; metric kubernetes.io/anthos/container/memory/used_bytes }\n    | union\n  ; { metric kubernetes.io/container/memory/request_bytes\n    ; metric kubernetes.io/anthos/container/memory/request_bytes }\n    | union }\n| align next_older(2m)\n| group_by [resource.namespace_name], .sum()\n| outer_join 0\n| div\n| top 5\n| scale \"%\"",
-                  "unitOverride": ""
+                  "prometheusQuery": "topk(5, 100 *\n  (\n    sum by (namespace_name) (\n      kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\"}\n      or\n      kubernetes_io:anthos_container_memory_used_bytes{monitored_resource=\"k8s_container\"}\n    )\n    /\n    (\n      sum by (namespace_name) (\n        kubernetes_io:container_memory_request_bytes{monitored_resource=\"k8s_container\"}\n        or\n        kubernetes_io:anthos_container_memory_request_bytes{monitored_resource=\"k8s_container\"}\n      )\n      and\n      (\n        sum by (namespace_name) (\n          kubernetes_io:container_memory_request_bytes{monitored_resource=\"k8s_container\"}\n          or\n          kubernetes_io:anthos_container_memory_request_bytes{monitored_resource=\"k8s_container\"}\n        ) > 0\n      )\n    )\n  )\n)\n",
+                  "unitOverride": "%"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "height": 16,
-        "width": 24
+        }
       },
       {
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
         "widget": {
           "title": "Memory Used (Top 5 Namespaces)",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -44,27 +48,27 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { metric kubernetes.io/container/memory/used_bytes\n  ; metric kubernetes.io/anthos/container/memory/used_bytes }\n| union\n| align next_older(1m)\n| every 1m\n| group_by [resource.namespace_name], .sum()\n| top 5",
-                  "unitOverride": ""
+                  "prometheusQuery": "topk(5,\n    sum by (namespace_name) (\n        kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\"}\n        or \n        kubernetes_io:anthos_container_memory_used_bytes{monitored_resource=\"k8s_container\"}\n    )\n)",
+                  "unitOverride": "By"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "height": 16,
-        "width": 24,
-        "xPos": 24
+        }
       },
       {
+        "yPos": 16,
+        "height": 16,
+        "width": 24,
         "widget": {
           "title": "Requested Memory (Top 5 Namespaces)",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -72,27 +76,28 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { metric kubernetes.io/container/memory/request_bytes\n  ; metric kubernetes.io/anthos/container/memory/request_bytes }\n| union\n| align next_older(1m)\n| every 1m\n| group_by [resource.namespace_name], .sum()\n| top 5",
-                  "unitOverride": ""
+                  "prometheusQuery": "topk(5,\n    sum by (namespace_name) (\n        kubernetes_io:container_memory_request_bytes{monitored_resource=\"k8s_container\"}\n        or \n        kubernetes_io:anthos_container_memory_request_bytes{monitored_resource=\"k8s_container\"}\n    )\n)",
+                  "unitOverride": "By"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "height": 16,
-        "width": 24,
-        "yPos": 16
+        }
       },
       {
+        "yPos": 16,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
         "widget": {
           "title": "Requested Memory Unused (Top 5 Namespaces)",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -100,24 +105,18 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { { metric kubernetes.io/container/memory/request_bytes\n    ; metric kubernetes.io/anthos/container/memory/request_bytes }\n    | union\n  ; { metric kubernetes.io/container/memory/used_bytes\n    ; metric kubernetes.io/anthos/container/memory/used_bytes }\n    | union }\n| align next_older(2m)\n| group_by [resource.namespace_name], .sum()\n| join\n| sub\n| top 5",
-                  "unitOverride": ""
+                  "prometheusQuery": "topk(5,\n    sum by (namespace_name) (\n        kubernetes_io:container_memory_request_bytes{monitored_resource=\"k8s_container\"}\n        or \n        kubernetes_io:anthos_container_memory_request_bytes{monitored_resource=\"k8s_container\"}\n    )\n    -\n    sum by (namespace_name) (\n        kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\"}\n        or \n        kubernetes_io:anthos_container_memory_used_bytes{monitored_resource=\"k8s_container\"}\n    )\n)",
+                  "unitOverride": "By"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "height": 16,
-        "width": 24,
-        "xPos": 24,
-        "yPos": 16
+        }
       }
     ]
-  },
-  "labels": {}
+  }
 }


### PR DESCRIPTION
This PR updates the GKE Enterprise Namespace Observability Memory Dashboard to use PromQL instead of the deprecated MQL.

To prove equivalence, here are screenshots of two different versions of the dashboard over the same time period. The former is the previous version of the dashboard, the latter the updated version of the dashboard.

MQL:
![image](https://github.com/user-attachments/assets/70b54b5e-c458-4acc-943e-651cb1bcdef9)

PromQL:
![image](https://github.com/user-attachments/assets/bfb8d369-7e5f-4504-927e-9c3c2415c04e)
