### PR TITLE
PromQL: GKE Enterprise Namespace Observability Overview

### DIFF
--- a/dashboards/google-kubernetes-engine-enterprise/gke-enterprise-namespace-observability-overview.json
+++ b/dashboards/google-kubernetes-engine-enterprise/gke-enterprise-namespace-observability-overview.json
@@ -1,15 +1,18 @@
 {
-  "category": "CUSTOM",
   "displayName": "GKE Enterprise Namespace Observability Overview",
   "dashboardFilters": [],
+  "labels": {},
   "mosaicLayout": {
     "columns": 48,
     "tiles": [
       {
+        "height": 16,
+        "width": 24,
         "widget": {
           "title": "CPU Request % Used (Top 5 Namespaces)",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -17,26 +20,27 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { { metric kubernetes.io/container/cpu/core_usage_time\n    ; metric kubernetes.io/anthos/container/cpu/core_usage_time }\n    | union\n    | rate\n    | every 1m\n    | align next_older(2m)\n  ; { metric kubernetes.io/container/cpu/request_cores\n    ; metric kubernetes.io/anthos/container/cpu/request_cores }\n    | union\n    | align next_older(2m) }\n| group_by [resource.namespace_name], .sum()\n| outer_join 0\n| div\n| top 5\n| scale \"%\"",
-                  "unitOverride": ""
+                  "prometheusQuery": "topk(5, 100 *\n  (\n    sum by (namespace_name) (\n      rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\"}[1m])\n      or\n      rate(kubernetes_io:anthos_container_cpu_core_usage_time{monitored_resource=\"k8s_container\"}[1m])\n    )\n    /\n    (\n      sum by (namespace_name) (\n        kubernetes_io:container_cpu_request_cores{monitored_resource=\"k8s_container\"}\n        or\n        kubernetes_io:anthos_container_cpu_request_cores{monitored_resource=\"k8s_container\"}\n      )\n      and\n      (\n        sum by (namespace_name) (\n          kubernetes_io:container_cpu_request_cores{monitored_resource=\"k8s_container\"}\n          or\n          kubernetes_io:anthos_container_cpu_request_cores{monitored_resource=\"k8s_container\"}\n        ) > 0\n      )\n    )\n  )\n)\n",
+                  "unitOverride": "%"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "height": 16,
-        "width": 24
+        }
       },
       {
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
         "widget": {
           "title": "Memory Request % Used (Top 5 Namespaces)",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -44,27 +48,27 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { { metric kubernetes.io/container/memory/used_bytes\n    ; metric kubernetes.io/anthos/container/memory/used_bytes }\n    | union\n  ; { metric kubernetes.io/container/memory/request_bytes\n    ; metric kubernetes.io/anthos/container/memory/request_bytes }\n    | union }\n| align next_older(2m)\n| group_by [resource.namespace_name], .sum()\n| outer_join 0\n| div\n| top 5\n| scale \"%\"",
-                  "unitOverride": ""
+                  "prometheusQuery": "topk(5, 100 *\n  (\n    sum by (namespace_name) (\n      kubernetes_io:container_memory_used_bytes{monitored_resource=\"k8s_container\"}\n      or\n      kubernetes_io:anthos_container_memory_used_bytes{monitored_resource=\"k8s_container\"}\n    )\n    /\n    (\n      sum by (namespace_name) (\n        kubernetes_io:container_memory_request_bytes{monitored_resource=\"k8s_container\"}\n        or\n        kubernetes_io:anthos_container_memory_request_bytes{monitored_resource=\"k8s_container\"}\n      )\n      and\n      (\n        sum by (namespace_name) (\n          kubernetes_io:container_memory_request_bytes{monitored_resource=\"k8s_container\"}\n          or\n          kubernetes_io:anthos_container_memory_request_bytes{monitored_resource=\"k8s_container\"}\n        ) > 0\n      )\n    )\n  )\n)\n",
+                  "unitOverride": "%"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "height": 16,
-        "width": 24,
-        "xPos": 24
+        }
       },
       {
+        "yPos": 16,
+        "height": 16,
+        "width": 24,
         "widget": {
           "title": "Container Restarts/Min. (Top 5 Namespaces)",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -72,27 +76,27 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { metric kubernetes.io/container/restart_count\n  ; metric kubernetes.io/anthos/container/restart_count }\n| union\n| align delta(1m)\n| every 1m\n| group_by [resource.namespace_name], .sum()\n| top 5",
-                  "unitOverride": ""
+                  "prometheusQuery": "topk(5, \n    sum by (namespace_name) (\n        increase(kubernetes_io:container_restart_count{monitored_resource=\"k8s_container\"}[1m])\n        or\n        increase(kubernetes_io:anthos_container_restart_count{monitored_resource=\"k8s_container\"}[1m])\n    )\n)"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "height": 16,
-        "width": 24,
-        "yPos": 16
+        }
       },
       {
+        "yPos": 16,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
         "widget": {
           "title": "Container Error Logs/Sec. (Top 5 Namespaces)",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -100,24 +104,18 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| metric logging.googleapis.com/log_entry_count\n| filter metric.severity =~ \"ERROR|CRITICAL|ALERT|EMERGENCY\"\n| align rate(1m)\n| every 1m\n| group_by [resource.namespace_name], .sum()\n| top 5",
-                  "unitOverride": ""
+                  "prometheusQuery": "topk(5,\n    sum by (namespace_name) (\n        rate(logging_googleapis_com:log_entry_count{monitored_resource=\"k8s_container\", severity=~\"ERROR|CRITICAL|ALERT|EMERGENCY\"}[1m])\n    )\n)",
+                  "unitOverride": "1/s"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "height": 16,
-        "width": 24,
-        "xPos": 24,
-        "yPos": 16
+        }
       }
     ]
-  },
-  "labels": {}
+  }
 }


### PR DESCRIPTION
This PR updates the GKE Enterprise Namespace Observability Overview Dashboard to use PromQL instead of the deprecated MQL.

To prove equivalence, here are screenshots of two different versions of the dashboard over the same time period. The former is the previous version of the dashboard, the latter the updated version of the dashboard.

MQL:
![image](https://github.com/user-attachments/assets/25ade6b4-5256-41e1-9f90-d5176a64b24b)

PromQL:
![image](https://github.com/user-attachments/assets/1ba79ec8-0b55-429a-a44e-8a3e594b2e39)
