### PR TITLE
Hadoop PromQL Migration Proposal

### DIFF
--- a/dashboards/couchbase/gce-overview.json
+++ b/dashboards/couchbase/gce-overview.json
@@ -1,274 +1,372 @@
 {
-    "category": "CUSTOM",
-    "displayName": "Couchbase - GCE Overview",
-    "mosaicLayout": {
-        "columns": 12,
-        "tiles": [
-            {
-                "height": 4,
-                "widget": {
-                    "title": "Bucket Memory Usage",
-                    "xyChart": {
-                        "chartOptions": {
-                            "mode": "COLOR"
-                        },
-                        "dataSets": [
-                            {
-                                "plotType": "LINE",
-                                "targetAxis": "Y1",
-                                "timeSeriesQuery": {
-                                    "timeSeriesQueryLanguage": "fetch gce_instance\n| metric 'workload.googleapis.com/couchbase.bucket.memory.usage'\n| group_by 1m, [value_usage_mean: mean(value.usage)]\n| every 1m\n| cast_units 'By'"
-                                }
-                            }
-                        ],
-                        "timeshiftDuration": "0s",
-                        "yAxis": {
-                            "scale": "LINEAR"
-                        }
-                    }
-                },
-                "width": 6,
-                "xPos": 0,
-                "yPos": 1
-            },
-            {
-                "height": 4,
-                "widget": {
-                    "title": "OOM Errrors",
-                    "xyChart": {
-                        "chartOptions": {
-                            "mode": "COLOR"
-                        },
-                        "dataSets": [
-                            {
-                                "minAlignmentPeriod": "60s",
-                                "plotType": "LINE",
-                                "targetAxis": "Y1",
-                                "timeSeriesQuery": {
-                                    "apiSource": "DEFAULT_CLOUD",
-                                    "timeSeriesFilter": {
-                                        "aggregation": {
-                                            "alignmentPeriod": "60s",
-                                            "crossSeriesReducer": "REDUCE_NONE",
-                                            "perSeriesAligner": "ALIGN_RATE"
-                                        },
-                                        "filter": "metric.type=\"workload.googleapis.com/couchbase.bucket.error.oom.count\" resource.type=\"gce_instance\"",
-                                        "secondaryAggregation": {
-                                            "alignmentPeriod": "60s",
-                                            "crossSeriesReducer": "REDUCE_NONE",
-                                            "perSeriesAligner": "ALIGN_MEAN"
-                                        }
-                                    }
-                                }
-                            }
-                        ],
-                        "timeshiftDuration": "0s",
-                        "yAxis": {
-                            "scale": "LINEAR"
-                        }
-                    }
-                },
-                "width": 6,
-                "xPos": 6,
-                "yPos": 1
-            },
-            {
-                "height": 4,
-                "widget": {
-                    "title": "Operation Count",
-                    "xyChart": {
-                        "chartOptions": {
-                            "mode": "COLOR"
-                        },
-                        "dataSets": [
-                            {
-                                "minAlignmentPeriod": "60s",
-                                "plotType": "LINE",
-                                "targetAxis": "Y1",
-                                "timeSeriesQuery": {
-                                    "apiSource": "DEFAULT_CLOUD",
-                                    "timeSeriesFilter": {
-                                        "aggregation": {
-                                            "alignmentPeriod": "60s",
-                                            "crossSeriesReducer": "REDUCE_NONE",
-                                            "perSeriesAligner": "ALIGN_RATE"
-                                        },
-                                        "filter": "metric.type=\"workload.googleapis.com/couchbase.bucket.operation.count\" resource.type=\"gce_instance\"",
-                                        "secondaryAggregation": {
-                                            "alignmentPeriod": "60s",
-                                            "crossSeriesReducer": "REDUCE_NONE",
-                                            "perSeriesAligner": "ALIGN_MEAN"
-                                        }
-                                    }
-                                }
-                            }
-                        ],
-                        "timeshiftDuration": "0s",
-                        "yAxis": {
-                            "scale": "LINEAR"
-                        }
-                    }
-                },
-                "width": 6,
-                "xPos": 0,
-                "yPos": 5
-            },
-            {
-                "height": 1,
-                "widget": {
-                    "text": {
-                        "content": "",
-                        "format": "RAW"
-                    },
-                    "title": "Bucket Metrics"
-                },
-                "width": 12,
-                "xPos": 0,
-                "yPos": 0
-            },
-            {
-                "height": 1,
-                "widget": {
-                    "text": {
-                        "content": "",
-                        "format": "RAW"
-                    },
-                    "title": "Host Metrics"
-                },
-                "width": 12,
-                "xPos": 0,
-                "yPos": 9
-            },
-            {
-                "height": 4,
-                "widget": {
-                    "title": "Item Count",
-                    "xyChart": {
-                        "chartOptions": {
-                            "mode": "COLOR"
-                        },
-                        "dataSets": [
-                            {
-                                "minAlignmentPeriod": "60s",
-                                "plotType": "LINE",
-                                "targetAxis": "Y1",
-                                "timeSeriesQuery": {
-                                    "apiSource": "DEFAULT_CLOUD",
-                                    "timeSeriesFilter": {
-                                        "aggregation": {
-                                            "alignmentPeriod": "60s",
-                                            "crossSeriesReducer": "REDUCE_NONE",
-                                            "perSeriesAligner": "ALIGN_MEAN"
-                                        },
-                                        "filter": "metric.type=\"workload.googleapis.com/couchbase.bucket.item.count\" resource.type=\"gce_instance\""
-                                    }
-                                }
-                            }
-                        ],
-                        "timeshiftDuration": "0s",
-                        "yAxis": {
-                            "scale": "LINEAR"
-                        }
-                    }
-                },
-                "width": 6,
-                "xPos": 6,
-                "yPos": 5
-            },
-            {
-                "height": 4,
-                "widget": {
-                    "title": "CPU % Top 5 VMs",
-                    "xyChart": {
-                        "chartOptions": {
-                            "mode": "COLOR"
-                        },
-                        "dataSets": [
-                            {
-                                "plotType": "LINE",
-                                "targetAxis": "Y1",
-                                "timeSeriesQuery": {
-                                    "timeSeriesQueryLanguage": "def top_5_cpu_filtered_by_metric  filter_metric =\n  fetch gce_instance\n  | { t_memory: metric 'agent.googleapis.com/cpu/utilization'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n@top_5_cpu_filtered_by_metric 'workload.googleapis.com/couchbase.bucket.item.count'"
-                                }
-                            }
-                        ],
-                        "timeshiftDuration": "0s",
-                        "yAxis": {
-                            "scale": "LINEAR"
-                        }
-                    }
-                },
-                "width": 6,
-                "xPos": 0,
-                "yPos": 10
-            },
-            {
-                "height": 4,
-                "widget": {
-                    "title": "Memory % Top 5 VMs",
-                    "xyChart": {
-                        "chartOptions": {
-                            "mode": "COLOR"
-                        },
-                        "dataSets": [
-                            {
-                                "plotType": "LINE",
-                                "targetAxis": "Y1",
-                                "timeSeriesQuery": {
-                                    "timeSeriesQueryLanguage": "def top_5_memory_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/memory/percent_used'\n        | filter metric.state = 'used'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n  @top_5_memory_filtered_by_metric 'workload.googleapis.com/couchbase.bucket.memory.usage'"
-                                }
-                            }
-                        ],
-                        "timeshiftDuration": "0s",
-                        "yAxis": {
-                            "scale": "LINEAR"
-                        }
-                    }
-                },
-                "width": 6,
-                "xPos": 6,
-                "yPos": 10
-            },
-            {
-                "height": 4,
-                "widget": {
-                    "title": "Hosts By Region",
-                    "xyChart": {
-                        "chartOptions": {
-                            "mode": "COLOR"
-                        },
-                        "dataSets": [
-                            {
-                                "plotType": "STACKED_BAR",
-                                "targetAxis": "Y1",
-                                "timeSeriesQuery": {
-                                    "timeSeriesQueryLanguage": "def vms_with_metric_count_by_region metric =  fetch gce_instance \n | metric $metric\n# Shift points forward from the past 2 minutes so a VM that misses a point  # won't temporarily shift down the number of VMs.\n| align next_older(2m)\n| group_by [resource.project_id, resource.zone, resource.instance_id], 1m, .pick_any  \n| group_by [resource.project_id, resource.zone], 1m, .count\n  | map      add[        region: re_extract(resource.zone, '([^-]+-[^-]+)-[^-]+', '\\\\\\\\1')]  | group_by [region], .sum  | every 1m;\n  \n  @vms_with_metric_count_by_region 'workload.googleapis.com/couchbase.bucket.item.count'"
-                                }
-                            }
-                        ],
-                        "timeshiftDuration": "0s",
-                        "yAxis": {
-                            "scale": "LINEAR"
-                        }
-                    }
-                },
-                "width": 6,
-                "xPos": 0,
-                "yPos": 14
-            },
-            {
-                "height": 4,
-                "widget": {
-                    "text": {
-                        "content": "[Configuring Couchbase Monitoring](https://cloud.google.com/monitoring/agent/ops-agent/third-party/couchbase)\n\n[View Couchbase General Logs](https://console.cloud.google.com/logs/query?query=logName:%22couchbase_general%22%0Aresource.type%3D%22gce_instance%22)\n\n[View Couchbase HTTP Access Logs](https://console.cloud.google.com/logs/query?query=logName:%22couchbase_http_access%22%0Aresource.type%3D%22gce_instance%22)\n\n[View Couchbase Cross Datacenter Logs](https://console.cloud.google.com/logs/query?query=logName:%22couchbase_goxdcr%22%0Aresource.type%3D%22gce_instance%22)",
-                        "format": "MARKDOWN"
-                    },
-                    "title": "Logs"
-                },
-                "width": 6,
-                "xPos": 6,
-                "yPos": 14
+  "displayName": "Couchbase - GCE Overview",
+  "dashboardFilters": [],
+  "labels": {},
+  "mosaicLayout": {
+    "columns": 12,
+    "tiles": [
+      {
+        "height": 1,
+        "width": 12,
+        "widget": {
+          "title": "Bucket Metrics",
+          "id": "",
+          "text": {
+            "content": "",
+            "format": "RAW",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
             }
-        ]
-    }
+          }
+        }
+      },
+      {
+        "yPos": 1,
+        "height": 4,
+        "width": 6,
+        "widget": {
+          "title": "Bucket Memory Usage",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesQueryLanguage": "fetch gce_instance\n| metric 'workload.googleapis.com/couchbase.bucket.memory.usage'\n| group_by 1m, [value_usage_mean: mean(value.usage)]\n| every 1m\n| cast_units 'By'",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 1,
+        "xPos": 6,
+        "height": 4,
+        "width": 6,
+        "widget": {
+          "title": "OOM Errrors",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/couchbase.bucket.error.oom.count\" resource.type=\"gce_instance\"",
+                    "secondaryAggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 5,
+        "height": 4,
+        "width": 6,
+        "widget": {
+          "title": "Operation Count",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/couchbase.bucket.operation.count\" resource.type=\"gce_instance\"",
+                    "secondaryAggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    }
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 5,
+        "xPos": 6,
+        "height": 4,
+        "width": 6,
+        "widget": {
+          "title": "Item Count",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/couchbase.bucket.item.count\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 9,
+        "height": 1,
+        "width": 12,
+        "widget": {
+          "title": "Host Metrics",
+          "id": "",
+          "text": {
+            "content": "",
+            "format": "RAW",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 10,
+        "height": 4,
+        "width": 6,
+        "widget": {
+          "title": "CPU % Top 5 VMs",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesQueryLanguage": "def top_5_cpu_filtered_by_metric  filter_metric =\n  fetch gce_instance\n  | { t_memory: metric 'agent.googleapis.com/cpu/utilization'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n@top_5_cpu_filtered_by_metric 'workload.googleapis.com/couchbase.bucket.item.count'",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 10,
+        "xPos": 6,
+        "height": 4,
+        "width": 6,
+        "widget": {
+          "title": "Memory % Top 5 VMs",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesQueryLanguage": "def top_5_memory_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/memory/percent_used'\n        | filter metric.state = 'used'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n  @top_5_memory_filtered_by_metric 'workload.googleapis.com/couchbase.bucket.memory.usage'",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 14,
+        "height": 4,
+        "width": 6,
+        "widget": {
+          "title": "Hosts By Region",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "plotType": "STACKED_BAR",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesQueryLanguage": "def vms_with_metric_count_by_region metric =  fetch gce_instance \n | metric $metric\n# Shift points forward from the past 2 minutes so a VM that misses a point  # won't temporarily shift down the number of VMs.\n| align next_older(2m)\n| group_by [resource.project_id, resource.zone, resource.instance_id], 1m, .pick_any  \n| group_by [resource.project_id, resource.zone], 1m, .count\n  | map      add[        region: re_extract(resource.zone, '([^-]+-[^-]+)-[^-]+', '\\\\\\\\1')]  | group_by [region], .sum  | every 1m;\n  \n  @vms_with_metric_count_by_region 'workload.googleapis.com/couchbase.bucket.item.count'",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 14,
+        "xPos": 6,
+        "height": 4,
+        "width": 6,
+        "widget": {
+          "title": "Logs",
+          "id": "",
+          "text": {
+            "content": "[Configuring Couchbase Monitoring](https://cloud.google.com/monitoring/agent/ops-agent/third-party/couchbase)\n\n[View Couchbase General Logs](https://console.cloud.google.com/logs/query?query=logName:%22couchbase_general%22%0Aresource.type%3D%22gce_instance%22)\n\n[View Couchbase HTTP Access Logs](https://console.cloud.google.com/logs/query?query=logName:%22couchbase_http_access%22%0Aresource.type%3D%22gce_instance%22)\n\n[View Couchbase Cross Datacenter Logs](https://console.cloud.google.com/logs/query?query=logName:%22couchbase_goxdcr%22%0Aresource.type%3D%22gce_instance%22)",
+            "format": "MARKDOWN",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
+            }
+          }
+        }
+      }
+    ]
+  }
 }

--- a/dashboards/couchbase/gce-overview.json
+++ b/dashboards/couchbase/gce-overview.json
@@ -1,355 +1,274 @@
 {
-  "displayName": "Couchbase - GCE Overview",
-  "dashboardFilters": [],
-  "labels": {},
-  "mosaicLayout": {
-    "columns": 12,
-    "tiles": [
-      {
-        "height": 1,
-        "width": 12,
-        "widget": {
-          "title": "Bucket Metrics",
-          "id": "",
-          "text": {
-            "content": "",
-            "format": "RAW",
-            "style": {
-              "backgroundColor": "",
-              "fontSize": "FONT_SIZE_UNSPECIFIED",
-              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
-              "padding": "PADDING_SIZE_UNSPECIFIED",
-              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
-              "textColor": "",
-              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
-            }
-          }
-        }
-      },
-      {
-        "yPos": 1,
-        "height": 4,
-        "width": 6,
-        "widget": {
-          "title": "Bucket Memory Usage",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "prometheusQuery": "sum by (zone, instance_id) (avg_over_time(workload_googleapis_com:couchbase_bucket_memory_usage{monitored_resource=\"gce_instance\"}[1m]))",
-                  "unitOverride": "By"
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
-            }
-          }
-        }
-      },
-      {
-        "yPos": 1,
-        "xPos": 6,
-        "height": 4,
-        "width": 6,
-        "widget": {
-          "title": "OOM Errrors",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_RATE"
-                    },
-                    "filter": "metric.type=\"workload.googleapis.com/couchbase.bucket.error.oom.count\" resource.type=\"gce_instance\"",
-                    "secondaryAggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_MEAN"
+    "category": "CUSTOM",
+    "displayName": "Couchbase - GCE Overview",
+    "mosaicLayout": {
+        "columns": 12,
+        "tiles": [
+            {
+                "height": 4,
+                "widget": {
+                    "title": "Bucket Memory Usage",
+                    "xyChart": {
+                        "chartOptions": {
+                            "mode": "COLOR"
+                        },
+                        "dataSets": [
+                            {
+                                "plotType": "LINE",
+                                "targetAxis": "Y1",
+                                "timeSeriesQuery": {
+                                    "timeSeriesQueryLanguage": "fetch gce_instance\n| metric 'workload.googleapis.com/couchbase.bucket.memory.usage'\n| group_by 1m, [value_usage_mean: mean(value.usage)]\n| every 1m\n| cast_units 'By'"
+                                }
+                            }
+                        ],
+                        "timeshiftDuration": "0s",
+                        "yAxis": {
+                            "scale": "LINEAR"
+                        }
                     }
-                  },
-                  "unitOverride": ""
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
-            }
-          }
-        }
-      },
-      {
-        "yPos": 5,
-        "height": 4,
-        "width": 6,
-        "widget": {
-          "title": "Operation Count",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
+                },
+                "width": 6,
+                "xPos": 0,
+                "yPos": 1
             },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_RATE"
-                    },
-                    "filter": "metric.type=\"workload.googleapis.com/couchbase.bucket.operation.count\" resource.type=\"gce_instance\"",
-                    "secondaryAggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_MEAN"
+            {
+                "height": 4,
+                "widget": {
+                    "title": "OOM Errrors",
+                    "xyChart": {
+                        "chartOptions": {
+                            "mode": "COLOR"
+                        },
+                        "dataSets": [
+                            {
+                                "minAlignmentPeriod": "60s",
+                                "plotType": "LINE",
+                                "targetAxis": "Y1",
+                                "timeSeriesQuery": {
+                                    "apiSource": "DEFAULT_CLOUD",
+                                    "timeSeriesFilter": {
+                                        "aggregation": {
+                                            "alignmentPeriod": "60s",
+                                            "crossSeriesReducer": "REDUCE_NONE",
+                                            "perSeriesAligner": "ALIGN_RATE"
+                                        },
+                                        "filter": "metric.type=\"workload.googleapis.com/couchbase.bucket.error.oom.count\" resource.type=\"gce_instance\"",
+                                        "secondaryAggregation": {
+                                            "alignmentPeriod": "60s",
+                                            "crossSeriesReducer": "REDUCE_NONE",
+                                            "perSeriesAligner": "ALIGN_MEAN"
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "timeshiftDuration": "0s",
+                        "yAxis": {
+                            "scale": "LINEAR"
+                        }
                     }
-                  },
-                  "unitOverride": ""
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
-            }
-          }
-        }
-      },
-      {
-        "yPos": 5,
-        "xPos": 6,
-        "height": 4,
-        "width": 6,
-        "widget": {
-          "title": "Item Count",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
+                },
+                "width": 6,
+                "xPos": 6,
+                "yPos": 1
             },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "groupByFields": [],
-                      "perSeriesAligner": "ALIGN_MEAN"
+            {
+                "height": 4,
+                "widget": {
+                    "title": "Operation Count",
+                    "xyChart": {
+                        "chartOptions": {
+                            "mode": "COLOR"
+                        },
+                        "dataSets": [
+                            {
+                                "minAlignmentPeriod": "60s",
+                                "plotType": "LINE",
+                                "targetAxis": "Y1",
+                                "timeSeriesQuery": {
+                                    "apiSource": "DEFAULT_CLOUD",
+                                    "timeSeriesFilter": {
+                                        "aggregation": {
+                                            "alignmentPeriod": "60s",
+                                            "crossSeriesReducer": "REDUCE_NONE",
+                                            "perSeriesAligner": "ALIGN_RATE"
+                                        },
+                                        "filter": "metric.type=\"workload.googleapis.com/couchbase.bucket.operation.count\" resource.type=\"gce_instance\"",
+                                        "secondaryAggregation": {
+                                            "alignmentPeriod": "60s",
+                                            "crossSeriesReducer": "REDUCE_NONE",
+                                            "perSeriesAligner": "ALIGN_MEAN"
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "timeshiftDuration": "0s",
+                        "yAxis": {
+                            "scale": "LINEAR"
+                        }
+                    }
+                },
+                "width": 6,
+                "xPos": 0,
+                "yPos": 5
+            },
+            {
+                "height": 1,
+                "widget": {
+                    "text": {
+                        "content": "",
+                        "format": "RAW"
                     },
-                    "filter": "metric.type=\"workload.googleapis.com/couchbase.bucket.item.count\" resource.type=\"gce_instance\""
-                  },
-                  "unitOverride": ""
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
-            }
-          }
-        }
-      },
-      {
-        "yPos": 9,
-        "height": 1,
-        "width": 12,
-        "widget": {
-          "title": "Host Metrics",
-          "id": "",
-          "text": {
-            "content": "",
-            "format": "RAW",
-            "style": {
-              "backgroundColor": "",
-              "fontSize": "FONT_SIZE_UNSPECIFIED",
-              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
-              "padding": "PADDING_SIZE_UNSPECIFIED",
-              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
-              "textColor": "",
-              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
-            }
-          }
-        }
-      },
-      {
-        "yPos": 10,
-        "height": 4,
-        "width": 6,
-        "widget": {
-          "title": "VMs CPU %",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR"
+                    "title": "Bucket Metrics"
+                },
+                "width": 12,
+                "xPos": 0,
+                "yPos": 0
             },
-            "dataSets": [
-              {
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "prometheusQuery": "avg by (project_id, zone, instance_id) (\n  avg_over_time(\n    agent_googleapis_com:cpu_utilization{monitored_resource=\"gce_instance\"}[1m]\n  )\n  and\n  on(project_id, zone, instance_id)\n  (workload_googleapis_com:couchbase_bucket_item_count{monitored_resource=\"gce_instance\"})\n)",
-                  "unitOverride": "%"
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "scale": "LINEAR"
-            }
-          }
-        }
-      },
-      {
-        "yPos": 10,
-        "xPos": 6,
-        "height": 4,
-        "width": 6,
-        "widget": {
-          "title": "VMs Memory %",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR"
+            {
+                "height": 1,
+                "widget": {
+                    "text": {
+                        "content": "",
+                        "format": "RAW"
+                    },
+                    "title": "Host Metrics"
+                },
+                "width": 12,
+                "xPos": 0,
+                "yPos": 9
             },
-            "dataSets": [
-              {
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "prometheusQuery": "avg by (project_id, zone, instance_id) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n  and on(project_id, zone, instance_id) (\n    workload_googleapis_com:couchbase_bucket_memory_usage{monitored_resource=\"gce_instance\"}\n  )\n)",
-                  "unitOverride": "%"
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "scale": "LINEAR"
-            }
-          }
-        }
-      },
-      {
-        "yPos": 14,
-        "height": 4,
-        "width": 6,
-        "widget": {
-          "title": "Hosts By Region",
-          "id": "",
-          "xyChart": {
-            "chartOptions": {
-              "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
+            {
+                "height": 4,
+                "widget": {
+                    "title": "Item Count",
+                    "xyChart": {
+                        "chartOptions": {
+                            "mode": "COLOR"
+                        },
+                        "dataSets": [
+                            {
+                                "minAlignmentPeriod": "60s",
+                                "plotType": "LINE",
+                                "targetAxis": "Y1",
+                                "timeSeriesQuery": {
+                                    "apiSource": "DEFAULT_CLOUD",
+                                    "timeSeriesFilter": {
+                                        "aggregation": {
+                                            "alignmentPeriod": "60s",
+                                            "crossSeriesReducer": "REDUCE_NONE",
+                                            "perSeriesAligner": "ALIGN_MEAN"
+                                        },
+                                        "filter": "metric.type=\"workload.googleapis.com/couchbase.bucket.item.count\" resource.type=\"gce_instance\""
+                                    }
+                                }
+                            }
+                        ],
+                        "timeshiftDuration": "0s",
+                        "yAxis": {
+                            "scale": "LINEAR"
+                        }
+                    }
+                },
+                "width": 6,
+                "xPos": 6,
+                "yPos": 5
             },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
-                "plotType": "STACKED_BAR",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "prometheusQuery": "avg_over_time(\n  (count by (region) (\n    label_replace(\n      sum by (project_id, zone, instance_id) (\n        workload_googleapis_com:couchbase_bucket_item_count{monitored_resource=\"gce_instance\"}\n      ),\n      \"region\", \"$1\", \"zone\", \"([^-]+-[^-]+)-[^-]+\"\n    )\n  ))[${__interval}:]\n)",
-                  "unitOverride": ""
-                }
-              }
-            ],
-            "thresholds": [],
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
+            {
+                "height": 4,
+                "widget": {
+                    "title": "CPU % Top 5 VMs",
+                    "xyChart": {
+                        "chartOptions": {
+                            "mode": "COLOR"
+                        },
+                        "dataSets": [
+                            {
+                                "plotType": "LINE",
+                                "targetAxis": "Y1",
+                                "timeSeriesQuery": {
+                                    "timeSeriesQueryLanguage": "def top_5_cpu_filtered_by_metric  filter_metric =\n  fetch gce_instance\n  | { t_memory: metric 'agent.googleapis.com/cpu/utilization'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n@top_5_cpu_filtered_by_metric 'workload.googleapis.com/couchbase.bucket.item.count'"
+                                }
+                            }
+                        ],
+                        "timeshiftDuration": "0s",
+                        "yAxis": {
+                            "scale": "LINEAR"
+                        }
+                    }
+                },
+                "width": 6,
+                "xPos": 0,
+                "yPos": 10
+            },
+            {
+                "height": 4,
+                "widget": {
+                    "title": "Memory % Top 5 VMs",
+                    "xyChart": {
+                        "chartOptions": {
+                            "mode": "COLOR"
+                        },
+                        "dataSets": [
+                            {
+                                "plotType": "LINE",
+                                "targetAxis": "Y1",
+                                "timeSeriesQuery": {
+                                    "timeSeriesQueryLanguage": "def top_5_memory_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/memory/percent_used'\n        | filter metric.state = 'used'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n  @top_5_memory_filtered_by_metric 'workload.googleapis.com/couchbase.bucket.memory.usage'"
+                                }
+                            }
+                        ],
+                        "timeshiftDuration": "0s",
+                        "yAxis": {
+                            "scale": "LINEAR"
+                        }
+                    }
+                },
+                "width": 6,
+                "xPos": 6,
+                "yPos": 10
+            },
+            {
+                "height": 4,
+                "widget": {
+                    "title": "Hosts By Region",
+                    "xyChart": {
+                        "chartOptions": {
+                            "mode": "COLOR"
+                        },
+                        "dataSets": [
+                            {
+                                "plotType": "STACKED_BAR",
+                                "targetAxis": "Y1",
+                                "timeSeriesQuery": {
+                                    "timeSeriesQueryLanguage": "def vms_with_metric_count_by_region metric =  fetch gce_instance \n | metric $metric\n# Shift points forward from the past 2 minutes so a VM that misses a point  # won't temporarily shift down the number of VMs.\n| align next_older(2m)\n| group_by [resource.project_id, resource.zone, resource.instance_id], 1m, .pick_any  \n| group_by [resource.project_id, resource.zone], 1m, .count\n  | map      add[        region: re_extract(resource.zone, '([^-]+-[^-]+)-[^-]+', '\\\\\\\\1')]  | group_by [region], .sum  | every 1m;\n  \n  @vms_with_metric_count_by_region 'workload.googleapis.com/couchbase.bucket.item.count'"
+                                }
+                            }
+                        ],
+                        "timeshiftDuration": "0s",
+                        "yAxis": {
+                            "scale": "LINEAR"
+                        }
+                    }
+                },
+                "width": 6,
+                "xPos": 0,
+                "yPos": 14
+            },
+            {
+                "height": 4,
+                "widget": {
+                    "text": {
+                        "content": "[Configuring Couchbase Monitoring](https://cloud.google.com/monitoring/agent/ops-agent/third-party/couchbase)\n\n[View Couchbase General Logs](https://console.cloud.google.com/logs/query?query=logName:%22couchbase_general%22%0Aresource.type%3D%22gce_instance%22)\n\n[View Couchbase HTTP Access Logs](https://console.cloud.google.com/logs/query?query=logName:%22couchbase_http_access%22%0Aresource.type%3D%22gce_instance%22)\n\n[View Couchbase Cross Datacenter Logs](https://console.cloud.google.com/logs/query?query=logName:%22couchbase_goxdcr%22%0Aresource.type%3D%22gce_instance%22)",
+                        "format": "MARKDOWN"
+                    },
+                    "title": "Logs"
+                },
+                "width": 6,
+                "xPos": 6,
+                "yPos": 14
             }
-          }
-        }
-      },
-      {
-        "yPos": 14,
-        "xPos": 6,
-        "height": 4,
-        "width": 6,
-        "widget": {
-          "title": "Logs",
-          "id": "",
-          "text": {
-            "content": "[Configuring Couchbase Monitoring](https://cloud.google.com/monitoring/agent/ops-agent/third-party/couchbase)\n\n[View Couchbase General Logs](https://console.cloud.google.com/logs/query?query=logName:%22couchbase_general%22%0Aresource.type%3D%22gce_instance%22)\n\n[View Couchbase HTTP Access Logs](https://console.cloud.google.com/logs/query?query=logName:%22couchbase_http_access%22%0Aresource.type%3D%22gce_instance%22)\n\n[View Couchbase Cross Datacenter Logs](https://console.cloud.google.com/logs/query?query=logName:%22couchbase_goxdcr%22%0Aresource.type%3D%22gce_instance%22)",
-            "format": "MARKDOWN",
-            "style": {
-              "backgroundColor": "",
-              "fontSize": "FONT_SIZE_UNSPECIFIED",
-              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
-              "padding": "PADDING_SIZE_UNSPECIFIED",
-              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
-              "textColor": "",
-              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
-            }
-          }
-        }
-      }
-    ]
-  }
+        ]
+    }
 }

--- a/dashboards/couchbase/gce-overview.json
+++ b/dashboards/couchbase/gce-overview.json
@@ -49,8 +49,8 @@
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
                   "outputFullDuration": false,
-                  "timeSeriesQueryLanguage": "fetch gce_instance\n| metric 'workload.googleapis.com/couchbase.bucket.memory.usage'\n| group_by 1m, [value_usage_mean: mean(value.usage)]\n| every 1m\n| cast_units 'By'",
-                  "unitOverride": ""
+                  "prometheusQuery": "sum by (zone, instance_id) (avg_over_time(workload_googleapis_com:couchbase_bucket_memory_usage{monitored_resource=\"gce_instance\"}[1m]))",
+                  "unitOverride": "By"
                 }
               }
             ],
@@ -237,33 +237,25 @@
         "height": 4,
         "width": 6,
         "widget": {
-          "title": "CPU % Top 5 VMs",
-          "id": "",
+          "title": "VMs CPU %",
           "xyChart": {
             "chartOptions": {
               "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
+              "mode": "COLOR"
             },
             "dataSets": [
               {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesQueryLanguage": "def top_5_cpu_filtered_by_metric  filter_metric =\n  fetch gce_instance\n  | { t_memory: metric 'agent.googleapis.com/cpu/utilization'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n@top_5_cpu_filtered_by_metric 'workload.googleapis.com/couchbase.bucket.item.count'",
-                  "unitOverride": ""
+                  "prometheusQuery": "avg by (project_id, zone, instance_id) (\n  avg_over_time(\n    agent_googleapis_com:cpu_utilization{monitored_resource=\"gce_instance\"}[1m]\n  )\n  and\n  on(project_id, zone, instance_id)\n  (workload_googleapis_com:couchbase_bucket_item_count{monitored_resource=\"gce_instance\"})\n)",
+                  "unitOverride": "%"
                 }
               }
             ],
             "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
@@ -275,33 +267,25 @@
         "height": 4,
         "width": 6,
         "widget": {
-          "title": "Memory % Top 5 VMs",
-          "id": "",
+          "title": "VMs Memory %",
           "xyChart": {
             "chartOptions": {
               "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
+              "mode": "COLOR"
             },
             "dataSets": [
               {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesQueryLanguage": "def top_5_memory_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/memory/percent_used'\n        | filter metric.state = 'used'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n  @top_5_memory_filtered_by_metric 'workload.googleapis.com/couchbase.bucket.memory.usage'",
-                  "unitOverride": ""
+                  "prometheusQuery": "avg by (project_id, zone, instance_id) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n  and on(project_id, zone, instance_id) (\n    workload_googleapis_com:couchbase_bucket_memory_usage{monitored_resource=\"gce_instance\"}\n  )\n)",
+                  "unitOverride": "%"
                 }
               }
             ],
             "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
@@ -330,13 +314,12 @@
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
                   "outputFullDuration": false,
-                  "timeSeriesQueryLanguage": "def vms_with_metric_count_by_region metric =  fetch gce_instance \n | metric $metric\n# Shift points forward from the past 2 minutes so a VM that misses a point  # won't temporarily shift down the number of VMs.\n| align next_older(2m)\n| group_by [resource.project_id, resource.zone, resource.instance_id], 1m, .pick_any  \n| group_by [resource.project_id, resource.zone], 1m, .count\n  | map      add[        region: re_extract(resource.zone, '([^-]+-[^-]+)-[^-]+', '\\\\\\\\1')]  | group_by [region], .sum  | every 1m;\n  \n  @vms_with_metric_count_by_region 'workload.googleapis.com/couchbase.bucket.item.count'",
+                  "prometheusQuery": "avg_over_time(\n  (count by (region) (\n    label_replace(\n      sum by (project_id, zone, instance_id) (\n        workload_googleapis_com:couchbase_bucket_item_count{monitored_resource=\"gce_instance\"}\n      ),\n      \"region\", \"$1\", \"zone\", \"([^-]+-[^-]+)-[^-]+\"\n    )\n  ))[${__interval}:]\n)",
                   "unitOverride": ""
                 }
               }
             ],
             "thresholds": [],
-            "timeshiftDuration": "0s",
             "yAxis": {
               "label": "",
               "scale": "LINEAR"

--- a/dashboards/hadoop/hadoop-gce-overview.json
+++ b/dashboards/hadoop/hadoop-gce-overview.json
@@ -1,57 +1,127 @@
 {
   "displayName": "Hadoop GCE Overview",
+  "dashboardFilters": [],
+  "labels": {},
   "mosaicLayout": {
     "columns": 12,
     "tiles": [
       {
         "height": 4,
+        "width": 6,
         "widget": {
           "title": "Data Nodes",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
                 "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "60s",
+                      "groupByFields": [],
                       "perSeriesAligner": "ALIGN_MEAN"
                     },
                     "filter": "metric.type=\"workload.googleapis.com/hadoop.name_node.data_node.count\" resource.type=\"gce_instance\""
-                  }
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 6
+        }
       },
       {
+        "xPos": 6,
         "height": 4,
+        "width": 6,
         "widget": {
-          "title": "Capacity Used",
+          "title": "Volume Failures",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/hadoop.name_node.volume.failed\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 4,
+        "height": 4,
+        "width": 6,
+        "widget": {
+          "title": "Capacity Used",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
                 "minAlignmentPeriod": "60s",
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "60s",
+                      "groupByFields": [],
                       "perSeriesAligner": "ALIGN_MEAN"
                     },
                     "filter": "metric.type=\"workload.googleapis.com/hadoop.name_node.capacity.usage\" resource.type=\"gce_instance\""
@@ -60,351 +130,433 @@
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 6,
-        "yPos": 4
+        }
       },
       {
-        "height": 4,
-        "widget": {
-          "title": "Volume Failures",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "perSeriesAligner": "ALIGN_MEAN"
-                    },
-                    "filter": "metric.type=\"workload.googleapis.com/hadoop.name_node.volume.failed\" resource.type=\"gce_instance\""
-                  }
-                }
-              }
-            ],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "scale": "LINEAR"
-            }
-          }
-        },
-        "width": 6,
-        "xPos": 6
-      },
-      {
-        "height": 4,
-        "widget": {
-          "title": "Block Count",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "minAlignmentPeriod": "60s",
-                "plotType": "STACKED_AREA",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "perSeriesAligner": "ALIGN_MEAN"
-                    },
-                    "filter": "metric.type=\"workload.googleapis.com/hadoop.name_node.block.count\" resource.type=\"gce_instance\""
-                  }
-                }
-              }
-            ],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "scale": "LINEAR"
-            }
-          }
-        },
-        "width": 4,
-        "yPos": 8
-      },
-      {
-        "height": 4,
-        "widget": {
-          "title": "Corrupt Blocks",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "perSeriesAligner": "ALIGN_MEAN"
-                    },
-                    "filter": "metric.type=\"workload.googleapis.com/hadoop.name_node.block.corrupt\" resource.type=\"gce_instance\""
-                  }
-                }
-              }
-            ],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "scale": "LINEAR"
-            }
-          }
-        },
-        "width": 4,
-        "xPos": 4,
-        "yPos": 8
-      },
-      {
-        "height": 4,
-        "widget": {
-          "title": "Missing Blocks",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "perSeriesAligner": "ALIGN_MEAN"
-                    },
-                    "filter": "metric.type=\"workload.googleapis.com/hadoop.name_node.block.missing\" resource.type=\"gce_instance\""
-                  }
-                }
-              }
-            ],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "scale": "LINEAR"
-            }
-          }
-        },
-        "width": 4,
-        "xPos": 8,
-        "yPos": 8
-      },
-      {
-        "height": 4,
-        "widget": {
-          "title": "File Count",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "minAlignmentPeriod": "60s",
-                "plotType": "STACKED_AREA",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "perSeriesAligner": "ALIGN_MEAN"
-                    },
-                    "filter": "metric.type=\"workload.googleapis.com/hadoop.name_node.file.count\" resource.type=\"gce_instance\"",
-                    "secondaryAggregation": {
-                      "alignmentPeriod": "60s"
-                    }
-                  }
-                }
-              }
-            ],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "scale": "LINEAR"
-            }
-          }
-        },
-        "width": 6,
-        "yPos": 12
-      },
-      {
-        "height": 4,
-        "widget": {
-          "title": "File Load",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "minAlignmentPeriod": "60s",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesFilter": {
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "perSeriesAligner": "ALIGN_MEAN"
-                    },
-                    "filter": "metric.type=\"workload.googleapis.com/hadoop.name_node.file.load\" resource.type=\"gce_instance\""
-                  }
-                }
-              }
-            ],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "scale": "LINEAR"
-            }
-          }
-        },
-        "width": 6,
+        "yPos": 4,
         "xPos": 6,
-        "yPos": 12
-      },
-      {
         "height": 4,
-        "widget": {
-          "title": "CPU % Top 5 VMs",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "legendTemplate": "${labels.metric\\.instance_name} (${labels.resource\\.zone})",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "def top_5_cpu_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_cpu: metric 'compute.googleapis.com/instance/cpu/utilization'; \n  t_filter_metric: metric $filter_metric }\n  | join\n  | value t_cpu.value.utilization\n  | group_by [resource.project_id, resource.zone, metric.instance_name], 1m,\n      [value_utilization_mean: mean(t_cpu.value.utilization)]\n  | top 5\n  | every 1m;\n\n@top_5_cpu_filtered_by_metric 'workload.googleapis.com/hadoop.name_node.block.count'\n"
-                }
-              }
-            ],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "scale": "LINEAR"
-            }
-          }
-        },
-        "width": 4,
-        "yPos": 16
-      },
-      {
-        "height": 4,
-        "widget": {
-          "title": "Memory % Top 5 VMs",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "legendTemplate": "${labels.metadata\\.system\\.name} (${labels.resource\\.zone})",
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "def top_5_memory_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/memory/percent_used'\n        | filter metric.state = 'used'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n@top_5_memory_filtered_by_metric 'workload.googleapis.com/hadoop.name_node.block.count'"
-                }
-              }
-            ],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "scale": "LINEAR"
-            }
-          }
-        },
-        "width": 4,
-        "xPos": 4,
-        "yPos": 16
-      },
-      {
-        "height": 4,
-        "widget": {
-          "title": "Hosts By Region",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "legendTemplate": "${labels.region}",
-                "plotType": "STACKED_AREA",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "def vms_with_metric_count_by_region metric =\n  fetch gce_instance\n  | metric $metric\n  # Shift points forward from the past 2 minutes so a VM that misses a point\n  # won't temporarily shift down the number of VMs.\n  | align next_older(2m)\n  | group_by [resource.project_id, resource.zone, resource.instance_id], 1m, .pick_any\n  | group_by [resource.project_id, resource.zone], 1m, .count\n  | map\n      add[\n        region: re_extract(resource.zone, '([^-]+-[^-]+)-[^-]+', '\\\\1')]\n  | group_by [region], .sum\n  | every 1m;\n\n@vms_with_metric_count_by_region 'workload.googleapis.com/hadoop.name_node.block.count'"
-                }
-              }
-            ],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "scale": "LINEAR"
-            }
-          }
-        },
-        "width": 4,
-        "xPos": 8,
-        "yPos": 16
-      },
-      {
-        "height": 3,
-        "widget": {
-          "text": {
-            "content": "[How to configure Hadoop Monitoring](https://cloud.google.com/monitoring/agent/ops-agent/third-party/Hadoop)\n\n[View Hadoop Error Logs](https://console.cloud.google.com/logs/query?query=logName:%22hadoop%22%0Aresource.type%3D%22gce_instance%22)\n",
-            "format": "MARKDOWN"
-          },
-          "title": "Hadoop Monitoring Links"
-        },
-        "width": 12,
-        "yPos": 20
-      },
-      {
-        "height": 4,
+        "width": 6,
         "widget": {
           "title": "Capacity Limit",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
                 "minAlignmentPeriod": "60s",
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "60s",
+                      "groupByFields": [],
                       "perSeriesAligner": "ALIGN_MEAN"
                     },
                     "filter": "metric.type=\"workload.googleapis.com/hadoop.name_node.capacity.limit\" resource.type=\"gce_instance\"",
                     "secondaryAggregation": {
-                      "alignmentPeriod": "60s"
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_NONE"
                     }
                   },
                   "unitOverride": "By"
                 }
               }
             ],
+            "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
+              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
+        }
+      },
+      {
+        "yPos": 8,
+        "height": 4,
+        "width": 4,
+        "widget": {
+          "title": "Block Count",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/hadoop.name_node.block.count\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 8,
+        "xPos": 4,
+        "height": 4,
+        "width": 4,
+        "widget": {
+          "title": "Corrupt Blocks",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/hadoop.name_node.block.corrupt\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 8,
+        "xPos": 8,
+        "height": 4,
+        "width": 4,
+        "widget": {
+          "title": "Missing Blocks",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/hadoop.name_node.block.missing\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 12,
+        "height": 4,
         "width": 6,
+        "widget": {
+          "title": "File Count",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/hadoop.name_node.file.count\" resource.type=\"gce_instance\"",
+                    "secondaryAggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_NONE"
+                    }
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 12,
         "xPos": 6,
-        "yPos": 4
+        "height": 4,
+        "width": 6,
+        "widget": {
+          "title": "File Load",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/hadoop.name_node.file.load\" resource.type=\"gce_instance\""
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 16,
+        "height": 4,
+        "width": 4,
+        "widget": {
+          "title": "CPU % Top 5 VMs",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "${labels.metric\\.instance_name} (${labels.resource\\.zone})",
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesQueryLanguage": "def top_5_cpu_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_cpu: metric 'compute.googleapis.com/instance/cpu/utilization'; \n  t_filter_metric: metric $filter_metric }\n  | join\n  | value t_cpu.value.utilization\n  | group_by [resource.project_id, resource.zone, metric.instance_name], 1m,\n      [value_utilization_mean: mean(t_cpu.value.utilization)]\n  | top 5\n  | every 1m;\n\n@top_5_cpu_filtered_by_metric 'workload.googleapis.com/hadoop.name_node.block.count'\n",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 16,
+        "xPos": 4,
+        "height": 4,
+        "width": 4,
+        "widget": {
+          "title": "Memory % Top 5 VMs",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "${labels.metadata\\.system\\.name} (${labels.resource\\.zone})",
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesQueryLanguage": "def top_5_memory_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/memory/percent_used'\n        | filter metric.state = 'used'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n@top_5_memory_filtered_by_metric 'workload.googleapis.com/hadoop.name_node.block.count'",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 16,
+        "xPos": 8,
+        "height": 4,
+        "width": 4,
+        "widget": {
+          "title": "Hosts By Region",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "${labels.region}",
+                "measures": [],
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesQueryLanguage": "def vms_with_metric_count_by_region metric =\n  fetch gce_instance\n  | metric $metric\n  # Shift points forward from the past 2 minutes so a VM that misses a point\n  # won't temporarily shift down the number of VMs.\n  | align next_older(2m)\n  | group_by [resource.project_id, resource.zone, resource.instance_id], 1m, .pick_any\n  | group_by [resource.project_id, resource.zone], 1m, .count\n  | map\n      add[\n        region: re_extract(resource.zone, '([^-]+-[^-]+)-[^-]+', '\\\\1')]\n  | group_by [region], .sum\n  | every 1m;\n\n@vms_with_metric_count_by_region 'workload.googleapis.com/hadoop.name_node.block.count'",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 20,
+        "height": 3,
+        "width": 12,
+        "widget": {
+          "title": "Hadoop Monitoring Links",
+          "id": "",
+          "text": {
+            "content": "[How to configure Hadoop Monitoring](https://cloud.google.com/monitoring/agent/ops-agent/third-party/Hadoop)\n\n[View Hadoop Error Logs](https://console.cloud.google.com/logs/query?query=logName:%22hadoop%22%0Aresource.type%3D%22gce_instance%22)\n",
+            "format": "MARKDOWN",
+            "style": {
+              "backgroundColor": "",
+              "fontSize": "FONT_SIZE_UNSPECIFIED",
+              "horizontalAlignment": "HORIZONTAL_ALIGNMENT_UNSPECIFIED",
+              "padding": "PADDING_SIZE_UNSPECIFIED",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "",
+              "verticalAlignment": "VERTICAL_ALIGNMENT_UNSPECIFIED"
+            }
+          }
+        }
       }
     ]
   }

--- a/dashboards/hadoop/hadoop-gce-overview.json
+++ b/dashboards/hadoop/hadoop-gce-overview.json
@@ -428,33 +428,25 @@
         "height": 4,
         "width": 4,
         "widget": {
-          "title": "CPU % Top 5 VMs",
-          "id": "",
+          "title": "VMs CPU %",
           "xyChart": {
             "chartOptions": {
               "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
+              "mode": "COLOR"
             },
             "dataSets": [
               {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "${labels.metric\\.instance_name} (${labels.resource\\.zone})",
-                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesQueryLanguage": "def top_5_cpu_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_cpu: metric 'compute.googleapis.com/instance/cpu/utilization'; \n  t_filter_metric: metric $filter_metric }\n  | join\n  | value t_cpu.value.utilization\n  | group_by [resource.project_id, resource.zone, metric.instance_name], 1m,\n      [value_utilization_mean: mean(t_cpu.value.utilization)]\n  | top 5\n  | every 1m;\n\n@top_5_cpu_filtered_by_metric 'workload.googleapis.com/hadoop.name_node.block.count'\n",
-                  "unitOverride": ""
+                  "prometheusQuery": "100 *\n  (avg by (project_id, zone, instance_name) (\n    avg_over_time(\n      compute_googleapis_com:instance_cpu_utilization{monitored_resource=\"gce_instance\"}[1m]\n    )\n    and\n    on(instance_id, project_id, zone)\n    (workload_googleapis_com:hadoop_name_node_block_count{monitored_resource=\"gce_instance\"})\n  )\n)",
+                  "unitOverride": "%"
                 }
               }
             ],
             "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
@@ -466,33 +458,25 @@
         "height": 4,
         "width": 4,
         "widget": {
-          "title": "Memory % Top 5 VMs",
-          "id": "",
+          "title": "VMs Memory %",
           "xyChart": {
             "chartOptions": {
               "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
+              "mode": "COLOR"
             },
             "dataSets": [
               {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "${labels.metadata\\.system\\.name} (${labels.resource\\.zone})",
-                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesQueryLanguage": "def top_5_memory_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/memory/percent_used'\n        | filter metric.state = 'used'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n@top_5_memory_filtered_by_metric 'workload.googleapis.com/hadoop.name_node.block.count'",
-                  "unitOverride": ""
+                  "prometheusQuery": "avg by (project_id, zone, instance_id) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n  and on(project_id, zone, instance_id) (\n    workload_googleapis_com:hadoop_name_node_block_count{monitored_resource=\"gce_instance\"}\n  )\n)",
+                  "unitOverride": "%"
                 }
               }
             ],
             "thresholds": [],
             "timeshiftDuration": "0s",
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
@@ -516,19 +500,18 @@
               {
                 "breakdowns": [],
                 "dimensions": [],
-                "legendTemplate": "${labels.region}",
+                "legendTemplate": "",
                 "measures": [],
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
                   "outputFullDuration": false,
-                  "timeSeriesQueryLanguage": "def vms_with_metric_count_by_region metric =\n  fetch gce_instance\n  | metric $metric\n  # Shift points forward from the past 2 minutes so a VM that misses a point\n  # won't temporarily shift down the number of VMs.\n  | align next_older(2m)\n  | group_by [resource.project_id, resource.zone, resource.instance_id], 1m, .pick_any\n  | group_by [resource.project_id, resource.zone], 1m, .count\n  | map\n      add[\n        region: re_extract(resource.zone, '([^-]+-[^-]+)-[^-]+', '\\\\1')]\n  | group_by [region], .sum\n  | every 1m;\n\n@vms_with_metric_count_by_region 'workload.googleapis.com/hadoop.name_node.block.count'",
+                  "prometheusQuery": "count by (region) (\n  label_replace(\n    sum by (project_id, zone, instance_id) (\n      count_over_time(workload_googleapis_com:hadoop_name_node_block_count{monitored_resource=\"gce_instance\"}[2m])\n    ),\n    \"region\",\n    \"$1\",\n    \"zone\",\n    \"([^-]+-[^-]+)-.*\"\n  )\n)",
                   "unitOverride": ""
                 }
               }
             ],
             "thresholds": [],
-            "timeshiftDuration": "0s",
             "yAxis": {
               "label": "",
               "scale": "LINEAR"


### PR DESCRIPTION
This PR updates the Hadoop GCE Overview Dashboard to use PromQL instead of the deprecated MQL.

