### PR TITLE
PromQL: GKE Enterprise Project Observability CPU

### DIFF
--- a/dashboards/google-kubernetes-engine-enterprise/gke-enterprise-project-observability-cpu.json
+++ b/dashboards/google-kubernetes-engine-enterprise/gke-enterprise-project-observability-cpu.json
@@ -20,7 +20,8 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { { metric kubernetes.io/container/cpu/core_usage_time\n    ; metric kubernetes.io/anthos/container/cpu/core_usage_time }\n    | union\n    | rate\n    | every 1m\n    | align next_older(2m)\n  ; { metric kubernetes.io/container/cpu/request_cores\n    ; metric kubernetes.io/anthos/container/cpu/request_cores }\n    | union\n    | align next_older(2m) }\n| group_by [resource.project_id], .sum()\n| outer_join 0\n| div\n| scale \"%\""
+                  "prometheusQuery": "100 *\n(\n  sum by (project_id) (\n    rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\"}[1m])\n    or\n    rate(kubernetes_io:anthos_container_cpu_core_usage_time{monitored_resource=\"k8s_container\"}[1m])\n  )\n  /\n  (\n    sum by (project_id) (\n      kubernetes_io:container_cpu_request_cores{monitored_resource=\"k8s_container\"}\n      or\n      kubernetes_io:anthos_container_cpu_request_cores{monitored_resource=\"k8s_container\"}\n    )\n    and\n    (\n      sum by (project_id) (\n        kubernetes_io:container_cpu_request_cores{monitored_resource=\"k8s_container\"}\n        or\n        kubernetes_io:anthos_container_cpu_request_cores{monitored_resource=\"k8s_container\"}\n      ) > 0\n    )\n  )\n)\n",
+                  "unitOverride": "%"
                 }
               }
             ],
@@ -47,7 +48,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { metric kubernetes.io/container/cpu/core_usage_time\n  ; metric kubernetes.io/anthos/container/cpu/core_usage_time }\n| union\n| align rate(1m)\n| every 1m\n| group_by [resource.project_id], .sum()"
+                  "prometheusQuery": "sum by (project_id) (\n    rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\"}[1m])\n    or \n    rate(kubernetes_io:anthos_container_cpu_core_usage_time{monitored_resource=\"k8s_container\"}[1m])\n)"
                 }
               }
             ],
@@ -74,7 +75,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { metric kubernetes.io/container/cpu/request_cores\n  ; metric kubernetes.io/anthos/container/cpu/request_cores }\n| union\n| align next_older(1m)\n| every 1m\n| group_by [resource.project_id], .sum()"
+                  "prometheusQuery": "sum by (project_id) (\n    kubernetes_io:container_cpu_request_cores{monitored_resource=\"k8s_container\"}\n    or \n    kubernetes_io:anthos_container_cpu_request_cores{monitored_resource=\"k8s_container\"}\n)"
                 }
               }
             ],
@@ -102,7 +103,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { { metric kubernetes.io/container/cpu/request_cores\n    ; metric kubernetes.io/anthos/container/cpu/request_cores }\n    | union\n  ; { metric kubernetes.io/container/cpu/core_usage_time\n    ; metric kubernetes.io/anthos/container/cpu/core_usage_time }\n    | union\n    | rate\n    | every 1m }\n| align next_older(2m)\n| group_by [resource.project_id], .sum()\n| join\n| sub"
+                  "prometheusQuery": "sum by (project_id) (\n    kubernetes_io:container_cpu_request_cores{monitored_resource=\"k8s_container\"}\n    or \n    kubernetes_io:anthos_container_cpu_request_cores{monitored_resource=\"k8s_container\"}\n)\n-\nsum by (project_id) (\n    rate(kubernetes_io:container_cpu_core_usage_time{monitored_resource=\"k8s_container\"}[1m])\n    or \n    rate(kubernetes_io:anthos_container_cpu_core_usage_time{monitored_resource=\"k8s_container\"}[1m])\n)"
                 }
               }
             ],
@@ -129,7 +130,8 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "{ fetch k8s_container\n  | { metric kubernetes.io/container/cpu/request_cores\n    ; metric kubernetes.io/anthos/container/cpu/request_cores }\n  | union\n; fetch k8s_node\n  | { metric kubernetes.io/node/cpu/allocatable_cores\n    ; metric kubernetes.io/anthos/node/cpu/allocatable_cores }\n  | union }\n| align next_older(2m)\n| group_by [resource.project_id], .sum()\n| join\n| div\n| scale \"%\""
+                  "prometheusQuery": "100 *\n(\n  sum by (project_id) (\n    kubernetes_io:container_cpu_request_cores{monitored_resource=\"k8s_container\"}\n    or\n    kubernetes_io:anthos_container_cpu_request_cores{monitored_resource=\"k8s_container\"}\n  )\n  /\n  (\n    sum by (project_id) (\n      kubernetes_io:node_cpu_allocatable_cores{monitored_resource=\"k8s_node\"}\n      or\n      kubernetes_io:anthos_node_cpu_allocatable_cores{monitored_resource=\"k8s_node\"}\n    )\n    and\n    (\n      sum by (project_id) (\n        kubernetes_io:node_cpu_allocatable_cores{monitored_resource=\"k8s_node\"}\n        or\n        kubernetes_io:anthos_node_cpu_allocatable_cores{monitored_resource=\"k8s_node\"}\n      ) > 0\n    )\n  )\n)\n",
+                  "unitOverride": "%"
                 }
               }
             ],
@@ -157,7 +159,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| { { metric kubernetes.io/node/cpu/total_cores\n    ; metric kubernetes.io/anthos/node/cpu/total_cores }\n    | union\n    | align next_older(2m)\n  ; { metric kubernetes.io/node/cpu/core_usage_time\n    ; metric kubernetes.io/anthos/node/cpu/core_usage_time }\n    | union\n    | rate\n    | every 1m\n    | align next_older(2m) }\n| group_by [resource.project_id], .sum()\n| join\n| sub"
+                  "prometheusQuery": "sum by (project_id) (\n    kubernetes_io:node_cpu_total_cores{monitored_resource=\"k8s_node\"}\n    or\n    kubernetes_io:anthos_node_cpu_total_cores{monitored_resource=\"k8s_node\"}\n)\n-\nsum by (project_id) (\n    rate(kubernetes_io:node_cpu_core_usage_time{monitored_resource=\"k8s_node\"}[1m])\n    or\n    rate(kubernetes_io:anthos_node_cpu_core_usage_time{monitored_resource=\"k8s_node\"}[1m])\n)"
                 }
               }
             ],
@@ -184,7 +186,8 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| { { metric kubernetes.io/node/cpu/core_usage_time\n    ; metric kubernetes.io/anthos/node/cpu/core_usage_time }\n    | union\n    | rate\n    | every 1m\n    | align next_older(2m)\n  ; { metric kubernetes.io/node/cpu/total_cores\n    ; metric kubernetes.io/anthos/node/cpu/total_cores }\n    | union\n    | align next_older(2m) }\n| group_by [resource.project_id], .sum()\n| join\n| div\n| scale \"%\""
+                  "prometheusQuery": "100 *\n(\n  sum by (project_id) (\n    rate(kubernetes_io:node_cpu_core_usage_time{monitored_resource=\"k8s_node\"}[1m])\n    or\n    rate(kubernetes_io:anthos_node_cpu_core_usage_time{monitored_resource=\"k8s_node\"}[1m])\n  )\n  /\n  (\n    sum by (project_id) (\n      kubernetes_io:node_cpu_total_cores{monitored_resource=\"k8s_node\"}\n      or\n      kubernetes_io:anthos_node_cpu_total_cores{monitored_resource=\"k8s_node\"}\n    )\n    and\n    (\n      sum by (project_id) (\n        kubernetes_io:node_cpu_total_cores{monitored_resource=\"k8s_node\"}\n        or\n        kubernetes_io:anthos_node_cpu_total_cores{monitored_resource=\"k8s_node\"}\n      ) > 0\n    )\n  )\n)\n",
+                  "unitOverride": "%"
                 }
               }
             ],
@@ -212,7 +215,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| { { metric kubernetes.io/node/cpu/total_cores\n    ; metric kubernetes.io/anthos/node/cpu/total_cores }\n    | union\n    | align next_older(2m)\n  ; { metric kubernetes.io/node/cpu/core_usage_time\n    ; metric kubernetes.io/anthos/node/cpu/core_usage_time }\n    | union\n    | rate\n    | every 1m\n    | align next_older(2m) }\n| group_by [resource.project_id], .sum()\n| join\n| sub"
+                  "prometheusQuery": "sum by (project_id) (\n    kubernetes_io:node_cpu_total_cores{monitored_resource=\"k8s_node\"}\n    or \n    kubernetes_io:anthos_node_cpu_total_cores{monitored_resource=\"k8s_node\"}\n)\n-\nsum by (project_id) (\n    rate(kubernetes_io:node_cpu_core_usage_time{monitored_resource=\"k8s_node\"}[1m])\n    or \n    rate(kubernetes_io:anthos_node_cpu_core_usage_time{monitored_resource=\"k8s_node\"}[1m])\n)"
                 }
               }
             ],
@@ -239,7 +242,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| { metric kubernetes.io/node/cpu/total_cores\n  ; metric kubernetes.io/anthos/node/cpu/total_cores }\n| union\n| align next_older(2m)\n| every 2m\n| group_by [resource.project_id], .sum()"
+                  "prometheusQuery": "sum by (project_id) (\n    kubernetes_io:node_cpu_total_cores{monitored_resource=\"k8s_node\"}\n    or \n    kubernetes_io:anthos_node_cpu_total_cores{monitored_resource=\"k8s_node\"}\n)"
                 }
               }
             ],
@@ -267,7 +270,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| { metric kubernetes.io/node/cpu/allocatable_cores\n  ; metric kubernetes.io/anthos/node/cpu/allocatable_cores }\n| union\n| align next_older(2m)\n| every 2m\n| group_by [resource.project_id], .sum()"
+                  "prometheusQuery": "sum by (project_id) (\n    kubernetes_io:node_cpu_allocatable_cores{monitored_resource=\"k8s_node\"}\n    or \n    kubernetes_io:anthos_node_cpu_allocatable_cores{monitored_resource=\"k8s_node\"}\n)"
                 }
               }
             ],

--- a/dashboards/google-kubernetes-engine-enterprise/gke-enterprise-project-observability-cpu.json
+++ b/dashboards/google-kubernetes-engine-enterprise/gke-enterprise-project-observability-cpu.json
@@ -1,17 +1,18 @@
 {
-  "category": "CUSTOM",
   "displayName": "GKE Enterprise Project Observability CPU",
   "dashboardFilters": [],
+  "labels": {},
   "mosaicLayout": {
     "columns": 48,
     "tiles": [
       {
-        "width": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "CPU Request % Used",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -19,14 +20,12 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { { metric kubernetes.io/container/cpu/core_usage_time\n    ; metric kubernetes.io/anthos/container/cpu/core_usage_time }\n    | union\n    | rate\n    | every 1m\n    | align next_older(2m)\n  ; { metric kubernetes.io/container/cpu/request_cores\n    ; metric kubernetes.io/anthos/container/cpu/request_cores }\n    | union\n    | align next_older(2m) }\n| group_by [resource.project_id], .sum()\n| outer_join 0\n| div\n| scale \"%\"",
-                  "unitOverride": ""
+                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { { metric kubernetes.io/container/cpu/core_usage_time\n    ; metric kubernetes.io/anthos/container/cpu/core_usage_time }\n    | union\n    | rate\n    | every 1m\n    | align next_older(2m)\n  ; { metric kubernetes.io/container/cpu/request_cores\n    ; metric kubernetes.io/anthos/container/cpu/request_cores }\n    | union\n    | align next_older(2m) }\n| group_by [resource.project_id], .sum()\n| outer_join 0\n| div\n| scale \"%\""
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
@@ -34,12 +33,13 @@
       },
       {
         "xPos": 24,
-        "width": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Cores Used",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -47,14 +47,12 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { metric kubernetes.io/container/cpu/core_usage_time\n  ; metric kubernetes.io/anthos/container/cpu/core_usage_time }\n| union\n| align rate(1m)\n| every 1m\n| group_by [resource.project_id], .sum()",
-                  "unitOverride": ""
+                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { metric kubernetes.io/container/cpu/core_usage_time\n  ; metric kubernetes.io/anthos/container/cpu/core_usage_time }\n| union\n| align rate(1m)\n| every 1m\n| group_by [resource.project_id], .sum()"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
@@ -62,12 +60,13 @@
       },
       {
         "yPos": 16,
-        "width": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Requested Cores",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -75,28 +74,27 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { metric kubernetes.io/container/cpu/request_cores\n  ; metric kubernetes.io/anthos/container/cpu/request_cores }\n| union\n| align next_older(1m)\n| every 1m\n| group_by [resource.project_id], .sum()",
-                  "unitOverride": ""
+                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { metric kubernetes.io/container/cpu/request_cores\n  ; metric kubernetes.io/anthos/container/cpu/request_cores }\n| union\n| align next_older(1m)\n| every 1m\n| group_by [resource.project_id], .sum()"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
         }
       },
       {
-        "xPos": 24,
         "yPos": 16,
-        "width": 24,
+        "xPos": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Requested Cores Unused",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -104,14 +102,12 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { { metric kubernetes.io/container/cpu/request_cores\n    ; metric kubernetes.io/anthos/container/cpu/request_cores }\n    | union\n  ; { metric kubernetes.io/container/cpu/core_usage_time\n    ; metric kubernetes.io/anthos/container/cpu/core_usage_time }\n    | union\n    | rate\n    | every 1m }\n| align next_older(2m)\n| group_by [resource.project_id], .sum()\n| join\n| sub",
-                  "unitOverride": ""
+                  "timeSeriesQueryLanguage": "fetch k8s_container\n| { { metric kubernetes.io/container/cpu/request_cores\n    ; metric kubernetes.io/anthos/container/cpu/request_cores }\n    | union\n  ; { metric kubernetes.io/container/cpu/core_usage_time\n    ; metric kubernetes.io/anthos/container/cpu/core_usage_time }\n    | union\n    | rate\n    | every 1m }\n| align next_older(2m)\n| group_by [resource.project_id], .sum()\n| join\n| sub"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
@@ -119,12 +115,13 @@
       },
       {
         "yPos": 32,
-        "width": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Cluster CPU % Used",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -132,28 +129,27 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "{ fetch k8s_container\n  | { metric kubernetes.io/container/cpu/request_cores\n    ; metric kubernetes.io/anthos/container/cpu/request_cores }\n  | union\n; fetch k8s_node\n  | { metric kubernetes.io/node/cpu/allocatable_cores\n    ; metric kubernetes.io/anthos/node/cpu/allocatable_cores }\n  | union }\n| align next_older(2m)\n| group_by [resource.project_id], .sum()\n| join\n| div\n| scale \"%\"",
-                  "unitOverride": ""
+                  "timeSeriesQueryLanguage": "{ fetch k8s_container\n  | { metric kubernetes.io/container/cpu/request_cores\n    ; metric kubernetes.io/anthos/container/cpu/request_cores }\n  | union\n; fetch k8s_node\n  | { metric kubernetes.io/node/cpu/allocatable_cores\n    ; metric kubernetes.io/anthos/node/cpu/allocatable_cores }\n  | union }\n| align next_older(2m)\n| group_by [resource.project_id], .sum()\n| join\n| div\n| scale \"%\""
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
         }
       },
       {
-        "xPos": 24,
         "yPos": 32,
-        "width": 24,
+        "xPos": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Cluster Cores Unused",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -161,14 +157,12 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| { { metric kubernetes.io/node/cpu/total_cores\n    ; metric kubernetes.io/anthos/node/cpu/total_cores }\n    | union\n    | align next_older(2m)\n  ; { metric kubernetes.io/node/cpu/core_usage_time\n    ; metric kubernetes.io/anthos/node/cpu/core_usage_time }\n    | union\n    | rate\n    | every 1m\n    | align next_older(2m) }\n| group_by [resource.project_id], .sum()\n| join\n| sub",
-                  "unitOverride": ""
+                  "timeSeriesQueryLanguage": "fetch k8s_node\n| { { metric kubernetes.io/node/cpu/total_cores\n    ; metric kubernetes.io/anthos/node/cpu/total_cores }\n    | union\n    | align next_older(2m)\n  ; { metric kubernetes.io/node/cpu/core_usage_time\n    ; metric kubernetes.io/anthos/node/cpu/core_usage_time }\n    | union\n    | rate\n    | every 1m\n    | align next_older(2m) }\n| group_by [resource.project_id], .sum()\n| join\n| sub"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
@@ -176,12 +170,13 @@
       },
       {
         "yPos": 48,
-        "width": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Cluster CPU % Requested",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -189,28 +184,27 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| { { metric kubernetes.io/node/cpu/core_usage_time\n    ; metric kubernetes.io/anthos/node/cpu/core_usage_time }\n    | union\n    | rate\n    | every 1m\n    | align next_older(2m)\n  ; { metric kubernetes.io/node/cpu/total_cores\n    ; metric kubernetes.io/anthos/node/cpu/total_cores }\n    | union\n    | align next_older(2m) }\n| group_by [resource.project_id], .sum()\n| join\n| div\n| scale \"%\"",
-                  "unitOverride": ""
+                  "timeSeriesQueryLanguage": "fetch k8s_node\n| { { metric kubernetes.io/node/cpu/core_usage_time\n    ; metric kubernetes.io/anthos/node/cpu/core_usage_time }\n    | union\n    | rate\n    | every 1m\n    | align next_older(2m)\n  ; { metric kubernetes.io/node/cpu/total_cores\n    ; metric kubernetes.io/anthos/node/cpu/total_cores }\n    | union\n    | align next_older(2m) }\n| group_by [resource.project_id], .sum()\n| join\n| div\n| scale \"%\""
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
         }
       },
       {
-        "xPos": 24,
         "yPos": 48,
-        "width": 24,
+        "xPos": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Cluster Unrequested Cores",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -218,14 +212,12 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| { { metric kubernetes.io/node/cpu/total_cores\n    ; metric kubernetes.io/anthos/node/cpu/total_cores }\n    | union\n    | align next_older(2m)\n  ; { metric kubernetes.io/node/cpu/core_usage_time\n    ; metric kubernetes.io/anthos/node/cpu/core_usage_time }\n    | union\n    | rate\n    | every 1m\n    | align next_older(2m) }\n| group_by [resource.project_id], .sum()\n| join\n| sub",
-                  "unitOverride": ""
+                  "timeSeriesQueryLanguage": "fetch k8s_node\n| { { metric kubernetes.io/node/cpu/total_cores\n    ; metric kubernetes.io/anthos/node/cpu/total_cores }\n    | union\n    | align next_older(2m)\n  ; { metric kubernetes.io/node/cpu/core_usage_time\n    ; metric kubernetes.io/anthos/node/cpu/core_usage_time }\n    | union\n    | rate\n    | every 1m\n    | align next_older(2m) }\n| group_by [resource.project_id], .sum()\n| join\n| sub"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
@@ -233,12 +225,13 @@
       },
       {
         "yPos": 64,
-        "width": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Cluster Total Cores",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -246,28 +239,27 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| { metric kubernetes.io/node/cpu/total_cores\n  ; metric kubernetes.io/anthos/node/cpu/total_cores }\n| union\n| align next_older(2m)\n| every 2m\n| group_by [resource.project_id], .sum()",
-                  "unitOverride": ""
+                  "timeSeriesQueryLanguage": "fetch k8s_node\n| { metric kubernetes.io/node/cpu/total_cores\n  ; metric kubernetes.io/anthos/node/cpu/total_cores }\n| union\n| align next_older(2m)\n| every 2m\n| group_by [resource.project_id], .sum()"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
         }
       },
       {
-        "xPos": 24,
         "yPos": 64,
-        "width": 24,
+        "xPos": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Cluster Allocatable Cores",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -275,20 +267,17 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| { metric kubernetes.io/node/cpu/allocatable_cores\n  ; metric kubernetes.io/anthos/node/cpu/allocatable_cores }\n| union\n| align next_older(2m)\n| every 2m\n| group_by [resource.project_id], .sum()",
-                  "unitOverride": ""
+                  "timeSeriesQueryLanguage": "fetch k8s_node\n| { metric kubernetes.io/node/cpu/allocatable_cores\n  ; metric kubernetes.io/anthos/node/cpu/allocatable_cores }\n| union\n| align next_older(2m)\n| every 2m\n| group_by [resource.project_id], .sum()"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
         }
       }
     ]
-  },
-  "labels": {}
+  }
 }


### PR DESCRIPTION
This PR updates the GKE Enterprise Project Observability CPU Dashboard to use PromQL instead of the deprecated MQL.

To prove equivalence, here are screenshots of two different versions of the dashboard over the same time period. The former is the previous version of the dashboard, the latter the updated version of the dashboard.

MQL:
![image](https://github.com/user-attachments/assets/eabe469e-389a-4389-a89b-f8396805d838)
![image](https://github.com/user-attachments/assets/092a2296-7498-47d7-9ea3-4ad9d90bf4e2)

PromQL:
![image](https://github.com/user-attachments/assets/88d5879c-456c-40be-8f5b-920408f918c6)
![image](https://github.com/user-attachments/assets/21e2c206-45a9-46e8-895a-f787fa5f02f2)

