### PR TITLE
PromQL: GKE Enterprise Project Observability Kubernetes Events

### DIFF
--- a/dashboards/google-kubernetes-engine-enterprise/gke-enterprise-project-observability-kubernetes-events.json
+++ b/dashboards/google-kubernetes-engine-enterprise/gke-enterprise-project-observability-kubernetes-events.json
@@ -1,15 +1,18 @@
 {
-  "category": "CUSTOM",
   "displayName": "GKE Enterprise Project Observability Kubernetes Events",
   "dashboardFilters": [],
+  "labels": {},
   "mosaicLayout": {
     "columns": 48,
     "tiles": [
       {
+        "height": 16,
+        "width": 24,
         "widget": {
           "title": "Container Error Logs/Sec.",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -17,22 +20,17 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| metric logging.googleapis.com/log_entry_count\n| filter metric.severity =~ \"ERROR|CRITICAL|ALERT|EMERGENCY\"\n| align rate(1m)\n| every 1m\n| group_by [resource.project_id], .sum()",
-                  "unitOverride": ""
+                  "timeSeriesQueryLanguage": "fetch k8s_container\n| metric logging.googleapis.com/log_entry_count\n| filter metric.severity =~ \"ERROR|CRITICAL|ALERT|EMERGENCY\"\n| align rate(1m)\n| every 1m\n| group_by [resource.project_id], .sum()"
                 }
               }
             ],
             "thresholds": [],
             "yAxis": {
-              "label": "",
               "scale": "LINEAR"
             }
           }
-        },
-        "height": 16,
-        "width": 24
+        }
       }
     ]
-  },
-  "labels": {}
+  }
 }

--- a/dashboards/google-kubernetes-engine-enterprise/gke-enterprise-project-observability-kubernetes-events.json
+++ b/dashboards/google-kubernetes-engine-enterprise/gke-enterprise-project-observability-kubernetes-events.json
@@ -20,7 +20,8 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| metric logging.googleapis.com/log_entry_count\n| filter metric.severity =~ \"ERROR|CRITICAL|ALERT|EMERGENCY\"\n| align rate(1m)\n| every 1m\n| group_by [resource.project_id], .sum()"
+                  "prometheusQuery": "sum by (project_id) (\n    rate(logging_googleapis_com:log_entry_count{monitored_resource=\"k8s_container\", severity=~\"ERROR|CRITICAL|ALERT|EMERGENCY\"}[1m])\n)",
+                  "unitOverride": "1/s"
                 }
               }
             ],


### PR DESCRIPTION
This PR updates the GKE Enterprise Project Observability Kubernetes Events Dashboard to use PromQL instead of the deprecated MQL.

To prove equivalence, here are screenshots of two different versions of the dashboard over the same time period. The former is the previous version of the dashboard, the latter the updated version of the dashboard.

MQL:
![image](https://github.com/user-attachments/assets/36746005-8c6d-4d12-9495-93911325b130)

PromQL:
![image](https://github.com/user-attachments/assets/dfb64491-2910-4cf8-ade3-f7db9c5fb821)
