### PR TITLE
PromQL: GKE Active/Idle clusters

### DIFF
--- a/dashboards/google-kubernetes-engine/gke-active-idle-clusters.json
+++ b/dashboards/google-kubernetes-engine/gke-active-idle-clusters.json
@@ -38,7 +38,8 @@
                 "minAlignmentPeriod": "60s",
                 "timeSeriesQuery": {
                   "outputFullDuration": false,
-                  "prometheusQuery": "label_replace(\n  (\n    sum by (cluster_name, location, project_id) (\n      increase(kubernetes_io:container_cpu_core_usage_time{\n        monitored_resource=\"k8s_container\",\n        namespace_name!~\"^(kube-system|istio-system|gatekeeper-system|gke-system)$\"\n      }[7d])\n    )\n    /\n    (\n      604800 *\n      sum by (cluster_name, location, project_id) (\n        avg_over_time(kubernetes_io:node_cpu_allocatable_cores{monitored_resource=\"k8s_node\"}[7d])\n      )\n    )\n  ) * 100,\n  \"cluster_status\", \"running\", \"\", \"\"\n)\nand on (cluster_name, location, project_id)\n(\n  count by (cluster_name, location, project_id) (\n    avg_over_time(kubernetes_io:container_uptime{\n      monitored_resource=\"k8s_container\",\n      namespace_name=\"kube-system\"\n    }[7d])\n  ) > 0\n)\n"
+                  "prometheusQuery": "label_replace(\n  (\n    sum by (cluster_name, location, project_id) (\n      increase(kubernetes_io:container_cpu_core_usage_time{\n        monitored_resource=\"k8s_container\",\n        namespace_name!~\"^(kube-system|istio-system|gatekeeper-system|gke-system)$\"\n      }[7d])\n    )\n    /\n    (\n      604800 *\n      sum by (cluster_name, location, project_id) (\n        avg_over_time(kubernetes_io:node_cpu_allocatable_cores{monitored_resource=\"k8s_node\"}[7d])\n      )\n    )\n  ) * 100,\n  \"cluster_status\", \"running\", \"\", \"\"\n)\nand on (cluster_name, location, project_id)\n(\n  count by (cluster_name, location, project_id) (\n    avg_over_time(kubernetes_io:container_uptime{\n      monitored_resource=\"k8s_container\",\n      namespace_name=\"kube-system\"\n    }[7d])\n  ) > 0\n)\n",
+                  "unitOverride": "%"
                 }
               }
             ],


### PR DESCRIPTION
This PR updates the GKE Enterprise Project Observability Memory Dashboard to use PromQL instead of the deprecated MQL.

## Conversion Issues

Windowing - MQL allows you to set the interval of data points for the metric, and PromQL basically just picks an intelligent interval based on the overall window.

Also, the Latest Value column in the table just seems to work different for the two query languages - of the two, PromQL does seem to be more what I'd expect, so that's actually an upgrade. MQL seems to average the datapoints, whereas PromQL actually provides the value of the last reported datapoint.

### Query 1

To attempt to prove this is as close as we get for query 1, here's a couple screenshots of the line chart version of these queries over the same window, but with the MQL query adjusted to replace 7d with 1m (PromQL's default):

MQL:
![image](https://github.com/user-attachments/assets/d48cd7cd-77aa-4ebf-a2bd-3ba88e050821)

PromQL:
![image](https://github.com/user-attachments/assets/79d404e8-1418-4b56-961c-62f6fd030f90)

### Query 2

To attempt to prove this is as close as we get for query 2, here's a couple screenshots of the line chart version of these queries over the same window, but with the queries adjusted to replace 7d with 1m.

MQL:
![image](https://github.com/user-attachments/assets/419e1d15-816e-4fdd-9d47-a86af593b5ee)

PromQL:
![image](https://github.com/user-attachments/assets/00c041cf-0888-4fbf-9bdb-820e861c043f)

For reference, here's what the exact same query looks like over the last two weeks with the 7d interval back in.

MQL:
![image](https://github.com/user-attachments/assets/5d03f46f-d667-45a8-bb7c-b7a908fa89f5)

PromQL:
![image](https://github.com/user-attachments/assets/dd4d53d3-1903-4a81-82d4-428a4dc496c5)



