### PR TITLE
PromQL: Google Anthos

### DIFF
--- a/dashboards/google-anthos/anthos-cluster-control-plane-uptime.json
+++ b/dashboards/google-anthos/anthos-cluster-control-plane-uptime.json
@@ -176,7 +176,14 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "{ fetch k8s_container\n| metric\n    'kubernetes.io/anthos/apiserver_admission_webhook_admission_duration_seconds'\n| add [cluster: resource.cluster_name, namespace: resource.namespace_name]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile50:\n       percentile(value.apiserver_admission_webhook_admission_duration_seconds,\n         50)]\n; fetch prometheus_target\n| metric\n    'kubernetes.io/anthos/apiserver_admission_webhook_admission_duration_seconds/histogram'\n| add [cluster: resource.cluster, namespace: resource.namespace]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile50:\n       percentile(value.histogram,\n         50)] }\n| union"
+                "prometheusQuery": "# 50th percentile from k8s_container source\nhistogram_quantile(\n  0.5,\n  sum by (project_id, location, cluster_name, namespace_name, le) (\n    rate(kubernetes_io:apiserver_admission_webhook_admission_duration_seconds_bucket{monitored_resource=\"k8s_container\"}[1m])\n  )\n)"
+              }
+            },
+            {
+              "plotType": "LINE",
+              "targetAxis": "Y1",
+              "timeSeriesQuery": {
+                "prometheusQuery": "# 50th percentile from prometheus_target source\nhistogram_quantile(\n  0.5,\n  sum by (project_id, location, cluster, namespace, le) (\n    rate(kubernetes_io:apiserver_admission_webhook_admission_duration_seconds_histogram_bucket{monitored_resource=\"prometheus_target\"}[1m])\n  )\n)"
               }
             }
           ],
@@ -199,7 +206,14 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "{ fetch k8s_container\n| metric\n    'kubernetes.io/anthos/apiserver_request_duration_seconds'\n| add [cluster: resource.cluster_name, namespace: resource.namespace_name]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile50:\n       percentile(value.apiserver_request_duration_seconds,\n         50)]\n; fetch prometheus_target\n| metric\n    'kubernetes.io/anthos/apiserver_request_duration_seconds/histogram'\n| add [cluster: resource.cluster, namespace: resource.namespace]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile50:\n       percentile(value.histogram,\n         50)] }\n| union"
+                "prometheusQuery": "histogram_quantile(\n  0.5,\n  sum by (project_id, location, cluster_name, namespace_name, le) (\n    rate(kubernetes_io:apiserver_request_duration_seconds_bucket{monitored_resource=\"k8s_container\"}[1m])\n  )\n)"
+              }
+            },
+            {
+              "plotType": "LINE",
+              "targetAxis": "Y1",
+              "timeSeriesQuery": {
+                "prometheusQuery": "histogram_quantile(\n  0.5,\n  sum by (project_id, location, cluster, namespace, le) (\n    rate(kubernetes_io:apiserver_request_duration_seconds_bucket{monitored_resource=\"prometheus_target\"}[1m])\n  )\n)\n"
               }
             }
           ],
@@ -222,7 +236,14 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "{ fetch k8s_container\n| metric\n    'kubernetes.io/anthos/apiserver_admission_webhook_admission_duration_seconds'\n| add [cluster: resource.cluster_name, namespace: resource.namespace_name]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile95:\n       percentile(value.apiserver_admission_webhook_admission_duration_seconds,\n         95)]\n; fetch prometheus_target\n| metric\n    'kubernetes.io/anthos/apiserver_admission_webhook_admission_duration_seconds/histogram'\n| add [cluster: resource.cluster, namespace: resource.namespace]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile95:\n       percentile(value.histogram,\n         95)] }\n| union"
+                "prometheusQuery": "# 95th percentile from k8s_container source\nhistogram_quantile(\n  0.95,\n  sum by (project_id, location, cluster_name, namespace_name, le) (\n    rate(kubernetes_io:apiserver_admission_webhook_admission_duration_seconds_bucket{monitored_resource=\"k8s_container\"}[1m])\n  )\n)"
+              }
+            },
+            {
+              "plotType": "LINE",
+              "targetAxis": "Y1",
+              "timeSeriesQuery": {
+                "prometheusQuery": "# 95th percentile from prometheus_target source\nhistogram_quantile(\n  0.95,\n  sum by (project_id, location, cluster, namespace, le) (\n    rate(kubernetes_io:apiserver_admission_webhook_admission_duration_seconds_histogram_bucket{monitored_resource=\"prometheus_target\"}[1m])\n  )\n)"
               }
             }
           ],
@@ -245,7 +266,14 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "{ fetch k8s_container\n| metric\n    'kubernetes.io/anthos/apiserver_request_duration_seconds'\n| add [cluster: resource.cluster_name, namespace: resource.namespace_name]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile95:\n       percentile(value.apiserver_request_duration_seconds,\n         95)]\n; fetch prometheus_target\n| metric\n    'kubernetes.io/anthos/apiserver_request_duration_seconds/histogram'\n| add [cluster: resource.cluster, namespace: resource.namespace]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile95:\n       percentile(value.histogram,\n         95)] }\n| union"
+                "prometheusQuery": "histogram_quantile(\n  0.95,\n  sum by (project_id, location, cluster_name, namespace_name, le) (\n    rate(kubernetes_io:apiserver_request_duration_seconds_bucket{monitored_resource=\"k8s_container\"}[1m])\n  )\n)"
+              }
+            },
+            {
+              "plotType": "LINE",
+              "targetAxis": "Y1",
+              "timeSeriesQuery": {
+                "prometheusQuery": "histogram_quantile(\n  0.95,\n  sum by (project_id, location, cluster, namespace, le) (\n    rate(kubernetes_io:apiserver_request_duration_seconds_bucket{monitored_resource=\"prometheus_target\"}[1m])\n  )\n)"
               }
             }
           ],

--- a/dashboards/google-anthos/anthos-cluster-control-plane-uptime.json
+++ b/dashboards/google-anthos/anthos-cluster-control-plane-uptime.json
@@ -1,19 +1,25 @@
 {
   "displayName": "Anthos Cluster Control Plane Uptime",
+  "dashboardFilters": [],
   "gridLayout": {
     "columns": "2",
     "widgets": [
       {
         "title": "API Server Uptime",
         "xyChart": {
+          "chartOptions": {
+            "displayHorizontal": false,
+            "mode": "COLOR"
+          },
           "dataSets": [
             {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "targetAxis": "Y1",
               "timeSeriesQuery": {
                 "timeSeriesFilter": {
-                  "filter": "metric.type=\"kubernetes.io/anthos/container/uptime\" resource.type=\"k8s_container\" resource.label.\"container_name\"=monitoring.regex.full_match(\"kube-apiserver\")",
                   "aggregation": {
                     "alignmentPeriod": "60s",
-                    "perSeriesAligner": "ALIGN_MEAN",
                     "crossSeriesReducer": "REDUCE_MEAN",
                     "groupByFields": [
                       "resource.label.\"project_id\"",
@@ -22,39 +28,38 @@
                       "resource.label.\"namespace_name\"",
                       "resource.label.\"pod_name\"",
                       "resource.label.\"container_name\""
-                    ]
+                    ],
+                    "perSeriesAligner": "ALIGN_MEAN"
                   },
-                  "secondaryAggregation": {
-                    "alignmentPeriod": "60s"
-                  }
+                  "filter": "metric.type=\"kubernetes.io/anthos/container/uptime\" resource.type=\"k8s_container\" resource.label.\"container_name\"=monitoring.regex.full_match(\"kube-apiserver\")"
                 }
-              },
-              "plotType": "LINE",
-              "minAlignmentPeriod": "60s",
-              "targetAxis": "Y1"
+              }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
             "scale": "LINEAR"
-          },
-          "chartOptions": {
-            "mode": "COLOR"
           }
         }
       },
       {
         "title": "Scheduler Uptime",
         "xyChart": {
+          "chartOptions": {
+            "displayHorizontal": false,
+            "mode": "COLOR"
+          },
           "dataSets": [
             {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "targetAxis": "Y1",
               "timeSeriesQuery": {
                 "timeSeriesFilter": {
-                  "filter": "metric.type=\"kubernetes.io/anthos/container/uptime\" resource.type=\"k8s_container\" resource.label.\"container_name\"=monitoring.regex.full_match(\"kube-scheduler\")",
                   "aggregation": {
                     "alignmentPeriod": "60s",
-                    "perSeriesAligner": "ALIGN_MEAN",
                     "crossSeriesReducer": "REDUCE_MEAN",
                     "groupByFields": [
                       "resource.label.\"project_id\"",
@@ -63,39 +68,38 @@
                       "resource.label.\"namespace_name\"",
                       "resource.label.\"pod_name\"",
                       "resource.label.\"container_name\""
-                    ]
+                    ],
+                    "perSeriesAligner": "ALIGN_MEAN"
                   },
-                  "secondaryAggregation": {
-                    "alignmentPeriod": "60s"
-                  }
+                  "filter": "metric.type=\"kubernetes.io/anthos/container/uptime\" resource.type=\"k8s_container\" resource.label.\"container_name\"=monitoring.regex.full_match(\"kube-scheduler\")"
                 }
-              },
-              "plotType": "LINE",
-              "minAlignmentPeriod": "60s",
-              "targetAxis": "Y1"
+              }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
             "scale": "LINEAR"
-          },
-          "chartOptions": {
-            "mode": "COLOR"
           }
         }
       },
       {
         "title": "Controller Manager Uptime",
         "xyChart": {
+          "chartOptions": {
+            "displayHorizontal": false,
+            "mode": "COLOR"
+          },
           "dataSets": [
             {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "targetAxis": "Y1",
               "timeSeriesQuery": {
                 "timeSeriesFilter": {
-                  "filter": "metric.type=\"kubernetes.io/anthos/container/uptime\" resource.type=\"k8s_container\" resource.label.\"container_name\"=monitoring.regex.full_match(\"kube-controller-manager\")",
                   "aggregation": {
                     "alignmentPeriod": "60s",
-                    "perSeriesAligner": "ALIGN_MEAN",
                     "crossSeriesReducer": "REDUCE_MEAN",
                     "groupByFields": [
                       "resource.label.\"project_id\"",
@@ -104,39 +108,38 @@
                       "resource.label.\"namespace_name\"",
                       "resource.label.\"pod_name\"",
                       "resource.label.\"container_name\""
-                    ]
+                    ],
+                    "perSeriesAligner": "ALIGN_MEAN"
                   },
-                  "secondaryAggregation": {
-                    "alignmentPeriod": "60s"
-                  }
+                  "filter": "metric.type=\"kubernetes.io/anthos/container/uptime\" resource.type=\"k8s_container\" resource.label.\"container_name\"=monitoring.regex.full_match(\"kube-controller-manager\")"
                 }
-              },
-              "plotType": "LINE",
-              "minAlignmentPeriod": "60s",
-              "targetAxis": "Y1"
+              }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
             "scale": "LINEAR"
-          },
-          "chartOptions": {
-            "mode": "COLOR"
           }
         }
       },
       {
         "title": "ETCD Uptime",
         "xyChart": {
+          "chartOptions": {
+            "displayHorizontal": false,
+            "mode": "COLOR"
+          },
           "dataSets": [
             {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "targetAxis": "Y1",
               "timeSeriesQuery": {
                 "timeSeriesFilter": {
-                  "filter": "metric.type=\"kubernetes.io/anthos/container/uptime\" resource.type=\"k8s_container\" resource.label.\"container_name\"=monitoring.regex.full_match(\".*etcd.*\")",
                   "aggregation": {
                     "alignmentPeriod": "60s",
-                    "perSeriesAligner": "ALIGN_MEAN",
                     "crossSeriesReducer": "REDUCE_MEAN",
                     "groupByFields": [
                       "resource.label.\"project_id\"",
@@ -145,25 +148,19 @@
                       "resource.label.\"namespace_name\"",
                       "resource.label.\"pod_name\"",
                       "resource.label.\"container_name\""
-                    ]
+                    ],
+                    "perSeriesAligner": "ALIGN_MEAN"
                   },
-                  "secondaryAggregation": {
-                    "alignmentPeriod": "60s"
-                  }
+                  "filter": "metric.type=\"kubernetes.io/anthos/container/uptime\" resource.type=\"k8s_container\" resource.label.\"container_name\"=monitoring.regex.full_match(\".*etcd.*\")"
                 }
-              },
-              "plotType": "LINE",
-              "minAlignmentPeriod": "60s",
-              "targetAxis": "Y1"
+              }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
             "scale": "LINEAR"
-          },
-          "chartOptions": {
-            "mode": "COLOR"
           }
         }
       },
@@ -171,6 +168,7 @@
         "title": "API Server Webhook Latency [MEDIAN]",
         "xyChart": {
           "chartOptions": {
+            "displayHorizontal": false,
             "mode": "COLOR"
           },
           "dataSets": [
@@ -178,15 +176,13 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "{ fetch k8s_container\n| metric\n    'kubernetes.io/anthos/apiserver_admission_webhook_admission_duration_seconds'\n| add [cluster: resource.cluster_name, namespace: resource.namespace_name]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile50:\n       percentile(value.apiserver_admission_webhook_admission_duration_seconds,\n         50)]\n; fetch prometheus_target\n| metric\n    'kubernetes.io/anthos/apiserver_admission_webhook_admission_duration_seconds/histogram'\n| add [cluster: resource.cluster, namespace: resource.namespace]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile50:\n       percentile(value.histogram,\n         50)] }\n| union",
-                "unitOverride": ""
+                "timeSeriesQueryLanguage": "{ fetch k8s_container\n| metric\n    'kubernetes.io/anthos/apiserver_admission_webhook_admission_duration_seconds'\n| add [cluster: resource.cluster_name, namespace: resource.namespace_name]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile50:\n       percentile(value.apiserver_admission_webhook_admission_duration_seconds,\n         50)]\n; fetch prometheus_target\n| metric\n    'kubernetes.io/anthos/apiserver_admission_webhook_admission_duration_seconds/histogram'\n| add [cluster: resource.cluster, namespace: resource.namespace]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile50:\n       percentile(value.histogram,\n         50)] }\n| union"
               }
             }
           ],
           "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
-            "label": "",
             "scale": "LINEAR"
           }
         }
@@ -195,6 +191,7 @@
         "title": "API Server Request Latency [MEDIAN]",
         "xyChart": {
           "chartOptions": {
+            "displayHorizontal": false,
             "mode": "COLOR"
           },
           "dataSets": [
@@ -202,15 +199,13 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "{ fetch k8s_container\n| metric\n    'kubernetes.io/anthos/apiserver_request_duration_seconds'\n| add [cluster: resource.cluster_name, namespace: resource.namespace_name]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile50:\n       percentile(value.apiserver_request_duration_seconds,\n         50)]\n; fetch prometheus_target\n| metric\n    'kubernetes.io/anthos/apiserver_request_duration_seconds/histogram'\n| add [cluster: resource.cluster, namespace: resource.namespace]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile50:\n       percentile(value.histogram,\n         50)] }\n| union",
-                "unitOverride": ""
+                "timeSeriesQueryLanguage": "{ fetch k8s_container\n| metric\n    'kubernetes.io/anthos/apiserver_request_duration_seconds'\n| add [cluster: resource.cluster_name, namespace: resource.namespace_name]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile50:\n       percentile(value.apiserver_request_duration_seconds,\n         50)]\n; fetch prometheus_target\n| metric\n    'kubernetes.io/anthos/apiserver_request_duration_seconds/histogram'\n| add [cluster: resource.cluster, namespace: resource.namespace]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile50:\n       percentile(value.histogram,\n         50)] }\n| union"
               }
             }
           ],
           "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
-            "label": "",
             "scale": "LINEAR"
           }
         }
@@ -219,6 +214,7 @@
         "title": "API Server Webhook Latency [95th Percentile]",
         "xyChart": {
           "chartOptions": {
+            "displayHorizontal": false,
             "mode": "COLOR"
           },
           "dataSets": [
@@ -226,15 +222,13 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "{ fetch k8s_container\n| metric\n    'kubernetes.io/anthos/apiserver_admission_webhook_admission_duration_seconds'\n| add [cluster: resource.cluster_name, namespace: resource.namespace_name]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile95:\n       percentile(value.apiserver_admission_webhook_admission_duration_seconds,\n         95)]\n; fetch prometheus_target\n| metric\n    'kubernetes.io/anthos/apiserver_admission_webhook_admission_duration_seconds/histogram'\n| add [cluster: resource.cluster, namespace: resource.namespace]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile95:\n       percentile(value.histogram,\n         95)] }\n| union",
-                "unitOverride": ""
+                "timeSeriesQueryLanguage": "{ fetch k8s_container\n| metric\n    'kubernetes.io/anthos/apiserver_admission_webhook_admission_duration_seconds'\n| add [cluster: resource.cluster_name, namespace: resource.namespace_name]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile95:\n       percentile(value.apiserver_admission_webhook_admission_duration_seconds,\n         95)]\n; fetch prometheus_target\n| metric\n    'kubernetes.io/anthos/apiserver_admission_webhook_admission_duration_seconds/histogram'\n| add [cluster: resource.cluster, namespace: resource.namespace]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile95:\n       percentile(value.histogram,\n         95)] }\n| union"
               }
             }
           ],
           "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
-            "label": "",
             "scale": "LINEAR"
           }
         }
@@ -243,6 +237,7 @@
         "title": "API Server Request Latency [95th Percentile]",
         "xyChart": {
           "chartOptions": {
+            "displayHorizontal": false,
             "mode": "COLOR"
           },
           "dataSets": [
@@ -250,15 +245,13 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "{ fetch k8s_container\n| metric\n    'kubernetes.io/anthos/apiserver_request_duration_seconds'\n| add [cluster: resource.cluster_name, namespace: resource.namespace_name]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile95:\n       percentile(value.apiserver_request_duration_seconds,\n         95)]\n; fetch prometheus_target\n| metric\n    'kubernetes.io/anthos/apiserver_request_duration_seconds/histogram'\n| add [cluster: resource.cluster, namespace: resource.namespace]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile95:\n       percentile(value.histogram,\n         95)] }\n| union",
-                "unitOverride": ""
+                "timeSeriesQueryLanguage": "{ fetch k8s_container\n| metric\n    'kubernetes.io/anthos/apiserver_request_duration_seconds'\n| add [cluster: resource.cluster_name, namespace: resource.namespace_name]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile95:\n       percentile(value.apiserver_request_duration_seconds,\n         95)]\n; fetch prometheus_target\n| metric\n    'kubernetes.io/anthos/apiserver_request_duration_seconds/histogram'\n| add [cluster: resource.cluster, namespace: resource.namespace]\n| align delta(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, cluster, namespace],\n    [value_percentile95:\n       percentile(value.histogram,\n         95)] }\n| union"
               }
             }
           ],
           "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
-            "label": "",
             "scale": "LINEAR"
           }
         }

--- a/dashboards/google-anthos/anthos-cluster-node-status.json
+++ b/dashboards/google-anthos/anthos-cluster-node-status.json
@@ -1,23 +1,34 @@
 {
   "displayName": "Anthos Cluster Node Status",
+  "dashboardFilters": [],
   "gridLayout": {
     "columns": "2",
     "widgets": [
       {
         "title": "Node Count by Condition and Status",
+        "id": "",
         "xyChart": {
           "chartOptions": {
-            "mode": "COLOR"
+            "displayHorizontal": false,
+            "mode": "COLOR",
+            "showLegend": false
           },
           "dataSets": [
             {
+              "breakdowns": [],
+              "dimensions": [],
+              "legendTemplate": "",
+              "measures": [],
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "{ fetch k8s_container\n  | metric 'kubernetes.io/anthos/kube_node_status_condition'\n  | add [cluster: resource.cluster_name]\n  | group_by 1m, [value_mean: mean(value.kube_node_status_condition)]\n  | every 1m\n  | group_by\n      [resource.project_id, resource.location, cluster, metric.condition,\n       metric.status],\n      [value_mean_aggregate: aggregate(value_mean)]\n; fetch prometheus_target\n  | metric 'kubernetes.io/anthos/kube_node_status_condition/gauge'\n  | add [cluster: resource.cluster]\n  | group_by 1m, [value_mean: mean(value.gauge)]\n  | every 1m\n  | group_by\n      [resource.project_id, resource.location, cluster, metric.condition,\n       metric.status],\n      [value_mean_aggregate: aggregate(value_mean)] }\n| union"
+                "outputFullDuration": false,
+                "timeSeriesQueryLanguage": "{ fetch k8s_container\n  | metric 'kubernetes.io/kube_node_status_condition'\n  | add [cluster: resource.cluster_name]\n  | group_by 1m, [value_mean: mean(value.kube_node_status_condition)]\n  | every 1m\n  | group_by\n      [resource.project_id, resource.location, cluster, metric.condition,\n       metric.status],\n      [value_mean_aggregate: aggregate(value_mean)]\n; fetch prometheus_target\n  | metric 'kubernetes.io/kube_node_status_condition/gauge'\n  | add [cluster: resource.cluster]\n  | group_by 1m, [value_mean: mean(value.gauge)]\n  | every 1m\n  | group_by\n      [resource.project_id, resource.location, cluster, metric.condition,\n       metric.status],\n      [value_mean_aggregate: aggregate(value_mean)] }\n| union",
+                "unitOverride": ""
               }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
@@ -29,6 +40,7 @@
         "title": "CPU Usage Per Node Per Mode Per CPU (s/s)",
         "xyChart": {
           "chartOptions": {
+            "displayHorizontal": false,
             "mode": "COLOR"
           },
           "dataSets": [
@@ -36,10 +48,11 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'kubernetes.io/anthos/node/cpu/core_usage_time'\n| align rate(1m)\n| every 1m"
+                "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'kubernetes.io/node/cpu/core_usage_time'\n| align rate(1m)\n| every 1m"
               }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
@@ -51,6 +64,7 @@
         "title": "Allocatable CPU Cores Per Node",
         "xyChart": {
           "chartOptions": {
+            "displayHorizontal": false,
             "mode": "COLOR"
           },
           "dataSets": [
@@ -58,10 +72,11 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'kubernetes.io/anthos/node/cpu/allocatable_cores'\n| group_by 1m, [value_allocatable_cores_mean: mean(value.allocatable_cores)]\n| every 1m"
+                "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'kubernetes.io/node/cpu/allocatable_cores'\n| group_by 1m, [value_allocatable_cores_mean: mean(value.allocatable_cores)]\n| every 1m"
               }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
@@ -73,6 +88,7 @@
         "title": "Memory Usage Per Node (Bytes)",
         "xyChart": {
           "chartOptions": {
+            "displayHorizontal": false,
             "mode": "COLOR"
           },
           "dataSets": [
@@ -84,13 +100,15 @@
                 "timeSeriesFilter": {
                   "aggregation": {
                     "alignmentPeriod": "60s",
+                    "groupByFields": [],
                     "perSeriesAligner": "ALIGN_MEAN"
                   },
-                  "filter": "metric.type=\"kubernetes.io/anthos/node/memory/used_bytes\" resource.type=\"k8s_node\""
+                  "filter": "metric.type=\"kubernetes.io/node/memory/used_bytes\" resource.type=\"k8s_node\""
                 }
               }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
@@ -102,6 +120,7 @@
         "title": "Allocatable Memory Per Node (Bytes)",
         "xyChart": {
           "chartOptions": {
+            "displayHorizontal": false,
             "mode": "COLOR"
           },
           "dataSets": [
@@ -109,10 +128,11 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'kubernetes.io/anthos/node/memory/allocatable_bytes'\n| group_by 1m, [value_allocatable_bytes_mean: mean(value.allocatable_bytes)]\n| every 1m"
+                "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'kubernetes.io/node/memory/allocatable_bytes'\n| group_by 1m, [value_allocatable_bytes_mean: mean(value.allocatable_bytes)]\n| every 1m"
               }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
@@ -122,19 +142,29 @@
       },
       {
         "title": "Available Filesystem Size Per Node Per Device (Bytes)",
+        "id": "",
         "xyChart": {
           "chartOptions": {
-            "mode": "COLOR"
+            "displayHorizontal": false,
+            "mode": "COLOR",
+            "showLegend": false
           },
           "dataSets": [
             {
+              "breakdowns": [],
+              "dimensions": [],
+              "legendTemplate": "",
+              "measures": [],
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "{ fetch k8s_node\n  | metric 'kubernetes.io/anthos/node_filesystem_free_bytes'\n  | add [cluster: resource.cluster_name, node: resource.node_name]\n  | group_by 1m, [value_mean: mean(value.node_filesystem_free_bytes)]\n  | every 1m\n  | group_by\n      [resource.project_id, resource.location, cluster, node, metric.device],\n      [value_mean_aggregate: aggregate(value_mean)]\n; fetch prometheus_target\n  | metric 'kubernetes.io/anthos/node_filesystem_free_bytes/gauge'\n  | add [cluster: resource.cluster, node: resource.instance]\n  | group_by 1m, [value_mean: mean(value.gauge)]\n  | every 1m\n  | group_by\n      [resource.project_id, resource.location, cluster, node, metric.device],\n      [value_mean_aggregate: aggregate(value_mean)] }\n| union"
+                "outputFullDuration": false,
+                "timeSeriesQueryLanguage": "{ fetch k8s_node\n  | metric 'kubernetes.io/node_filesystem_free_bytes'\n  | add [cluster: resource.cluster_name, node: resource.node_name]\n  | group_by 1m, [value_mean: mean(value.node_filesystem_free_bytes)]\n  | every 1m\n  | group_by\n      [resource.project_id, resource.location, cluster, node, metric.device],\n      [value_mean_aggregate: aggregate(value_mean)]\n; fetch prometheus_target\n  | metric 'kubernetes.io/node_filesystem_free_bytes/gauge'\n  | add [cluster: resource.cluster, node: resource.instance]\n  | group_by 1m, [value_mean: mean(value.gauge)]\n  | every 1m\n  | group_by\n      [resource.project_id, resource.location, cluster, node, metric.device],\n      [value_mean_aggregate: aggregate(value_mean)] }\n| union",
+                "unitOverride": ""
               }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
@@ -146,6 +176,7 @@
         "title": "Kubernetes Node - Memory Allocatable Utilization",
         "xyChart": {
           "chartOptions": {
+            "displayHorizontal": false,
             "mode": "COLOR"
           },
           "dataSets": [
@@ -157,13 +188,15 @@
                 "timeSeriesFilter": {
                   "aggregation": {
                     "alignmentPeriod": "60s",
+                    "groupByFields": [],
                     "perSeriesAligner": "ALIGN_MEAN"
                   },
-                  "filter": "metric.type=\"kubernetes.io/anthos/node/memory/allocatable_utilization\" resource.type=\"k8s_node\""
+                  "filter": "metric.type=\"kubernetes.io/node/memory/allocatable_utilization\" resource.type=\"k8s_node\""
                 }
               }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
@@ -175,6 +208,7 @@
         "title": "Kubernetes Node - CPU Allocatable Utilization",
         "xyChart": {
           "chartOptions": {
+            "displayHorizontal": false,
             "mode": "COLOR"
           },
           "dataSets": [
@@ -186,13 +220,15 @@
                 "timeSeriesFilter": {
                   "aggregation": {
                     "alignmentPeriod": "60s",
+                    "groupByFields": [],
                     "perSeriesAligner": "ALIGN_MEAN"
                   },
-                  "filter": "metric.type=\"kubernetes.io/anthos/node/cpu/allocatable_utilization\" resource.type=\"k8s_node\""
+                  "filter": "metric.type=\"kubernetes.io/node/cpu/allocatable_utilization\" resource.type=\"k8s_node\""
                 }
               }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",

--- a/dashboards/google-anthos/anthos-cluster-node-status.json
+++ b/dashboards/google-anthos/anthos-cluster-node-status.json
@@ -6,25 +6,24 @@
     "widgets": [
       {
         "title": "Node Count by Condition and Status",
-        "id": "",
         "xyChart": {
           "chartOptions": {
             "displayHorizontal": false,
-            "mode": "COLOR",
-            "showLegend": false
+            "mode": "COLOR"
           },
           "dataSets": [
             {
-              "breakdowns": [],
-              "dimensions": [],
-              "legendTemplate": "",
-              "measures": [],
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "outputFullDuration": false,
-                "timeSeriesQueryLanguage": "{ fetch k8s_container\n  | metric 'kubernetes.io/kube_node_status_condition'\n  | add [cluster: resource.cluster_name]\n  | group_by 1m, [value_mean: mean(value.kube_node_status_condition)]\n  | every 1m\n  | group_by\n      [resource.project_id, resource.location, cluster, metric.condition,\n       metric.status],\n      [value_mean_aggregate: aggregate(value_mean)]\n; fetch prometheus_target\n  | metric 'kubernetes.io/kube_node_status_condition/gauge'\n  | add [cluster: resource.cluster]\n  | group_by 1m, [value_mean: mean(value.gauge)]\n  | every 1m\n  | group_by\n      [resource.project_id, resource.location, cluster, metric.condition,\n       metric.status],\n      [value_mean_aggregate: aggregate(value_mean)] }\n| union",
-                "unitOverride": ""
+                "prometheusQuery": "sum by (project_id, location, cluster_name, condition, status) (\n  avg_over_time(kubernetes_io:anthos_kube_node_status_condition{monitored_resource=\"k8s_container\"}[1m])\n)"
+              }
+            },
+            {
+              "plotType": "LINE",
+              "targetAxis": "Y1",
+              "timeSeriesQuery": {
+                "prometheusQuery": "sum by (project_id, location, cluster, condition, status) (\n  avg_over_time(kubernetes_io:anthos_kube_node_status_condition_gauge{monitored_resource=\"prometheus_target\"}[1m])\n)"
               }
             }
           ],
@@ -48,7 +47,7 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'kubernetes.io/node/cpu/core_usage_time'\n| align rate(1m)\n| every 1m"
+                "prometheusQuery": "rate(kubernetes_io:node_cpu_core_usage_time{monitored_resource=\"k8s_node\"}[1m])\n"
               }
             }
           ],
@@ -72,7 +71,7 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'kubernetes.io/node/cpu/allocatable_cores'\n| group_by 1m, [value_allocatable_cores_mean: mean(value.allocatable_cores)]\n| every 1m"
+                "prometheusQuery": "avg_over_time(kubernetes_io:anthos_node_cpu_allocatable_cores{monitored_resource=\"k8s_node\"}[1m])"
               }
             }
           ],
@@ -103,7 +102,7 @@
                     "groupByFields": [],
                     "perSeriesAligner": "ALIGN_MEAN"
                   },
-                  "filter": "metric.type=\"kubernetes.io/node/memory/used_bytes\" resource.type=\"k8s_node\""
+                  "filter": "metric.type=\"kubernetes.io/anthos/node/memory/used_bytes\" resource.type=\"k8s_node\""
                 }
               }
             }
@@ -128,7 +127,7 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'kubernetes.io/node/memory/allocatable_bytes'\n| group_by 1m, [value_allocatable_bytes_mean: mean(value.allocatable_bytes)]\n| every 1m"
+                "prometheusQuery": "avg_over_time(kubernetes_io:node_memory_allocatable_bytes{monitored_resource=\"k8s_node\"}[1m])\n"
               }
             }
           ],
@@ -142,25 +141,24 @@
       },
       {
         "title": "Available Filesystem Size Per Node Per Device (Bytes)",
-        "id": "",
         "xyChart": {
           "chartOptions": {
             "displayHorizontal": false,
-            "mode": "COLOR",
-            "showLegend": false
+            "mode": "COLOR"
           },
           "dataSets": [
             {
-              "breakdowns": [],
-              "dimensions": [],
-              "legendTemplate": "",
-              "measures": [],
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "outputFullDuration": false,
-                "timeSeriesQueryLanguage": "{ fetch k8s_node\n  | metric 'kubernetes.io/node_filesystem_free_bytes'\n  | add [cluster: resource.cluster_name, node: resource.node_name]\n  | group_by 1m, [value_mean: mean(value.node_filesystem_free_bytes)]\n  | every 1m\n  | group_by\n      [resource.project_id, resource.location, cluster, node, metric.device],\n      [value_mean_aggregate: aggregate(value_mean)]\n; fetch prometheus_target\n  | metric 'kubernetes.io/node_filesystem_free_bytes/gauge'\n  | add [cluster: resource.cluster, node: resource.instance]\n  | group_by 1m, [value_mean: mean(value.gauge)]\n  | every 1m\n  | group_by\n      [resource.project_id, resource.location, cluster, node, metric.device],\n      [value_mean_aggregate: aggregate(value_mean)] }\n| union",
-                "unitOverride": ""
+                "prometheusQuery": "sum by (project_id, location, cluster_name, node_name, device) (\n  avg_over_time(kubernetes_io:node_filesystem_free_bytes{monitored_resource=\"k8s_node\"}[1m])\n)"
+              }
+            },
+            {
+              "plotType": "LINE",
+              "targetAxis": "Y1",
+              "timeSeriesQuery": {
+                "prometheusQuery": "sum by (project_id, location, cluster, instance, device) (\n  avg_over_time(kubernetes_io:node_filesystem_free_bytes_gauge{monitored_resource=\"prometheus_target\"}[1m])\n)"
               }
             }
           ],

--- a/dashboards/google-anthos/anthos-cluster-on-vmware-vm-status.json
+++ b/dashboards/google-anthos/anthos-cluster-on-vmware-vm-status.json
@@ -1,104 +1,116 @@
 {
   "displayName": "Anthos Cluster on VMware VM Status",
+  "dashboardFilters": [],
   "gridLayout": {
     "columns": "2",
     "widgets": [
       {
         "title": "CPU Readiness Per vCPU (Percentage)",
         "xyChart": {
+          "chartOptions": {
+            "displayHorizontal": false,
+            "mode": "COLOR"
+          },
           "dataSets": [
             {
+              "plotType": "LINE",
+              "targetAxis": "Y1",
               "timeSeriesQuery": {
                 "timeSeriesQueryLanguage": "{ fetch k8s_pod::kubernetes.io/anthos/vm_cpu_ready_seconds\n  | align rate(1m)\n  | add\n      [cluster_name:\n         if(re_full_match(resource.namespace_name, 'kube-system'),\n           resource.cluster_name, resource.namespace_name), node: metric.node]\n  | every 1m\n  | group_by [resource.project_id, cluster_name, resource.location, node],\n      [value_vm_cpu_ready_seconds_aggregate:\n         aggregate(value.vm_cpu_ready_seconds)]\n; fetch k8s_node::kubernetes.io/anthos/node/cpu/total_cores\n  | every 1m\n  | add [cluster_name: resource.cluster_name, node: resource.node_name]\n  | group_by [resource.project_id, resource.location, cluster_name, node],\n      [value_total_cores_aggregate: aggregate(value.total_cores)] }\n| join\n| div\n| mul (100)"
-              },
-              "plotType": "LINE"
+              }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
             "scale": "LINEAR"
-          },
-          "chartOptions": {
-            "mode": "COLOR"
           }
         }
       },
       {
         "title": "Memory Page Fault Latency (Percentage)",
         "xyChart": {
+          "chartOptions": {
+            "displayHorizontal": false,
+            "mode": "COLOR"
+          },
           "dataSets": [
             {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "targetAxis": "Y1",
               "timeSeriesQuery": {
                 "timeSeriesFilter": {
-                  "filter": "metric.type=\"kubernetes.io/anthos/vm_memory_access_latency\" resource.type=\"k8s_pod\"",
                   "aggregation": {
-                    "perSeriesAligner": "ALIGN_MEAN",
+                    "alignmentPeriod": "60s",
                     "crossSeriesReducer": "REDUCE_SUM",
                     "groupByFields": [
                       "resource.label.\"project_id\"",
                       "resource.label.\"location\"",
                       "resource.label.\"cluster_name\"",
                       "metric.label.\"node\""
-                    ]
+                    ],
+                    "perSeriesAligner": "ALIGN_MEAN"
                   },
-                  "secondaryAggregation": {}
-                },
-                "unitOverride": "1"
-              },
-              "plotType": "LINE",
-              "minAlignmentPeriod": "60s"
+                  "filter": "metric.type=\"kubernetes.io/anthos/vm_memory_access_latency\" resource.type=\"k8s_pod\""
+                }
+              }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
             "scale": "LINEAR"
-          },
-          "chartOptions": {
-            "mode": "COLOR"
           }
         }
       },
       {
         "title": "Average Virtual Disk Read Latency (Seconds)",
         "xyChart": {
+          "chartOptions": {
+            "displayHorizontal": false,
+            "mode": "COLOR"
+          },
           "dataSets": [
             {
+              "plotType": "LINE",
+              "targetAxis": "Y1",
               "timeSeriesQuery": {
                 "timeSeriesQueryLanguage": "{ fetch k8s_pod::kubernetes.io/anthos/vm_virtualdisk_read_latency_seconds\n  | align rate(1m)\n  | every 1m\n  | group_by\n      [resource.project_id, resource.cluster_name, resource.location,\n       metric.node],\n      [value_vm_virtualdisk_read_latency_seconds_sum:\n         sum(value.vm_virtualdisk_read_latency_seconds)]\n; fetch k8s_pod::kubernetes.io/anthos/vm_number_virtualdisk\n  | every 1m\n  | group_by\n      [resource.project_id, resource.cluster_name, resource.location,\n       metric.node],\n      [value_vm_number_virtualdisk_sum: sum(value.vm_number_virtualdisk)] }\n| join\n| div"
-              },
-              "plotType": "LINE"
+              }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
             "scale": "LINEAR"
-          },
-          "chartOptions": {
-            "mode": "COLOR"
           }
         }
       },
       {
         "title": "Average Virtual Disk Write Latency (Seconds)",
         "xyChart": {
+          "chartOptions": {
+            "displayHorizontal": false,
+            "mode": "COLOR"
+          },
           "dataSets": [
             {
+              "plotType": "LINE",
+              "targetAxis": "Y1",
               "timeSeriesQuery": {
                 "timeSeriesQueryLanguage": "{ fetch k8s_pod::kubernetes.io/anthos/vm_virtualdisk_write_latency_seconds\n  | align rate(1m)\n  | every 1m\n  | group_by\n      [resource.project_id, resource.cluster_name, resource.location,\n       metric.node],\n      [value_vm_virtualdisk_write_latency_seconds_sum:\n         sum(value.vm_virtualdisk_write_latency_seconds)]\n; fetch k8s_pod::kubernetes.io/anthos/vm_number_virtualdisk\n  | every 1m\n  | group_by\n      [resource.project_id, resource.cluster_name, resource.location,\n       metric.node],\n      [value_vm_number_virtualdisk_sum: sum(value.vm_number_virtualdisk)] }\n| join\n| div"
-              },
-              "plotType": "LINE"
+              }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
             "scale": "LINEAR"
-          },
-          "chartOptions": {
-            "mode": "COLOR"
           }
         }
       }

--- a/dashboards/google-anthos/anthos-cluster-on-vmware-vm-status.json
+++ b/dashboards/google-anthos/anthos-cluster-on-vmware-vm-status.json
@@ -16,7 +16,7 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "{ fetch k8s_pod::kubernetes.io/anthos/vm_cpu_ready_seconds\n  | align rate(1m)\n  | add\n      [cluster_name:\n         if(re_full_match(resource.namespace_name, 'kube-system'),\n           resource.cluster_name, resource.namespace_name), node: metric.node]\n  | every 1m\n  | group_by [resource.project_id, cluster_name, resource.location, node],\n      [value_vm_cpu_ready_seconds_aggregate:\n         aggregate(value.vm_cpu_ready_seconds)]\n; fetch k8s_node::kubernetes.io/anthos/node/cpu/total_cores\n  | every 1m\n  | add [cluster_name: resource.cluster_name, node: resource.node_name]\n  | group_by [resource.project_id, resource.location, cluster_name, node],\n      [value_total_cores_aggregate: aggregate(value.total_cores)] }\n| join\n| div\n| mul (100)"
+                "prometheusQuery": "100 *\n(\n  sum by (project_id, cluster_name, location, node) (\n    # Case 1: kube-system — use cluster_name as-is\n    label_replace(\n      rate(kubernetes_io:anthos_vm_cpu_ready_seconds_sum{monitored_resource=\"k8s_pod\", namespace_name=\"kube-system\"}[1m]),\n      \"cluster_name\", \"$1\", \"cluster_name\", \"(.*)\"\n    )\n    or\n    # Case 2: all other namespaces — set cluster_name = namespace_name\n    label_replace(\n      rate(kubernetes_io:anthos_vm_cpu_ready_seconds_sum{monitored_resource=\"k8s_pod\", namespace_name!~\"kube-system\"}[1m]),\n      \"cluster_name\", \"$1\", \"namespace_name\", \"(.*)\"\n    )\n  )\n)\n/\n(\n  sum by (project_id, cluster_name, location, node) (\n    label_replace(\n      kubernetes_io:anthos_node_cpu_total_cores{monitored_resource=\"k8s_node\"},\n      \"node\", \"$1\", \"node_name\", \"(.*)\"\n    )\n  )\n)\n"
               }
             }
           ],
@@ -78,7 +78,7 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "{ fetch k8s_pod::kubernetes.io/anthos/vm_virtualdisk_read_latency_seconds\n  | align rate(1m)\n  | every 1m\n  | group_by\n      [resource.project_id, resource.cluster_name, resource.location,\n       metric.node],\n      [value_vm_virtualdisk_read_latency_seconds_sum:\n         sum(value.vm_virtualdisk_read_latency_seconds)]\n; fetch k8s_pod::kubernetes.io/anthos/vm_number_virtualdisk\n  | every 1m\n  | group_by\n      [resource.project_id, resource.cluster_name, resource.location,\n       metric.node],\n      [value_vm_number_virtualdisk_sum: sum(value.vm_number_virtualdisk)] }\n| join\n| div"
+                "prometheusQuery": "(\n  sum by (project_id, cluster_name, location, node) (\n    rate(kubernetes_io:anthos_vm_virtualdisk_read_latency_seconds_sum{monitored_resource=\"k8s_pod\"}[1m])\n  )\n)\n/\n(\n  sum by (project_id, cluster_name, location, node) (\n    kubernetes_io:anthos_vm_number_virtualdisk{monitored_resource=\"k8s_pod\"}\n  )\n)"
               }
             }
           ],
@@ -102,7 +102,7 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "{ fetch k8s_pod::kubernetes.io/anthos/vm_virtualdisk_write_latency_seconds\n  | align rate(1m)\n  | every 1m\n  | group_by\n      [resource.project_id, resource.cluster_name, resource.location,\n       metric.node],\n      [value_vm_virtualdisk_write_latency_seconds_sum:\n         sum(value.vm_virtualdisk_write_latency_seconds)]\n; fetch k8s_pod::kubernetes.io/anthos/vm_number_virtualdisk\n  | every 1m\n  | group_by\n      [resource.project_id, resource.cluster_name, resource.location,\n       metric.node],\n      [value_vm_number_virtualdisk_sum: sum(value.vm_number_virtualdisk)] }\n| join\n| div"
+                "prometheusQuery": "(\n  sum by (project_id, cluster_name, location, node) (\n    rate(kubernetes_io:anthos_vm_virtualdisk_write_latency_seconds_sum{monitored_resource=\"k8s_pod\"}[1m])\n  )\n)\n/\n(\n  sum by (project_id, cluster_name, location, node) (\n    kubernetes_io:anthos_vm_number_virtualdisk{monitored_resource=\"k8s_pod\"}\n  )\n)"
               }
             }
           ],

--- a/dashboards/google-anthos/anthos-cluster-pod-status.json
+++ b/dashboards/google-anthos/anthos-cluster-pod-status.json
@@ -1,5 +1,6 @@
 {
   "displayName": "Anthos Cluster Pod Status",
+  "dashboardFilters": [],
   "gridLayout": {
     "columns": "2",
     "widgets": [
@@ -7,6 +8,7 @@
         "title": "Number of Restarts per Container",
         "xyChart": {
           "chartOptions": {
+            "displayHorizontal": false,
             "mode": "COLOR"
           },
           "dataSets": [
@@ -18,6 +20,7 @@
               }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
@@ -29,6 +32,7 @@
         "title": "Container Memory Usage Per Container",
         "xyChart": {
           "chartOptions": {
+            "displayHorizontal": false,
             "mode": "COLOR"
           },
           "dataSets": [
@@ -40,6 +44,7 @@
               }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
@@ -51,6 +56,7 @@
         "title": "Container CPU Usage Per Container",
         "xyChart": {
           "chartOptions": {
+            "displayHorizontal": false,
             "mode": "COLOR"
           },
           "dataSets": [
@@ -62,6 +68,7 @@
               }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
@@ -73,6 +80,7 @@
         "title": "Network ingress Per Pod (Bytes)",
         "xyChart": {
           "chartOptions": {
+            "displayHorizontal": false,
             "mode": "COLOR"
           },
           "dataSets": [
@@ -84,6 +92,7 @@
               }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
@@ -95,6 +104,7 @@
         "title": "Network Egress Per Pod (Bytes)",
         "xyChart": {
           "chartOptions": {
+            "displayHorizontal": false,
             "mode": "COLOR"
           },
           "dataSets": [
@@ -106,6 +116,7 @@
               }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
@@ -117,6 +128,7 @@
         "title": "Pod Count by Phase",
         "xyChart": {
           "chartOptions": {
+            "displayHorizontal": false,
             "mode": "COLOR"
           },
           "dataSets": [
@@ -128,6 +140,7 @@
               }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
@@ -139,6 +152,7 @@
         "title": "Kubernetes Container - Memory Request Utilization",
         "xyChart": {
           "chartOptions": {
+            "displayHorizontal": false,
             "mode": "COLOR"
           },
           "dataSets": [
@@ -150,6 +164,7 @@
               }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
@@ -161,6 +176,7 @@
         "title": "Kubernetes Container - Memory Limit Utilization",
         "xyChart": {
           "chartOptions": {
+            "displayHorizontal": false,
             "mode": "COLOR"
           },
           "dataSets": [
@@ -172,6 +188,7 @@
               }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
@@ -183,6 +200,7 @@
         "title": "Kubernetes Container - CPU Request Utilization",
         "xyChart": {
           "chartOptions": {
+            "displayHorizontal": false,
             "mode": "COLOR"
           },
           "dataSets": [
@@ -194,6 +212,7 @@
               }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
@@ -205,6 +224,7 @@
         "title": "Kubernetes Container - CPU Limit Utilization",
         "xyChart": {
           "chartOptions": {
+            "displayHorizontal": false,
             "mode": "COLOR"
           },
           "dataSets": [
@@ -216,6 +236,7 @@
               }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
@@ -227,6 +248,7 @@
         "title": "Kubernetes Pod - Volume Utilization",
         "xyChart": {
           "chartOptions": {
+            "displayHorizontal": false,
             "mode": "COLOR"
           },
           "dataSets": [
@@ -238,6 +260,7 @@
               }
             }
           ],
+          "thresholds": [],
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",

--- a/dashboards/google-anthos/anthos-cluster-pod-status.json
+++ b/dashboards/google-anthos/anthos-cluster-pod-status.json
@@ -16,7 +16,7 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "fetch k8s_container\n| metric 'kubernetes.io/anthos/container/restart_count'\n| align delta(2m)\n| every 2m\n| group_by\n    [resource.project_id, resource.location, resource.cluster_name,\n     resource.container_name],\n    [value_restart_count_aggregate: aggregate(value.restart_count)]"
+                "prometheusQuery": "sum by (project_id, location, cluster_name, container_name) (\n  rate(kubernetes_io:anthos_container_restart_count_sum{monitored_resource=\"k8s_container\"}[2m])\n)\n"
               }
             }
           ],
@@ -40,7 +40,7 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "fetch k8s_container\n| metric 'kubernetes.io/anthos/container/memory/used_bytes'\n| filter (metric.memory_type == 'non-evictable')\n| group_by 1m, [value_used_bytes_mean: mean(value.used_bytes)]\n| every 1m\n"
+                "prometheusQuery": "avg_over_time(\n  kubernetes_io:anthos_container_memory_used_bytes{monitored_resource=\"k8s_container\", memory_type=\"non-evictable\"}[1m]\n)"
               }
             }
           ],
@@ -64,7 +64,7 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "fetch k8s_container\n| metric 'kubernetes.io/anthos/container/cpu/core_usage_time'\n| align rate(1m)\n| every 1m"
+                "prometheusQuery": "rate(kubernetes_io:anthos_container_cpu_core_usage_time{monitored_resource=\"k8s_container\"}[1m])\n"
               }
             }
           ],
@@ -88,7 +88,7 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "fetch k8s_pod\n| metric 'kubernetes.io/anthos/pod/network/received_bytes_count'\n| align rate(1m)\n| every 1m\n"
+                "prometheusQuery": "rate(kubernetes_io:anthos_pod_network_received_bytes_count{monitored_resource=\"k8s_pod\"}[1m])\n"
               }
             }
           ],
@@ -112,7 +112,7 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "fetch k8s_pod\n| metric 'kubernetes.io/anthos/pod/network/sent_bytes_count'\n| align rate(1m)\n| every 1m\n"
+                "prometheusQuery": "rate(kubernetes_io:anthos_pod_network_sent_bytes_count{monitored_resource=\"k8s_pod\"}[1m])\n"
               }
             }
           ],
@@ -136,7 +136,14 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "{ fetch k8s_container\n  | metric 'kubernetes.io/anthos/kube_pod_status_phase'\n  | add [cluster: resource.cluster_name]\n  | group_by 1m, [value_phase_mean: mean(value.kube_pod_status_phase)]\n  | every 1m\n  | group_by [metric.phase, resource.project_id, resource.location, cluster],\n      [value_phase_mean_aggregate: aggregate(value_phase_mean)]\n; fetch prometheus_target\n  | metric 'kubernetes.io/anthos/kube_pod_status_phase/gauge'\n  | add [cluster: resource.cluster]\n  | group_by 1m, [value_phase_mean: mean(value.gauge)]\n  | every 1m\n  | group_by [metric.phase, resource.project_id, resource.location, cluster],\n      [value_phase_mean_aggregate: aggregate(value_phase_mean)] }\n| union"
+                "prometheusQuery": "sum by (phase, project_id, location, cluster_name) (\n  avg_over_time(kubernetes_io:anthos_kube_pod_status_phase{monitored_resource=\"k8s_container\"}[1m])\n)\n\n"
+              }
+            },
+            {
+              "plotType": "LINE",
+              "targetAxis": "Y1",
+              "timeSeriesQuery": {
+                "prometheusQuery": "sum by (phase, project_id, location, cluster) (\n  avg_over_time(kubernetes_io:anthos_kube_pod_status_phase_gauge[1m])\n)"
               }
             }
           ],
@@ -160,7 +167,8 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "fetch k8s_container\n| metric 'kubernetes.io/anthos/container/memory/request_utilization'\n| group_by 1m, [value_request_utilization_mean: mean(value.request_utilization)]\n| every 1m\n| scale '%'"
+                "prometheusQuery": "100 * avg_over_time(kubernetes_io:anthos_container_memory_request_utilization{monitored_resource=\"k8s_container\"}[1m])\n",
+                "unitOverride": "%"
               }
             }
           ],
@@ -184,7 +192,8 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "fetch k8s_container\n| metric 'kubernetes.io/anthos/container/memory/limit_utilization'\n| group_by 1m, [value_limit_utilization_mean: mean(value.limit_utilization)]\n| every 1m\n| scale '%'"
+                "prometheusQuery": "avg_over_time(kubernetes_io:anthos_container_memory_limit_utilization{monitored_resource=\"k8s_container\"}[1m]) * 100\n",
+                "unitOverride": "%"
               }
             }
           ],
@@ -208,7 +217,8 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "fetch k8s_container\n| metric 'kubernetes.io/anthos/container/cpu/request_utilization'\n| group_by 1m, [value_request_utilization_mean: mean(value.request_utilization)]\n| every 1m\n| scale '%'"
+                "prometheusQuery": "avg_over_time(kubernetes_io:anthos_container_cpu_request_utilization{monitored_resource=\"k8s_container\"}[1m]) * 100\n",
+                "unitOverride": "%"
               }
             }
           ],
@@ -232,7 +242,8 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "fetch k8s_container\n| metric 'kubernetes.io/anthos/container/cpu/limit_utilization'\n| group_by 1m, [value_limit_utilization_mean: mean(value.limit_utilization)]\n| every 1m\n| scale '%'"
+                "prometheusQuery": "avg_over_time(kubernetes_io:anthos_container_cpu_limit_utilization{monitored_resource=\"k8s_container\"}[1m]) * 100\n",
+                "unitOverride": "%"
               }
             }
           ],
@@ -256,7 +267,8 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "timeSeriesQueryLanguage": "fetch k8s_pod\n| metric 'kubernetes.io/anthos/pod/volume/utilization'\n| group_by 1m, [value_utilization_mean: mean(value.utilization)]\n| every 1m\n| scale '%'"
+                "prometheusQuery": "avg_over_time(kubernetes_io:anthos_pod_volume_utilization{monitored_resource=\"k8s_pod\"}[1m]) * 100\n",
+                "unitOverride": "%"
               }
             }
           ],


### PR DESCRIPTION
This PR updates the Google Anthos Dashboards to use PromQL instead of the deprecated MQL.

No screenshots are included here, since generating load on Anthos metrics is non-trivial. Conversions are best effort, but should largely be 1-1. Exception is MQL queries that UNION two queries with different monitored resources - for clarity, these queries have been split into two separate PromQL queries for the same dashboard panel.

Apologies for the slightly unclean diff for the `PromQL` in the `anthos-cluster-node-status.json` file - lack of load gen resulted in a panel that I couldn't `Apply`, meaning I couldn't save it with the updated structure. Hopefully it is not too much of a review obstacle.