### PR TITLE
PromQL: GKE System logs

### DIFF
--- a/dashboards/logging/gke-system-usage.json
+++ b/dashboards/logging/gke-system-usage.json
@@ -35,7 +35,8 @@
             "thresholds": [],
             "timeSeriesQuery": {
               "outputFullDuration": false,
-              "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'logging.googleapis.com/byte_count'\n| filter\n    (metric.log == 'container-runtime') || (metric.log = 'docker')\n    || (metric.log == 'kube-container-runtime-monitor')\n    || (metric.log == 'kube-logrotate')\n    || (metric.log == 'kube-node-configuration')\n    || (metric.log == 'kube-node-installation') || (metric.log == 'kubelet')\n    || (metric.log == 'kubelet-monitor') || (metric.log == 'node-journal')\n    || (metric.log == 'node-problem-detector')\n| group_by [], sum(value.byte_count)\n| every 30d"
+              "prometheusQuery": "sum(\n  increase(\n    logging_googleapis_com:byte_count{\n      monitored_resource=\"k8s_node\",\n      log=~\"^(container-runtime|docker|kube-container-runtime-monitor|kube-logrotate|kube-node-configuration|kube-node-installation|kubelet|kubelet-monitor|node-journal|node-problem-detector)$\"\n    }[30d]\n  )\n)\n",
+              "unitOverride": "By"
             }
           }
         }
@@ -51,7 +52,8 @@
             "thresholds": [],
             "timeSeriesQuery": {
               "outputFullDuration": false,
-              "timeSeriesQueryLanguage": "fetch k8s_container\n| metric 'logging.googleapis.com/byte_count'\n| filter\n   (resource.namespace_name == 'cnrm-system')\n   || (resource.namespace_name == 'docker')\n   || (resource.namespace_name == 'config-management-system')\n   || (resource.namespace_name == 'gatekeeper-system')\n   || (resource.namespace_name == 'gke-connect')\n   || (resource.namespace_name == 'gke-system')\n   || (resource.namespace_name == 'istio-system')\n   || (resource.namespace_name == 'knative-serving')\n   || (resource.namespace_name == 'monitoring-system')\n   || (resource.namespace_name == 'kube-system')\n| group_by [], sum(value.byte_count)\n| every 30d\n"
+              "prometheusQuery": "sum(\n  increase (\n    logging_googleapis_com:byte_count{\n      monitored_resource=\"k8s_container\",\n      namespace_name=~\"^(cnrm-system|docker|config-management-system|gatekeeper-system|gke-connect|gke-system|istio-system|knative-serving|monitoring-system|kube-system)$\"\n    }[30d]\n  )\n)",
+              "unitOverride": "By"
             }
           }
         }
@@ -67,7 +69,8 @@
             "thresholds": [],
             "timeSeriesQuery": {
               "outputFullDuration": false,
-              "timeSeriesQueryLanguage": "fetch k8s_pod\n| metric 'logging.googleapis.com/byte_count'\n| filter\n    (resource.namespace_name == 'cnrm-system')\n    || (resource.namespace_name == 'docker')\n    || (resource.namespace_name == 'config-management-system')\n    || (resource.namespace_name == 'gatekeeper-system')\n    || (resource.namespace_name == 'gke-connect')\n    || (resource.namespace_name == 'gke-system')\n    || (resource.namespace_name == 'istio-system')\n    || (resource.namespace_name == 'knative-serving')\n    || (resource.namespace_name == 'monitoring-system')\n    || (resource.namespace_name == 'kube-system')\n| group_by [], [value_byte_count_aggregate_aggregate: sum(value.byte_count)]\n| every 30d"
+              "prometheusQuery": "sum(\n  increase (\n    logging_googleapis_com:byte_count{\n      monitored_resource=\"k8s_pod\",\n      namespace_name=~\"^(cnrm-system|docker|config-management-system|gatekeeper-system|gke-connect|gke-system|istio-system|knative-serving|monitoring-system|kube-system)$\"\n    }[30d]\n  )\n)",
+              "unitOverride": "By"
             }
           }
         }
@@ -109,7 +112,8 @@
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'logging.googleapis.com/byte_count'\n| filter\n    (metric.log == 'container-runtime') \n    || (metric.log = 'docker')\n    || (metric.log == 'kube-container-runtime-monitor')\n    || (metric.log == 'kube-logrotate')\n    || (metric.log == 'kube-node-configuration')\n    || (metric.log == 'kube-node-installation') || (metric.log == 'kubelet')\n    || (metric.log == 'kubelet-monitor') \n    || (metric.log == 'node-journal')\n    || (metric.log == 'node-problem-detector')\n| group_by [project_id], sum(value.byte_count)\n| every 1d"
+                  "prometheusQuery": "sum by (project_id) (\n  increase(\n    logging_googleapis_com:byte_count{\n      monitored_resource=\"k8s_node\",\n      log=~\"^(container-runtime|docker|kube-container-runtime-monitor|kube-logrotate|kube-node-configuration|kube-node-installation|kubelet|kubelet-monitor|node-journal|node-problem-detector)$\"\n    }\n  [1d])\n)\n",
+                  "unitOverride": "By"
                 }
               }
             ],
@@ -137,7 +141,8 @@
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| metric 'logging.googleapis.com/byte_count'\n| filter\n    (resource.namespace_name == 'cnrm-system')\n    || (resource.namespace_name == 'docker')\n    || (resource.namespace_name == 'config-management-system')\n    || (resource.namespace_name == 'gatekeeper-system')\n    || (resource.namespace_name == 'gke-connect')\n    || (resource.namespace_name == 'gke-system')\n    || (resource.namespace_name == 'istio-system')\n    || (resource.namespace_name == 'knative-serving')\n    || (resource.namespace_name == 'monitoring-system')\n    || (resource.namespace_name == 'kube-system')\n| group_by [project_id], sum(value.byte_count)\n| every 1d"
+                  "prometheusQuery": "sum by (project_id) (\n  increase(\n    logging_googleapis_com:byte_count{\n      monitored_resource=\"k8s_container\",\n      namespace_name=~\"^(cnrm-system|docker|config-management-system|gatekeeper-system|gke-connect|gke-system|istio-system|knative-serving|monitoring-system|kube-system)$\"\n    }[1d]\n  )\n)\n",
+                  "unitOverride": "By"
                 }
               }
             ],
@@ -165,7 +170,8 @@
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_pod\n| metric 'logging.googleapis.com/byte_count'\n| filter\n    (resource.namespace_name == 'cnrm-system')\n    || (resource.namespace_name == 'docker')\n    || (resource.namespace_name == 'config-management-system')\n    || (resource.namespace_name == 'gatekeeper-system')\n    || (resource.namespace_name == 'gke-connect')\n    || (resource.namespace_name == 'gke-system')\n    || (resource.namespace_name == 'istio-system')\n    || (resource.namespace_name == 'knative-serving')\n    || (resource.namespace_name == 'monitoring-system')\n    || (resource.namespace_name == 'kube-system')\n| group_by [project_id], sum(value.byte_count)\n| every 1d"
+                  "prometheusQuery": "sum by (project_id) (\n  increase(\n    logging_googleapis_com:byte_count{\n      monitored_resource=\"k8s_pod\",\n      namespace_name=~\"^(cnrm-system|docker|config-management-system|gatekeeper-system|gke-connect|gke-system|istio-system|knative-serving|monitoring-system|kube-system)$\"\n    }[1d]\n  )\n)\n",
+                  "unitOverride": "By"
                 }
               }
             ],

--- a/dashboards/logging/gke-system-usage.json
+++ b/dashboards/logging/gke-system-usage.json
@@ -1,147 +1,180 @@
 {
   "displayName": "GKE System logs",
+  "dashboardFilters": [],
+  "labels": {},
   "mosaicLayout": {
-    "columns": 12,
+    "columns": 48,
     "tiles": [
       {
         "height": 4,
+        "width": 48,
         "widget": {
-          "title": "GKE system logs – k8s_container logs",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "STACKED_AREA",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| metric 'logging.googleapis.com/byte_count'\n| filter\n    (resource.namespace_name == 'cnrm-system')\n    || (resource.namespace_name == 'docker')\n    || (resource.namespace_name == 'config-management-system')\n    || (resource.namespace_name == 'gatekeeper-system')\n    || (resource.namespace_name == 'gke-connect')\n    || (resource.namespace_name == 'gke-system')\n    || (resource.namespace_name == 'istio-system')\n    || (resource.namespace_name == 'knative-serving')\n    || (resource.namespace_name == 'monitoring-system')\n    || (resource.namespace_name == 'kube-system')\n| group_by [project_id], sum(value.byte_count)\n| every 1d"
-                }
-              }
-            ],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "scale": "LINEAR"
+          "title": "Monthly GKE system log volume",
+          "text": {
+            "content": "",
+            "format": "MARKDOWN",
+            "style": {
+              "backgroundColor": "#FFFFFF",
+              "fontSize": "FS_LARGE",
+              "horizontalAlignment": "H_LEFT",
+              "padding": "P_EXTRA_SMALL",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "#212121",
+              "verticalAlignment": "V_TOP"
             }
           }
-        },
-        "width": 4,
-        "xPos": 4,
-        "yPos": 5
+        }
       },
       {
-        "height": 4,
+        "yPos": 4,
+        "height": 8,
+        "width": 16,
         "widget": {
-          "title": "GKE system logs – k8s_pod",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "STACKED_AREA",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_pod\n| metric 'logging.googleapis.com/byte_count'\n| filter\n    (resource.namespace_name == 'cnrm-system')\n    || (resource.namespace_name == 'docker')\n    || (resource.namespace_name == 'config-management-system')\n    || (resource.namespace_name == 'gatekeeper-system')\n    || (resource.namespace_name == 'gke-connect')\n    || (resource.namespace_name == 'gke-system')\n    || (resource.namespace_name == 'istio-system')\n    || (resource.namespace_name == 'knative-serving')\n    || (resource.namespace_name == 'monitoring-system')\n    || (resource.namespace_name == 'kube-system')\n| group_by [project_id], sum(value.byte_count)\n| every 1d"
-                }
-              }
-            ],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "scale": "LINEAR"
+          "title": "Node Byte Count",
+          "scorecard": {
+            "thresholds": [],
+            "timeSeriesQuery": {
+              "outputFullDuration": false,
+              "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'logging.googleapis.com/byte_count'\n| filter\n    (metric.log == 'container-runtime') || (metric.log = 'docker')\n    || (metric.log == 'kube-container-runtime-monitor')\n    || (metric.log == 'kube-logrotate')\n    || (metric.log == 'kube-node-configuration')\n    || (metric.log == 'kube-node-installation') || (metric.log == 'kubelet')\n    || (metric.log == 'kubelet-monitor') || (metric.log == 'node-journal')\n    || (metric.log == 'node-problem-detector')\n| group_by [], sum(value.byte_count)\n| every 30d"
             }
           }
-        },
-        "width": 4,
-        "xPos": 8,
-        "yPos": 5
+        }
       },
       {
-        "height": 4,
+        "yPos": 4,
+        "xPos": 16,
+        "height": 8,
+        "width": 16,
+        "widget": {
+          "title": "k8s_container Byte Count",
+          "scorecard": {
+            "thresholds": [],
+            "timeSeriesQuery": {
+              "outputFullDuration": false,
+              "timeSeriesQueryLanguage": "fetch k8s_container\n| metric 'logging.googleapis.com/byte_count'\n| filter\n   (resource.namespace_name == 'cnrm-system')\n   || (resource.namespace_name == 'docker')\n   || (resource.namespace_name == 'config-management-system')\n   || (resource.namespace_name == 'gatekeeper-system')\n   || (resource.namespace_name == 'gke-connect')\n   || (resource.namespace_name == 'gke-system')\n   || (resource.namespace_name == 'istio-system')\n   || (resource.namespace_name == 'knative-serving')\n   || (resource.namespace_name == 'monitoring-system')\n   || (resource.namespace_name == 'kube-system')\n| group_by [], sum(value.byte_count)\n| every 30d\n"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 4,
+        "xPos": 32,
+        "height": 8,
+        "width": 16,
+        "widget": {
+          "title": "k8s_pod Byte Count",
+          "scorecard": {
+            "thresholds": [],
+            "timeSeriesQuery": {
+              "outputFullDuration": false,
+              "timeSeriesQueryLanguage": "fetch k8s_pod\n| metric 'logging.googleapis.com/byte_count'\n| filter\n    (resource.namespace_name == 'cnrm-system')\n    || (resource.namespace_name == 'docker')\n    || (resource.namespace_name == 'config-management-system')\n    || (resource.namespace_name == 'gatekeeper-system')\n    || (resource.namespace_name == 'gke-connect')\n    || (resource.namespace_name == 'gke-system')\n    || (resource.namespace_name == 'istio-system')\n    || (resource.namespace_name == 'knative-serving')\n    || (resource.namespace_name == 'monitoring-system')\n    || (resource.namespace_name == 'kube-system')\n| group_by [], [value_byte_count_aggregate_aggregate: sum(value.byte_count)]\n| every 30d"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 12,
+        "height": 8,
+        "width": 48,
+        "widget": {
+          "title": "Adjustable log volume charts",
+          "text": {
+            "content": "Use these charts to view the GKE system log volume over time. Use the time range selector to adjust the time range.",
+            "format": "RAW",
+            "style": {
+              "backgroundColor": "#FFFFFF",
+              "fontSize": "FS_LARGE",
+              "horizontalAlignment": "H_LEFT",
+              "padding": "P_EXTRA_SMALL",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED",
+              "textColor": "#212121",
+              "verticalAlignment": "V_TOP"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 20,
+        "height": 16,
+        "width": 16,
         "widget": {
           "title": "GKE system logs – node logs",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
               {
                 "plotType": "STACKED_AREA",
+                "targetAxis": "Y1",
                 "timeSeriesQuery": {
                   "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'logging.googleapis.com/byte_count'\n| filter\n    (metric.log == 'container-runtime') \n    || (metric.log = 'docker')\n    || (metric.log == 'kube-container-runtime-monitor')\n    || (metric.log == 'kube-logrotate')\n    || (metric.log == 'kube-node-configuration')\n    || (metric.log == 'kube-node-installation') || (metric.log == 'kubelet')\n    || (metric.log == 'kubelet-monitor') \n    || (metric.log == 'node-journal')\n    || (metric.log == 'node-problem-detector')\n| group_by [project_id], sum(value.byte_count)\n| every 1d"
                 }
               }
             ],
-            "timeshiftDuration": "0s",
+            "thresholds": [],
             "yAxis": {
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 4,
-        "yPos": 5
+        }
       },
       {
-        "height": 1,
+        "yPos": 20,
+        "xPos": 16,
+        "height": 16,
+        "width": 16,
         "widget": {
-          "text": {
-            "format": "MARKDOWN"
-          },
-          "title": "Monthly GKE system log volume"
-        },
-        "width": 12
-      },
-      {
-        "height": 2,
-        "widget": {
-          "text": {
-            "content": "Use these charts to view the GKE system log volume over time. Use the time range selector to adjust the time range.",
-            "format": "RAW"
-          },
-          "title": "Adjustable log volume charts"
-        },
-        "width": 12,
-        "yPos": 3
-      },
-      {
-        "height": 2,
-        "widget": {
-          "scorecard": {
-            "timeSeriesQuery": {
-              "timeSeriesQueryLanguage": "fetch k8s_pod\n| metric 'logging.googleapis.com/byte_count'\n| filter\n    (resource.namespace_name == 'cnrm-system')\n    || (resource.namespace_name == 'docker')\n    || (resource.namespace_name == 'config-management-system')\n    || (resource.namespace_name == 'gatekeeper-system')\n    || (resource.namespace_name == 'gke-connect')\n    || (resource.namespace_name == 'gke-system')\n    || (resource.namespace_name == 'istio-system')\n    || (resource.namespace_name == 'knative-serving')\n    || (resource.namespace_name == 'monitoring-system')\n    || (resource.namespace_name == 'kube-system')\n| group_by [], [value_byte_count_aggregate_aggregate: sum(value.byte_count)]\n| every 30d"
+          "title": "GKE system logs – k8s_container logs",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch k8s_container\n| metric 'logging.googleapis.com/byte_count'\n| filter\n    (resource.namespace_name == 'cnrm-system')\n    || (resource.namespace_name == 'docker')\n    || (resource.namespace_name == 'config-management-system')\n    || (resource.namespace_name == 'gatekeeper-system')\n    || (resource.namespace_name == 'gke-connect')\n    || (resource.namespace_name == 'gke-system')\n    || (resource.namespace_name == 'istio-system')\n    || (resource.namespace_name == 'knative-serving')\n    || (resource.namespace_name == 'monitoring-system')\n    || (resource.namespace_name == 'kube-system')\n| group_by [project_id], sum(value.byte_count)\n| every 1d"
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "scale": "LINEAR"
             }
-          },
-          "title": "k8s_pod Byte Count"
-        },
-        "width": 4,
-        "xPos": 8,
-        "yPos": 1
+          }
+        }
       },
       {
-        "height": 2,
+        "yPos": 20,
+        "xPos": 32,
+        "height": 16,
+        "width": 16,
         "widget": {
-          "scorecard": {
-            "timeSeriesQuery": {
-              "timeSeriesQueryLanguage": "fetch k8s_container\n| metric 'logging.googleapis.com/byte_count'\n| filter\n   (resource.namespace_name == 'cnrm-system')\n   || (resource.namespace_name == 'docker')\n   || (resource.namespace_name == 'config-management-system')\n   || (resource.namespace_name == 'gatekeeper-system')\n   || (resource.namespace_name == 'gke-connect')\n   || (resource.namespace_name == 'gke-system')\n   || (resource.namespace_name == 'istio-system')\n   || (resource.namespace_name == 'knative-serving')\n   || (resource.namespace_name == 'monitoring-system')\n   || (resource.namespace_name == 'kube-system')\n| group_by [], sum(value.byte_count)\n| every 30d\n"
+          "title": "GKE system logs – k8s_pod",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch k8s_pod\n| metric 'logging.googleapis.com/byte_count'\n| filter\n    (resource.namespace_name == 'cnrm-system')\n    || (resource.namespace_name == 'docker')\n    || (resource.namespace_name == 'config-management-system')\n    || (resource.namespace_name == 'gatekeeper-system')\n    || (resource.namespace_name == 'gke-connect')\n    || (resource.namespace_name == 'gke-system')\n    || (resource.namespace_name == 'istio-system')\n    || (resource.namespace_name == 'knative-serving')\n    || (resource.namespace_name == 'monitoring-system')\n    || (resource.namespace_name == 'kube-system')\n| group_by [project_id], sum(value.byte_count)\n| every 1d"
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "scale": "LINEAR"
             }
-          },
-          "title": "k8s_container Byte Count"
-        },
-        "width": 4,
-        "xPos": 4,
-        "yPos": 1
-      },
-      {
-        "height": 2,
-        "widget": {
-          "scorecard": {
-            "timeSeriesQuery": {
-              "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'logging.googleapis.com/byte_count'\n| filter\n    (metric.log == 'container-runtime') || (metric.log = 'docker')\n    || (metric.log == 'kube-container-runtime-monitor')\n    || (metric.log == 'kube-logrotate')\n    || (metric.log == 'kube-node-configuration')\n    || (metric.log == 'kube-node-installation') || (metric.log == 'kubelet')\n    || (metric.log == 'kubelet-monitor') || (metric.log == 'node-journal')\n    || (metric.log == 'node-problem-detector')\n| group_by [], sum(value.byte_count)\n| every 30d"
-            }
-          },
-          "title": "Node Byte Count"
-        },
-        "width": 4,
-        "yPos": 1
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
This PR updates the GKE Compute Resources - Node View Dashboard to use PromQL instead of the deprecated MQL.

To prove equivalence, here are screenshots of two different versions of the dashboard over the same time period. The former is the previous version of the dashboard, the latter the updated version of the dashboard.

One minor caveat on the screenshots - I replaced the 30d time window with 7d, because that window actually allowed the values to relatively match - MQL was very inconsistent with its values based on the window, whereas PromQL strictly increased as the window got larger. This resulted in a substantial mismatch.

MQL:
![image](https://github.com/user-attachments/assets/aefed45b-8306-44be-8bdf-69aa6d383fbb)

PromQL:
![image](https://github.com/user-attachments/assets/dc84b355-4706-49d3-8a8b-790eff12cb5b)
