### PR TITLE
Prevent top-level category in dashboard JSON

### DIFF
--- a/scripts/dashboard/validate_dashboards_format.py
+++ b/scripts/dashboard/validate_dashboards_format.py
@@ -82,7 +82,7 @@ def map_json_files(directory, path_map):
 
     # Check if 'category' field exists at the top level
     if 'category' in dash_dict:
-      raise JsonFormattingError("JsonFormattingError: category field is not allowed at the top level of sample dashboard JSON files. Found in {}".format(json_file))
+      raise JsonFormattingError("Category field is not allowed at the top level of sample dashboard JSON files. Found in {}".format(json_file))
 
     file_name_parts = json_file.split('.')
     check_json_file_name(json_file, file_name_parts)

--- a/scripts/dashboard/validate_dashboards_format.py
+++ b/scripts/dashboard/validate_dashboards_format.py
@@ -80,6 +80,10 @@ def map_json_files(directory, path_map):
     if not 'displayName' in dash_dict:
       raise JsonFormattingError("{} is missing displayName field".format(json_file))
 
+    # Check if 'category' field exists at the top level
+    if 'category' in dash_dict:
+      raise JsonFormattingError("JsonFormattingError: category field is not allowed at the top level of sample dashboard JSON files. Found in {}".format(json_file))
+
     file_name_parts = json_file.split('.')
     check_json_file_name(json_file, file_name_parts)
 


### PR DESCRIPTION
Updated the dashboard format validator to disallow the 'category' field at the top level of sample dashboard JSON files. This field is not a valid attribute for sample dashboards at that level.

The validation script `scripts/dashboard/validate_dashboards_format.py` was modified to check for and raise an error if this condition is met.