### PR TITLE
PromQL: Cloud CDN

### DIFF
--- a/dashboards/networking/cloud-cdn-monitoring.json
+++ b/dashboards/networking/cloud-cdn-monitoring.json
@@ -1,306 +1,338 @@
 {
-    "displayName": "Cloud CDN",
-    "mosaicLayout": {
-      "columns": 12,
-      "tiles": [
-        {
-          "height": 4,
-          "widget": {
-            "title": "Request Count by Continent",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "plotType": "STACKED_AREA",
-                  "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "fetch https_lb_rule\n| metric 'loadbalancing.googleapis.com/https/request_count'\n| align rate(1m)\n| every 1m\n| group_by [metric.proxy_continent],\n    [row_count: row_count()]"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
+  "displayName": "Cloud CDN - Ian",
+  "dashboardFilters": [],
+  "labels": {},
+  "mosaicLayout": {
+    "columns": 48,
+    "tiles": [
+      {
+        "height": 8,
+        "width": 12,
+        "widget": {
+          "title": "Total Requests",
+          "scorecard": {
+            "thresholds": [],
+            "timeSeriesQuery": {
+              "outputFullDuration": false,
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "alignmentPeriod": "60s",
+                  "crossSeriesReducer": "REDUCE_SUM",
+                  "groupByFields": [],
+                  "perSeriesAligner": "ALIGN_SUM"
+                },
+                "filter": "metric.type=\"loadbalancing.googleapis.com/https/request_count\" resource.type=\"https_lb_rule\""
               }
             }
-          },
-          "width": 6,
-          "yPos": 8
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Cache Hit Response Bytes by Continent",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "plotType": "STACKED_BAR",
-                  "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "fetch https_lb_rule\n| metric 'loadbalancing.googleapis.com/https/response_bytes_count'\n| filter (metric.cache_result = 'HIT')\n| align rate(1m)\n| every 1m\n| group_by [metric.proxy_continent],\n    [value_response_bytes_count_aggregate:\n       aggregate(value.response_bytes_count)]"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "xPos": 12,
+        "height": 8,
+        "width": 12,
+        "widget": {
+          "title": "Total Egress",
+          "scorecard": {
+            "thresholds": [],
+            "timeSeriesQuery": {
+              "outputFullDuration": false,
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "alignmentPeriod": "60s",
+                  "crossSeriesReducer": "REDUCE_SUM",
+                  "groupByFields": [],
+                  "perSeriesAligner": "ALIGN_SUM"
+                },
+                "filter": "metric.type=\"loadbalancing.googleapis.com/https/response_bytes_count\" resource.type=\"https_lb_rule\""
               }
             }
-          },
-          "width": 6,
-          "xPos": 6,
-          "yPos": 4
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Cache Status by Count",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "plotType": "LINE",
-                  "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "fetch https_lb_rule\n| metric 'loadbalancing.googleapis.com/https/request_count'\n| align rate(1m)\n| every 1m\n| group_by [metric.cache_result],\n    [row_count: row_count()]\n"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 6,
-          "yPos": 4
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Response Egress by Cache Status",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "plotType": "STACKED_AREA",
-                  "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "fetch https_lb_rule\n| metric 'loadbalancing.googleapis.com/https/response_bytes_count'\n| align rate(1m)\n| every 1m\n| group_by [metric.cache_result],\n    [value_response_bytes_count_aggregate:\n       aggregate(value.response_bytes_count)]"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 6,
-          "xPos": 6
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Latency by Continent 95%",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "plotType": "LINE",
-                  "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "fetch https_lb_rule\n| metric 'loadbalancing.googleapis.com/https/frontend_tcp_rtt'\n| group_by 1m,\n    [value_frontend_tcp_rtt_aggregate: aggregate(value.frontend_tcp_rtt)]\n| every 1m\n| group_by [metric.proxy_continent],\n    [value_frontend_tcp_rtt_aggregate_percentile:\n       percentile(value_frontend_tcp_rtt_aggregate, 95)]"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 6,
-          "yPos": 12
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Client Response Code",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "plotType": "STACKED_AREA",
-                  "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "fetch https_lb_rule\n| metric 'loadbalancing.googleapis.com/https/request_count'\n| group_by 1h, [row_count: row_count()]\n| every 1h\n| group_by [metric.response_code_class],\n    [row_count_aggregate: aggregate(row_count)]"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 6,
-          "xPos": 6,
-          "yPos": 8
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Non 2xx Error Codes",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "plotType": "STACKED_AREA",
-                  "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "fetch https_lb_rule\n| metric 'loadbalancing.googleapis.com/https/request_count'\n| filter (metric.response_code_class != 200)\n| group_by 1h, [row_count: row_count()]\n| every 1h\n| group_by [metric.response_code_class],\n    [row_count_aggregate: aggregate(row_count)]"
-                  }
-                }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
-              }
-            }
-          },
-          "width": 6,
-          "xPos": 6,
-          "yPos": 12
-        },
-        {
-          "height": 2,
-          "widget": {
-            "scorecard": {
-              "timeSeriesQuery": {
-                "timeSeriesFilter": {
-                  "aggregation": {
-                    "alignmentPeriod": "60s",
-                    "crossSeriesReducer": "REDUCE_SUM",
-                    "perSeriesAligner": "ALIGN_SUM"
-                  },
-                  "filter": "metric.type=\"loadbalancing.googleapis.com/https/request_count\" resource.type=\"https_lb_rule\""
-                }
-              }
+          }
+        }
+      },
+      {
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Response Egress by Cache Status",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
             },
-            "title": "Total Requests"
-          },
-          "width": 3
-        },
-        {
-          "height": 2,
-          "widget": {
-            "scorecard": {
-              "timeSeriesQuery": {
-                "timeSeriesFilter": {
-                  "aggregation": {
-                    "alignmentPeriod": "60s",
-                    "crossSeriesReducer": "REDUCE_SUM",
-                    "perSeriesAligner": "ALIGN_SUM"
-                  },
-                  "filter": "metric.type=\"loadbalancing.googleapis.com/https/response_bytes_count\" resource.type=\"https_lb_rule\""
+            "dataSets": [
+              {
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch https_lb_rule\n| metric 'loadbalancing.googleapis.com/https/response_bytes_count'\n| align rate(1m)\n| every 1m\n| group_by [metric.cache_result],\n    [value_response_bytes_count_aggregate:\n       aggregate(value.response_bytes_count)]"
                 }
               }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 8,
+        "height": 8,
+        "width": 12,
+        "widget": {
+          "title": "Cache Hit Egress",
+          "scorecard": {
+            "thresholds": [],
+            "timeSeriesQuery": {
+              "outputFullDuration": false,
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "alignmentPeriod": "60s",
+                  "crossSeriesReducer": "REDUCE_SUM",
+                  "groupByFields": [],
+                  "perSeriesAligner": "ALIGN_SUM"
+                },
+                "filter": "metric.type=\"loadbalancing.googleapis.com/https/response_bytes_count\" resource.type=\"https_lb_rule\" metric.label.\"cache_result\"=\"HIT\""
+              }
+            }
+          }
+        }
+      },
+      {
+        "yPos": 8,
+        "xPos": 12,
+        "height": 8,
+        "width": 12,
+        "widget": {
+          "title": "Cache Miss Egress",
+          "scorecard": {
+            "thresholds": [],
+            "timeSeriesQuery": {
+              "outputFullDuration": false,
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "alignmentPeriod": "60s",
+                  "crossSeriesReducer": "REDUCE_SUM",
+                  "groupByFields": [],
+                  "perSeriesAligner": "ALIGN_SUM"
+                },
+                "filter": "metric.type=\"loadbalancing.googleapis.com/https/response_bytes_count\" resource.type=\"https_lb_rule\" metric.label.\"cache_result\"=\"MISS\""
+              }
+            }
+          }
+        }
+      },
+      {
+        "yPos": 16,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Cache Status by Count",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
             },
-            "title": "Total Egress"
-          },
-          "width": 3,
-          "xPos": 3
-        },
-        {
-          "height": 2,
-          "widget": {
-            "scorecard": {
-              "timeSeriesQuery": {
-                "timeSeriesFilter": {
-                  "aggregation": {
-                    "alignmentPeriod": "60s",
-                    "crossSeriesReducer": "REDUCE_SUM",
-                    "perSeriesAligner": "ALIGN_SUM"
-                  },
-                  "filter": "metric.type=\"loadbalancing.googleapis.com/https/response_bytes_count\" resource.type=\"https_lb_rule\" metric.label.\"cache_result\"=\"HIT\""
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch https_lb_rule\n| metric 'loadbalancing.googleapis.com/https/request_count'\n| align rate(1m)\n| every 1m\n| group_by [metric.cache_result],\n    [row_count: row_count()]\n"
                 }
               }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 16,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Cache Hit Response Bytes by Continent",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
             },
-            "title": "Cache Hit Egress"
-          },
-          "width": 3,
-          "yPos": 2
-        },
-        {
-          "height": 2,
-          "widget": {
-            "scorecard": {
-              "timeSeriesQuery": {
-                "timeSeriesFilter": {
-                  "aggregation": {
-                    "alignmentPeriod": "60s",
-                    "crossSeriesReducer": "REDUCE_SUM",
-                    "perSeriesAligner": "ALIGN_SUM"
-                  },
-                  "filter": "metric.type=\"loadbalancing.googleapis.com/https/response_bytes_count\" resource.type=\"https_lb_rule\" metric.label.\"cache_result\"=\"MISS\""
+            "dataSets": [
+              {
+                "plotType": "STACKED_BAR",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch https_lb_rule\n| metric 'loadbalancing.googleapis.com/https/response_bytes_count'\n# | filter (metric.cache_result = 'HIT')\n| align rate(1m)\n| every 1m\n| group_by [metric.proxy_continent],\n    [value_response_bytes_count_aggregate:\n       aggregate(value.response_bytes_count)]"
                 }
               }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 32,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Request Count by Continent",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
             },
-            "title": "Cache Miss Egress"
-          },
-          "width": 3,
-          "xPos": 3,
-          "yPos": 2
-        },
-        {
-          "height": 4,
-          "widget": {
-            "title": "Request Count by Country",
-            "xyChart": {
-              "chartOptions": {
-                "mode": "COLOR"
-              },
-              "dataSets": [
-                {
-                  "minAlignmentPeriod": "60s",
-                  "plotType": "STACKED_AREA",
-                  "timeSeriesQuery": {
-                    "timeSeriesFilter": {
-                      "aggregation": {
-                        "alignmentPeriod": "60s",
-                        "perSeriesAligner": "ALIGN_RATE"
-                      },
-                      "filter": "metric.type=\"loadbalancing.googleapis.com/https/request_count\" resource.type=\"https_lb_rule\"",
-                      "secondaryAggregation": {
-                        "alignmentPeriod": "60s",
-                        "crossSeriesReducer": "REDUCE_SUM",
-                        "groupByFields": [
-                          "metric.label.\"client_country\""
-                        ],
-                        "perSeriesAligner": "ALIGN_SUM"
-                      }
+            "dataSets": [
+              {
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch https_lb_rule\n| metric 'loadbalancing.googleapis.com/https/request_count'\n| align rate(1m)\n| every 1m\n| group_by [metric.proxy_continent],\n    [row_count: row_count()]"
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 32,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Client Response Code",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch https_lb_rule\n| metric 'loadbalancing.googleapis.com/https/request_count'\n| group_by 1h, [row_count: row_count()]\n| every 1h\n| group_by [metric.response_code_class],\n    [row_count_aggregate: aggregate(row_count)]"
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 48,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Latency by Continent 95%",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch https_lb_rule\n| metric 'loadbalancing.googleapis.com/https/frontend_tcp_rtt'\n| group_by 1m,\n    [value_frontend_tcp_rtt_aggregate: aggregate(value.frontend_tcp_rtt)]\n| every 1m\n| group_by [metric.proxy_continent],\n    [value_frontend_tcp_rtt_aggregate_percentile:\n       percentile(value_frontend_tcp_rtt_aggregate, 95)]"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 48,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Non 2xx Error Codes",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch https_lb_rule\n| metric 'loadbalancing.googleapis.com/https/request_count'\n| filter (metric.response_code_class != 200)\n| group_by 1h, [row_count: row_count()]\n| every 1h\n| group_by [metric.response_code_class],\n    [row_count_aggregate: aggregate(row_count)]"
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 64,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Request Count by Country",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"loadbalancing.googleapis.com/https/request_count\" resource.type=\"https_lb_rule\"",
+                    "secondaryAggregation": {
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [
+                        "metric.label.\"client_country\""
+                      ],
+                      "perSeriesAligner": "ALIGN_SUM"
                     }
                   }
                 }
-              ],
-              "timeshiftDuration": "0s",
-              "yAxis": {
-                "scale": "LINEAR"
               }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "scale": "LINEAR"
             }
-          },
-          "width": 6,
-          "yPos": 16
+          }
         }
-      ]
-    }
+      }
+    ]
   }
+}

--- a/dashboards/networking/cloud-cdn-monitoring.json
+++ b/dashboards/networking/cloud-cdn-monitoring.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "Cloud CDN - Ian",
+  "displayName": "Cloud CDN",
   "dashboardFilters": [],
   "labels": {},
   "mosaicLayout": {
@@ -66,7 +66,8 @@
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch https_lb_rule\n| metric 'loadbalancing.googleapis.com/https/response_bytes_count'\n| align rate(1m)\n| every 1m\n| group_by [metric.cache_result],\n    [value_response_bytes_count_aggregate:\n       aggregate(value.response_bytes_count)]"
+                  "prometheusQuery": "sum by (cache_result) (\n  rate(\n    loadbalancing_googleapis_com:https_response_bytes_count{monitored_resource=\"https_lb_rule\"}[1m]\n  )\n)\n",
+                  "unitOverride": "By/s"
                 }
               }
             ],
@@ -140,7 +141,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch https_lb_rule\n| metric 'loadbalancing.googleapis.com/https/request_count'\n| align rate(1m)\n| every 1m\n| group_by [metric.cache_result],\n    [row_count: row_count()]\n"
+                  "prometheusQuery": "count by (cache_result) (\n  increase(loadbalancing_googleapis_com:https_request_count{monitored_resource=\"https_lb_rule\"}[1m])\n)\n\n"
                 }
               }
             ],
@@ -169,7 +170,8 @@
                 "plotType": "STACKED_BAR",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch https_lb_rule\n| metric 'loadbalancing.googleapis.com/https/response_bytes_count'\n# | filter (metric.cache_result = 'HIT')\n| align rate(1m)\n| every 1m\n| group_by [metric.proxy_continent],\n    [value_response_bytes_count_aggregate:\n       aggregate(value.response_bytes_count)]"
+                  "prometheusQuery": "sum by (proxy_continent) (\n  rate(\n    loadbalancing_googleapis_com:https_response_bytes_count{\n      monitored_resource=\"https_lb_rule\",\n      #   cache_result=\"HIT\"\n    }\n  [5m])\n)\n",
+                  "unitOverride": "By/s"
                 }
               }
             ],
@@ -196,7 +198,7 @@
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch https_lb_rule\n| metric 'loadbalancing.googleapis.com/https/request_count'\n| align rate(1m)\n| every 1m\n| group_by [metric.proxy_continent],\n    [row_count: row_count()]"
+                  "prometheusQuery": "count by (proxy_continent) (\n  increase(\n    loadbalancing_googleapis_com:https_request_count{\n      monitored_resource=\"https_lb_rule\"\n    }\n    [1m]\n  )\n)\n"
                 }
               }
             ],
@@ -224,7 +226,7 @@
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch https_lb_rule\n| metric 'loadbalancing.googleapis.com/https/request_count'\n| group_by 1h, [row_count: row_count()]\n| every 1h\n| group_by [metric.response_code_class],\n    [row_count_aggregate: aggregate(row_count)]"
+                  "prometheusQuery": "sum by (response_code_class) (\n  count_over_time(\n    loadbalancing_googleapis_com:https_request_count{\n      monitored_resource=\"https_lb_rule\"\n    }[1h]\n  )\n)\n"
                 }
               }
             ],
@@ -251,7 +253,8 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch https_lb_rule\n| metric 'loadbalancing.googleapis.com/https/frontend_tcp_rtt'\n| group_by 1m,\n    [value_frontend_tcp_rtt_aggregate: aggregate(value.frontend_tcp_rtt)]\n| every 1m\n| group_by [metric.proxy_continent],\n    [value_frontend_tcp_rtt_aggregate_percentile:\n       percentile(value_frontend_tcp_rtt_aggregate, 95)]"
+                  "prometheusQuery": "histogram_quantile(0.95,\n    sum by (le, proxy_continent) (\n        increase(\n            loadbalancing_googleapis_com:https_frontend_tcp_rtt_bucket{monitored_resource=\"https_lb_rule\"}[1m]\n        )\n    )\n)\n",
+                  "unitOverride": "ms"
                 }
               }
             ],
@@ -280,7 +283,7 @@
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch https_lb_rule\n| metric 'loadbalancing.googleapis.com/https/request_count'\n| filter (metric.response_code_class != 200)\n| group_by 1h, [row_count: row_count()]\n| every 1h\n| group_by [metric.response_code_class],\n    [row_count_aggregate: aggregate(row_count)]"
+                  "prometheusQuery": "sum by (response_code_class) (\n  count_over_time(\n    loadbalancing_googleapis_com:https_request_count{\n      monitored_resource=\"https_lb_rule\",\n      response_code_class!=\"200\"\n    }[1h]\n  )\n)"
                 }
               }
             ],


### PR DESCRIPTION
This PR updates the Cloud CDN Dashboard to use PromQL instead of the deprecated MQL.

To prove equivalence, here are screenshots of two different versions of the dashboard over the same time period. The former is the previous version of the dashboard, the latter the updated version of the dashboard.

Key review callouts: 
- `Cache Hit Response Bytes by Continent` looks different until you notice that the Y-axis scale is twice as large on the MQL as it is on the PromQL
- `Client Response Code` and `Non 2xx Error Codes` legitimately are different, but that's just because 1) we have no way of mimicking MQL's `every 1h`, so we get more frequent data points than hourly in the graph, resulting in a less smooth graph 2) MQL stacks the area charts by status code ascending, and PromQL stacks them in the reverse order.

MQL:
![image](https://github.com/user-attachments/assets/1820235b-9f05-4b17-8eb9-4914ebede74c)
![image](https://github.com/user-attachments/assets/a77da263-1a31-4bc2-9eac-aa367dc91e92)

PromQL:
![image](https://github.com/user-attachments/assets/a4a705e4-8a54-414f-8afb-b678d489e925)
![image](https://github.com/user-attachments/assets/d47918d4-1cc0-4b53-8c64-89181597ecf3)
