### PR TITLE
PromQL: Microservices (gRPC) Monitoring - GKE

### DIFF
--- a/dashboards/google-microservices/microservices-grpc-monitoring-gke.json
+++ b/dashboards/google-microservices/microservices-grpc-monitoring-gke.json
@@ -20,7 +20,8 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric 'custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs'\n  | filter (metric.grpc_client_status == 'OK')\n  | align rate(1m)\n  | every 1m\n"
+                  "prometheusQuery": "rate(custom_googleapis_com:opencensus_grpc_io_client_completed_rpcs{monitored_resource=\"k8s_container\", grpc_client_status=\"OK\"}[1m])",
+                  "unitOverride": "1/s"
                 }
               }
             ],
@@ -49,30 +50,25 @@
         "width": 24,
         "widget": {
           "title": "Client Concurrency",
-          "id": "",
           "xyChart": {
             "chartOptions": {
               "displayHorizontal": false,
-              "mode": "COLOR",
-              "showLegend": false
+              "mode": "COLOR"
             },
             "dataSets": [
               {
-                "breakdowns": [],
-                "dimensions": [],
-                "legendTemplate": "",
-                "measures": [],
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "outputFullDuration": false,
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | { t_0:\n      metric 'custom.googleapis.com/opencensus/grpc.io/client/started_rpcs'\n        | align delta(1m)\n        | every 1m\n      ; t_1:\n      metric 'custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs'\n        | align delta(1m)\n        | every 1m\n        | group_by drop [metric.grpc_client_status],\n            [completed_rpcs_aggregate: aggregate(value.completed_rpcs)] }\n  | outer_join [0]\n  | value [concurrent_rpcs: sub(t_0.started_rpcs, t_1.completed_rpcs_aggregate)]\n  | filter (val() >= 0)\n",
-                  "unitOverride": ""
+                  "prometheusQuery": "(\n    sum by (opencensus_task, grpc_client_method, project_id, instance_id, zone) (\n        increase(custom_googleapis_com:opencensus_grpc_io_client_started_rpcs{\n            monitored_resource=\"k8s_container\"\n        }[1m])\n    )\n    -\n    sum by (opencensus_task, grpc_client_method, project_id, instance_id, zone) (\n        increase(custom_googleapis_com:opencensus_grpc_io_client_completed_rpcs{\n            monitored_resource=\"k8s_container\"\n        }[1m])\n    )\n)\nand\n(\n    sum by (opencensus_task, grpc_client_method, project_id, instance_id, zone) (\n        increase(custom_googleapis_com:opencensus_grpc_io_client_started_rpcs{\n            monitored_resource=\"k8s_container\"\n        }[1m])\n    )\n    -\n    sum by (opencensus_task, grpc_client_method, project_id, instance_id, zone) (\n        increase(custom_googleapis_com:opencensus_grpc_io_client_completed_rpcs{\n            monitored_resource=\"k8s_container\"\n        }[1m])\n    )\n) >= 0\n\n"
                 }
               }
             ],
             "thresholds": [],
-            "timeshiftDuration": "0s"
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
           }
         }
       },
@@ -92,7 +88,8 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric 'custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs'\n  | filter (metric.grpc_client_status != 'OK')\n  | align rate(1m)\n  | every 1m\n"
+                  "prometheusQuery": "rate(custom_googleapis_com:opencensus_grpc_io_client_completed_rpcs{monitored_resource=\"k8s_container\", grpc_client_status!=\"OK\"}[1m])\n",
+                  "unitOverride": "1/s"
                 }
               }
             ],
@@ -121,7 +118,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs\n| align delta(1m)\n| every 1m\n| { t_0: \n      filter (metric.grpc_client_status != 'OK')\n      | group_by drop[metric.grpc_client_status],\n          [error_rpcs_aggregate: aggregate(value.completed_rpcs)]\n  ; t_1:\n      group_by drop[metric.grpc_client_status],\n        [completed_rpcs_aggregate: aggregate(value.completed_rpcs)] }\n| ratio\n"
+                  "prometheusQuery": "sum by(opencensus_task, grpc_client_method, project_id, instance_id, zone) (\n  increase(custom_googleapis_com:opencensus_grpc_io_client_completed_rpcs{\n    monitored_resource=\"k8s_container\",\n    grpc_client_status!=\"OK\"\n  }[1m])\n)\n/\n(\n  sum by(opencensus_task, grpc_client_method, project_id, instance_id, zone) (\n    increase(custom_googleapis_com:opencensus_grpc_io_client_completed_rpcs{\n      monitored_resource=\"k8s_container\"\n    }[1m])\n  )\n)\n"
                 }
               }
             ],
@@ -146,10 +143,71 @@
             },
             "dataSets": [
               {
+                "legendTemplate": "99 percentile",
+                "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n    | metric custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency\n    | group_by 1m, [roundtrip_latency_aligned: aggregate(value.roundtrip_latency)]\n    | every 1m\n    | group_by [], [roundtrip_latency_aggregated: aggregate(roundtrip_latency_aligned)]\n    | { t_0:\n          group_by [], [roundtrip_latency_stats_value: percentile(roundtrip_latency_aggregated, 50)]\n            | map add[roundtrip_latency_stats_tag: '50 percentile']\n      ; t_1:\n          group_by [], [roundtrip_latency_stats_value: percentile(roundtrip_latency_aggregated, 95)]\n            | map add[roundtrip_latency_stats_tag: '95 percentile']\n      ; t_2:\n          group_by [], [roundtrip_latency_stats_value: percentile(roundtrip_latency_aggregated, 99)]\n            | map add[roundtrip_latency_stats_tag: '99 percentile']\n      ; t_3:\n          group_by [], [roundtrip_latency_stats_value: mean(roundtrip_latency_aggregated)]\n            | map add[roundtrip_latency_stats_tag: 'mean']}\n    | union\n"
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_99",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency\" resource.type=\"k8s_container\""
+                  }
+                }
+              },
+              {
+                "legendTemplate": "90 percentile",
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_95",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency\" resource.type=\"k8s_container\""
+                  }
+                }
+              },
+              {
+                "legendTemplate": "50 percentile",
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_50",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency\" resource.type=\"k8s_container\""
+                  }
+                }
+              },
+              {
+                "legendTemplate": "mean",
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_MEAN",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency\" resource.type=\"k8s_container\""
+                  }
                 }
               }
             ],
@@ -175,10 +233,20 @@
             },
             "dataSets": [
               {
+                "legendTemplate": "Client RTT Latency",
+                "minAlignmentPeriod": "60s",
                 "plotType": "HEATMAP",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency\n  | align delta(1m)\n  | every 1m\n  | group_by [], [roundtrip_latency_aggregate: aggregate(value.roundtrip_latency)]\n  | map add[legend_tag: 'Client RTT Latency']"
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/client/roundtrip_latency\" resource.type=\"k8s_container\""
+                  }
                 }
               }
             ],
@@ -202,10 +270,71 @@
             },
             "dataSets": [
               {
+                "legendTemplate": "99 percentile",
+                "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n    | metric custom.googleapis.com/opencensus/grpc.io/client/api_latency\n    | group_by 1m, [api_latency_aligned: aggregate(value.api_latency)]\n    | every 1m\n    | group_by [], [api_latency_aggregated: aggregate(api_latency_aligned)]\n    | { t_0:\n          group_by [], [api_latency_stats_value: percentile(api_latency_aggregated, 50)]\n            | map add[api_latency_stats_tag: '50 percentile']\n      ; t_1:\n          group_by [], [api_latency_stats_value: percentile(api_latency_aggregated, 95)]\n            | map add[api_latency_stats_tag: '95 percentile']\n      ; t_2:\n          group_by [], [api_latency_stats_value: percentile(api_latency_aggregated, 99)]\n            | map add[api_latency_stats_tag: '99 percentile']\n      ; t_3:\n          group_by [], [api_latency_stats_value: mean(api_latency_aggregated)]\n            | map add[api_latency_stats_tag: 'mean']}\n    | union\n"
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_99",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/client/api_latency\" resource.type=\"k8s_container\""
+                  }
+                }
+              },
+              {
+                "legendTemplate": "95 percentile",
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_95",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/client/api_latency\" resource.type=\"k8s_container\""
+                  }
+                }
+              },
+              {
+                "legendTemplate": "50 percentile",
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_50",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/client/api_latency\" resource.type=\"k8s_container\""
+                  }
+                }
+              },
+              {
+                "legendTemplate": "mean",
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_MEAN",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/client/api_latency\" resource.type=\"k8s_container\""
+                  }
                 }
               }
             ],
@@ -231,10 +360,20 @@
             },
             "dataSets": [
               {
+                "legendTemplate": "Client API Latency",
+                "minAlignmentPeriod": "60s",
                 "plotType": "HEATMAP",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/client/api_latency\n  | align delta(1m)\n  | every 1m\n  | group_by [], [api_latency_aggregate: aggregate(value.api_latency)]\n  | map add[legend_tag: 'Client API Latency']"
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/client/api_latency\" resource.type=\"k8s_container\""
+                  }
                 }
               }
             ],
@@ -258,10 +397,71 @@
             },
             "dataSets": [
               {
+                "legendTemplate": "99 percentile",
+                "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/client/sent_compressed_message_bytes_per_rpc\n  | group_by 1m, [sent_compressed_message_bytes_per_rpc_aligned: aggregate(value.sent_compressed_message_bytes_per_rpc)]\n  | every 1m\n  | group_by [], [sent_compressed_message_bytes_per_rpc_aggregated: aggregate(sent_compressed_message_bytes_per_rpc_aligned)]\n  | { t_0:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: percentile(sent_compressed_message_bytes_per_rpc_aggregated, 50)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: '50 percentile']\n    ; t_1:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: percentile(sent_compressed_message_bytes_per_rpc_aggregated, 95)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: '95 percentile']\n    ; t_2:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: percentile(sent_compressed_message_bytes_per_rpc_aggregated, 99)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: '99 percentile']\n    ; t_3:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: mean(sent_compressed_message_bytes_per_rpc_aggregated)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: 'mean']}\n  | union\n"
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_99",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/client/sent_compressed_message_bytes_per_rpc\" resource.type=\"k8s_container\""
+                  }
+                }
+              },
+              {
+                "legendTemplate": "90.percentile",
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_95",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/client/sent_compressed_message_bytes_per_rpc\" resource.type=\"k8s_container\""
+                  }
+                }
+              },
+              {
+                "legendTemplate": "50 percentile",
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_50",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/client/sent_compressed_message_bytes_per_rpc\" resource.type=\"k8s_container\""
+                  }
+                }
+              },
+              {
+                "legendTemplate": "mean",
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_MEAN",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/client/sent_compressed_message_bytes_per_rpc\" resource.type=\"k8s_container\""
+                  }
                 }
               }
             ],
@@ -287,10 +487,20 @@
             },
             "dataSets": [
               {
+                "legendTemplate": "Client Sent Compressed Message Bytes per RPC",
+                "minAlignmentPeriod": "60s",
                 "plotType": "HEATMAP",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/client/sent_compressed_message_bytes_per_rpc\n  | align delta(1m)\n  | every 1m\n  | group_by [], [sent_compressed_message_bytes_per_rpc_aggregate: aggregate(value.sent_compressed_message_bytes_per_rpc)]\n  | map add[legend_tag: 'Client Sent Compressed Message Bytes per RPC']\n"
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/client/sent_compressed_message_bytes_per_rpc\" resource.type=\"k8s_container\""
+                  }
                 }
               }
             ],
@@ -314,10 +524,71 @@
             },
             "dataSets": [
               {
+                "legendTemplate": "99 percentile",
+                "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/client/received_compressed_message_bytes_per_rpc\n  | group_by 1m, [received_compressed_message_bytes_per_rpc_aligned: aggregate(value.received_compressed_message_bytes_per_rpc)]\n  | every 1m\n  | group_by [], [received_compressed_message_bytes_per_rpc_aggregated: aggregate(received_compressed_message_bytes_per_rpc_aligned)]\n  | { t_0:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: percentile(received_compressed_message_bytes_per_rpc_aggregated, 50)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: '50 percentile']\n    ; t_1:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: percentile(received_compressed_message_bytes_per_rpc_aggregated, 95)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: '95 percentile']\n    ; t_2:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: percentile(received_compressed_message_bytes_per_rpc_aggregated, 99)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: '99 percentile']\n    ; t_3:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: mean(received_compressed_message_bytes_per_rpc_aggregated)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: 'mean']}\n  | union\n"
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_99",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/client/received_compressed_message_bytes_per_rpc\" resource.type=\"k8s_container\""
+                  }
+                }
+              },
+              {
+                "legendTemplate": "95 percentile",
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_95",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/client/received_compressed_message_bytes_per_rpc\" resource.type=\"k8s_container\""
+                  }
+                }
+              },
+              {
+                "legendTemplate": "50 percentile",
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_50",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/client/received_compressed_message_bytes_per_rpc\" resource.type=\"k8s_container\""
+                  }
+                }
+              },
+              {
+                "legendTemplate": "mean",
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_MEAN",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/client/received_compressed_message_bytes_per_rpc\" resource.type=\"k8s_container\""
+                  }
                 }
               }
             ],
@@ -343,10 +614,20 @@
             },
             "dataSets": [
               {
+                "legendTemplate": "Client Received Compressed Message Bytes per RPC",
+                "minAlignmentPeriod": "60s",
                 "plotType": "HEATMAP",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/client/received_compressed_message_bytes_per_rpc\n  | align delta(1m)\n  | every 1m\n  | group_by [], [received_compressed_message_bytes_per_rpc_aggregate: aggregate(value.received_compressed_message_bytes_per_rpc)]\n  | map add[legend_tag: 'Client Received Compressed Message Bytes per RPC']\n"
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/client/received_compressed_message_bytes_per_rpc\" resource.type=\"k8s_container\""
+                  }
                 }
               }
             ],
@@ -373,7 +654,8 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric 'custom.googleapis.com/opencensus/grpc.io/server/completed_rpcs'\n  | filter (metric.grpc_server_status == 'OK')\n  | align rate(1m)\n  | every 1m\n"
+                  "prometheusQuery": "rate(custom_googleapis_com:opencensus_grpc_io_server_completed_rpcs{monitored_resource=\"k8s_container\", grpc_server_status=\"OK\"}[1m])",
+                  "unitOverride": "1/s"
                 }
               }
             ],
@@ -414,7 +696,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | { t_0:\n      metric 'custom.googleapis.com/opencensus/grpc.io/server/started_rpcs'\n        | align delta(1m)\n        | every 1m\n      ; t_1:\n      metric 'custom.googleapis.com/opencensus/grpc.io/server/completed_rpcs'\n        | align delta(1m)\n        | every 1m\n        | group_by drop [metric.grpc_server_status],\n            [completed_rpcs_aggregate: aggregate(value.completed_rpcs)] }\n  | outer_join [0]\n  | value [concurrent_rpcs: sub(t_0.started_rpcs, t_1.completed_rpcs_aggregate)]\n  | filter (val() >= 0)\n"
+                  "prometheusQuery": "(\n  sum by(grpc_server_method, opencensus_task, project_id, instance_id, zone) (\n    increase(custom_googleapis_com:opencensus_grpc_io_server_started_rpcs{\n      monitored_resource=\"k8s_container\"\n    }[1m])\n  )\n  -\n  sum by(grpc_server_method, opencensus_task, project_id, instance_id, zone) (\n    increase(custom_googleapis_com:opencensus_grpc_io_server_completed_rpcs{\n      monitored_resource=\"k8s_container\"\n    }[1m])\n  )\n)\nand\n(\n  sum by(grpc_server_method, opencensus_task, project_id, instance_id, zone) (\n    increase(custom_googleapis_com:opencensus_grpc_io_server_started_rpcs{\n      monitored_resource=\"k8s_container\"\n    }[1m])\n  )\n  -\n  sum by(grpc_server_method, opencensus_task, project_id, instance_id, zone) (\n    increase(custom_googleapis_com:opencensus_grpc_io_server_completed_rpcs{\n      monitored_resource=\"k8s_container\"\n    }[1m])\n  ) >= 0\n)\n"
                 }
               }
             ],
@@ -442,7 +724,8 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric 'custom.googleapis.com/opencensus/grpc.io/server/completed_rpcs'\n  | filter (metric.grpc_server_status != 'OK')\n  | align rate(1m)\n  | every 1m\n"
+                  "prometheusQuery": "rate(custom_googleapis_com:opencensus_grpc_io_server_completed_rpcs{monitored_resource=\"k8s_container\", grpc_server_status!=\"OK\"}[1m])",
+                  "unitOverride": "1/s"
                 }
               }
             ],
@@ -471,7 +754,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/server/completed_rpcs\n| align delta(1m)\n| every 1m\n| { t_0: \n      filter (metric.grpc_server_status != 'OK')\n      | group_by drop[metric.grpc_server_status],\n          [error_rpcs_aggregate: aggregate(value.completed_rpcs)]\n  ; t_1:\n      group_by drop[metric.grpc_server_status],\n        [completed_rpcs_aggregate: aggregate(value.completed_rpcs)] }\n| ratio\n"
+                  "prometheusQuery": "sum by(opencensus_task, grpc_client_method, project_id, instance_id, zone) (\n  increase(custom_googleapis_com:opencensus_grpc_io_server_completed_rpcs{\n    monitored_resource=\"k8s_container\",\n    grpc_server_status!=\"OK\"\n  }[1m])\n)\n/\n(\n  sum by(opencensus_task, grpc_client_method, project_id, instance_id, zone) (\n    increase(custom_googleapis_com:opencensus_grpc_io_server_completed_rpcs{\n      monitored_resource=\"k8s_container\"\n    }[1m])\n  )\n)"
                 }
               }
             ],
@@ -496,10 +779,71 @@
             },
             "dataSets": [
               {
+                "legendTemplate": "99 percentile",
+                "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n    | metric custom.googleapis.com/opencensus/grpc.io/server/server_latency\n    | group_by 1m, [server_latency_aligned: aggregate(value.server_latency)]\n    | every 1m\n    | group_by [], [server_latency_aggregated: aggregate(server_latency_aligned)]\n    | { t_0:\n          group_by [], [server_latency_stats_value: percentile(server_latency_aggregated, 50)]\n            | map add[server_latency_stats_tag: '50 percentile']\n      ; t_1:\n          group_by [], [server_latency_stats_value: percentile(server_latency_aggregated, 95)]\n            | map add[server_latency_stats_tag: '95 percentile']\n      ; t_2:\n          group_by [], [server_latency_stats_value: percentile(server_latency_aggregated, 99)]\n            | map add[server_latency_stats_tag: '99 percentile']\n      ; t_3:\n          group_by [], [server_latency_stats_value: mean(server_latency_aggregated)]\n            | map add[server_latency_stats_tag: 'mean']}\n    | union\n"
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_99",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/server/server_latency\" resource.type=\"k8s_container\""
+                  }
+                }
+              },
+              {
+                "legendTemplate": "95 percentile",
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_95",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/server/server_latency\" resource.type=\"k8s_container\""
+                  }
+                }
+              },
+              {
+                "legendTemplate": "50 percentile",
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_50",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/server/server_latency\" resource.type=\"k8s_container\""
+                  }
+                }
+              },
+              {
+                "legendTemplate": "mean",
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_MEAN",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/server/server_latency\" resource.type=\"k8s_container\""
+                  }
                 }
               }
             ],
@@ -525,10 +869,20 @@
             },
             "dataSets": [
               {
+                "legendTemplate": "Server Latency",
+                "minAlignmentPeriod": "60s",
                 "plotType": "HEATMAP",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/server/server_latency\n  | align delta(1m)\n  | every 1m\n  | group_by [], [server_latency_aggregate: aggregate(value.server_latency)]\n  | map add[legend_tag: 'Server Latency']\n"
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/server/server_latency\" resource.type=\"k8s_container\""
+                  }
                 }
               }
             ],
@@ -552,10 +906,71 @@
             },
             "dataSets": [
               {
+                "legendTemplate": "99 percentile",
+                "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/server/sent_compressed_message_bytes_per_rpc\n  | group_by 1m, [sent_compressed_message_bytes_per_rpc_aligned: aggregate(value.sent_compressed_message_bytes_per_rpc)]\n  | every 1m\n  | group_by [], [sent_compressed_message_bytes_per_rpc_aggregated: aggregate(sent_compressed_message_bytes_per_rpc_aligned)]\n  | { t_0:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: percentile(sent_compressed_message_bytes_per_rpc_aggregated, 50)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: '50 percentile']\n    ; t_1:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: percentile(sent_compressed_message_bytes_per_rpc_aggregated, 95)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: '95 percentile']\n    ; t_2:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: percentile(sent_compressed_message_bytes_per_rpc_aggregated, 99)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: '99 percentile']\n    ; t_3:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: mean(sent_compressed_message_bytes_per_rpc_aggregated)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: 'mean']}\n  | union\n"
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_99",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/server/sent_compressed_message_bytes_per_rpc\" resource.type=\"k8s_container\""
+                  }
+                }
+              },
+              {
+                "legendTemplate": "90 percentile",
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_95",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/server/sent_compressed_message_bytes_per_rpc\" resource.type=\"k8s_container\""
+                  }
+                }
+              },
+              {
+                "legendTemplate": "50 percentile",
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_50",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/server/sent_compressed_message_bytes_per_rpc\" resource.type=\"k8s_container\""
+                  }
+                }
+              },
+              {
+                "legendTemplate": "mean",
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_MEAN",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/server/sent_compressed_message_bytes_per_rpc\" resource.type=\"k8s_container\""
+                  }
                 }
               }
             ],
@@ -581,10 +996,20 @@
             },
             "dataSets": [
               {
+                "legendTemplate": "Server Sent Compressed Message Bytes per RPC",
+                "minAlignmentPeriod": "60s",
                 "plotType": "HEATMAP",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/server/sent_compressed_message_bytes_per_rpc\n  | align delta(1m)\n  | every 1m\n  | group_by [], [sent_compressed_message_bytes_per_rpc_aggregate: aggregate(value.sent_compressed_message_bytes_per_rpc)]\n  | map add[legend_tag: 'Server Sent Compressed Message Bytes per RPC']\n"
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/server/sent_compressed_message_bytes_per_rpc\" resource.type=\"k8s_container\""
+                  }
                 }
               }
             ],
@@ -608,10 +1033,67 @@
             },
             "dataSets": [
               {
+                "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/server/received_compressed_message_bytes_per_rpc\n  | group_by 1m, [received_compressed_message_bytes_per_rpc_aligned: aggregate(value.received_compressed_message_bytes_per_rpc)]\n  | every 1m\n  | group_by [], [received_compressed_message_bytes_per_rpc_aggregated: aggregate(received_compressed_message_bytes_per_rpc_aligned)]\n  | { t_0:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: percentile(received_compressed_message_bytes_per_rpc_aggregated, 50)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: '50 percentile']\n    ; t_1:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: percentile(received_compressed_message_bytes_per_rpc_aggregated, 95)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: '95 percentile']\n    ; t_2:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: percentile(received_compressed_message_bytes_per_rpc_aggregated, 99)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: '99 percentile']\n    ; t_3:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: mean(received_compressed_message_bytes_per_rpc_aggregated)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: 'mean']}\n  | union\n"
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_99",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/server/received_compressed_message_bytes_per_rpc\" resource.type=\"k8s_container\""
+                  }
+                }
+              },
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_95",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/server/received_compressed_message_bytes_per_rpc\" resource.type=\"k8s_container\""
+                  }
+                }
+              },
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_50",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/server/received_compressed_message_bytes_per_rpc\" resource.type=\"k8s_container\""
+                  }
+                }
+              },
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_MEAN",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/server/received_compressed_message_bytes_per_rpc\" resource.type=\"k8s_container\""
+                  }
                 }
               }
             ],
@@ -637,10 +1119,20 @@
             },
             "dataSets": [
               {
+                "legendTemplate": "Server Received Compressed Message Bytes per RPC",
+                "minAlignmentPeriod": "60s",
                 "plotType": "HEATMAP",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/server/received_compressed_message_bytes_per_rpc\n  | align delta(1m)\n  | every 1m\n  | group_by [], [received_compressed_message_bytes_per_rpc_aggregate: aggregate(value.received_compressed_message_bytes_per_rpc)]\n  | map add[legend_tag: 'Server Received Compressed Message Bytes per RPC']\n"
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"custom.googleapis.com/opencensus/grpc.io/server/received_compressed_message_bytes_per_rpc\" resource.type=\"k8s_container\""
+                  }
                 }
               }
             ],

--- a/dashboards/google-microservices/microservices-grpc-monitoring-gke.json
+++ b/dashboards/google-microservices/microservices-grpc-monitoring-gke.json
@@ -1,90 +1,18 @@
 {
-  "dashboardFilters": [],
   "displayName": "Microservices (gRPC) Monitoring - GKE",
+  "dashboardFilters": [],
   "labels": {},
   "mosaicLayout": {
-    "columns": 12,
+    "columns": 48,
     "tiles": [
       {
-        "height": 24,
-        "widget": {
-          "collapsibleGroup": {
-            "collapsed": false
-          },
-          "title": "Client Side Metrics"
-        },
-        "width": 12,
-        "xPos": 0,
-        "yPos": 0
-      },
-      {
-        "height": 20,
-        "widget": {
-          "collapsibleGroup": {
-            "collapsed": false
-          },
-          "title": "Server Side Metrics"
-        },
-        "width": 12,
-        "xPos": 0,
-        "yPos": 24
-      },
-      {
-        "height": 4,
-        "widget": {
-          "title": "Client Error Percentages",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs\n| align delta(1m)\n| every 1m\n| { t_0: \n      filter (metric.grpc_client_status != 'OK')\n      | group_by drop[metric.grpc_client_status],\n          [error_rpcs_aggregate: aggregate(value.completed_rpcs)]\n  ; t_1:\n      group_by drop[metric.grpc_client_status],\n        [completed_rpcs_aggregate: aggregate(value.completed_rpcs)] }\n| ratio\n"
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s"
-          }
-        },
-        "width": 6,
-        "xPos": 6,
-        "yPos": 4
-      },
-      {
-        "height": 4,
-        "widget": {
-          "title": "Client Concurrency",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | { t_0:\n      metric 'custom.googleapis.com/opencensus/grpc.io/client/started_rpcs'\n        | align delta(1m)\n        | every 1m\n      ; t_1:\n      metric 'custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs'\n        | align delta(1m)\n        | every 1m\n        | group_by drop [metric.grpc_client_status],\n            [completed_rpcs_aggregate: aggregate(value.completed_rpcs)] }\n  | outer_join [0]\n  | value [concurrent_rpcs: sub(t_0.started_rpcs, t_1.completed_rpcs_aggregate)]\n  | filter (val() >= 0)\n"
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s"
-          }
-        },
-        "width": 6,
-        "xPos": 6,
-        "yPos": 0
-      },
-      {
-        "height": 4,
+        "height": 16,
+        "width": 24,
         "widget": {
           "title": "Client Requests",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -97,19 +25,66 @@
               }
             ],
             "thresholds": [],
-            "timeshiftDuration": "0s"
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
           }
-        },
-        "width": 6,
-        "xPos": 0,
-        "yPos": 0
+        }
       },
       {
-        "height": 4,
+        "height": 96,
+        "width": 48,
+        "widget": {
+          "title": "Client Side Metrics",
+          "collapsibleGroup": {
+            "collapsed": false
+          },
+          "id": ""
+        }
+      },
+      {
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Client Concurrency",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | { t_0:\n      metric 'custom.googleapis.com/opencensus/grpc.io/client/started_rpcs'\n        | align delta(1m)\n        | every 1m\n      ; t_1:\n      metric 'custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs'\n        | align delta(1m)\n        | every 1m\n        | group_by drop [metric.grpc_client_status],\n            [completed_rpcs_aggregate: aggregate(value.completed_rpcs)] }\n  | outer_join [0]\n  | value [concurrent_rpcs: sub(t_0.started_rpcs, t_1.completed_rpcs_aggregate)]\n  | filter (val() >= 0)\n",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s"
+          }
+        }
+      },
+      {
+        "yPos": 16,
+        "height": 16,
+        "width": 24,
         "widget": {
           "title": "Client Errors",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -122,19 +97,23 @@
               }
             ],
             "thresholds": [],
-            "timeshiftDuration": "0s"
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
           }
-        },
-        "width": 6,
-        "xPos": 0,
-        "yPos": 4
+        }
       },
       {
-        "height": 4,
+        "yPos": 16,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
         "widget": {
-          "title": "Server Error Percentages",
+          "title": "Client Error Percentages",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -142,99 +121,27 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/server/completed_rpcs\n| align delta(1m)\n| every 1m\n| { t_0: \n      filter (metric.grpc_server_status != 'OK')\n      | group_by drop[metric.grpc_server_status],\n          [error_rpcs_aggregate: aggregate(value.completed_rpcs)]\n  ; t_1:\n      group_by drop[metric.grpc_server_status],\n        [completed_rpcs_aggregate: aggregate(value.completed_rpcs)] }\n| ratio\n"
+                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/client/completed_rpcs\n| align delta(1m)\n| every 1m\n| { t_0: \n      filter (metric.grpc_client_status != 'OK')\n      | group_by drop[metric.grpc_client_status],\n          [error_rpcs_aggregate: aggregate(value.completed_rpcs)]\n  ; t_1:\n      group_by drop[metric.grpc_client_status],\n        [completed_rpcs_aggregate: aggregate(value.completed_rpcs)] }\n| ratio\n"
                 }
               }
             ],
             "thresholds": [],
-            "timeshiftDuration": "0s"
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
           }
-        },
-        "width": 6,
-        "xPos": 6,
-        "yPos": 28
+        }
       },
       {
-        "height": 4,
-        "widget": {
-          "title": "Server Concurrency",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | { t_0:\n      metric 'custom.googleapis.com/opencensus/grpc.io/server/started_rpcs'\n        | align delta(1m)\n        | every 1m\n      ; t_1:\n      metric 'custom.googleapis.com/opencensus/grpc.io/server/completed_rpcs'\n        | align delta(1m)\n        | every 1m\n        | group_by drop [metric.grpc_server_status],\n            [completed_rpcs_aggregate: aggregate(value.completed_rpcs)] }\n  | outer_join [0]\n  | value [concurrent_rpcs: sub(t_0.started_rpcs, t_1.completed_rpcs_aggregate)]\n  | filter (val() >= 0)\n"
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s"
-          }
-        },
-        "width": 6,
-        "xPos": 6,
-        "yPos": 24
-      },
-      {
-        "height": 4,
-        "widget": {
-          "title": "Server Requests",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric 'custom.googleapis.com/opencensus/grpc.io/server/completed_rpcs'\n  | filter (metric.grpc_server_status == 'OK')\n  | align rate(1m)\n  | every 1m\n"
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s"
-          }
-        },
-        "width": 6,
-        "xPos": 0,
-        "yPos": 24
-      },
-      {
-        "height": 4,
-        "widget": {
-          "title": "Server Errors",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric 'custom.googleapis.com/opencensus/grpc.io/server/completed_rpcs'\n  | filter (metric.grpc_server_status != 'OK')\n  | align rate(1m)\n  | every 1m\n"
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s"
-          }
-        },
-        "width": 6,
-        "xPos": 0,
-        "yPos": 28
-      },
-      {
-        "height": 4,
+        "yPos": 32,
+        "height": 16,
+        "width": 24,
         "widget": {
           "title": "Client RTT Latency",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -247,19 +154,23 @@
               }
             ],
             "thresholds": [],
-            "timeshiftDuration": "0s"
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
           }
-        },
-        "width": 6,
-        "xPos": 0,
-        "yPos": 8
+        }
       },
       {
-        "height": 4,
+        "yPos": 32,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
         "widget": {
           "title": "Client RTT Latency",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -272,269 +183,21 @@
               }
             ],
             "thresholds": [],
-            "timeshiftDuration": "0s"
+            "yAxis": {
+              "scale": "LINEAR"
+            }
           }
-        },
-        "width": 6,
-        "xPos": 6,
-        "yPos": 8
+        }
       },
       {
-        "height": 4,
-        "widget": {
-          "title": "Client Sent Compressed Message Bytes per RPC",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/client/sent_compressed_message_bytes_per_rpc\n  | group_by 1m, [sent_compressed_message_bytes_per_rpc_aligned: aggregate(value.sent_compressed_message_bytes_per_rpc)]\n  | every 1m\n  | group_by [], [sent_compressed_message_bytes_per_rpc_aggregated: aggregate(sent_compressed_message_bytes_per_rpc_aligned)]\n  | { t_0:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: percentile(sent_compressed_message_bytes_per_rpc_aggregated, 50)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: '50 percentile']\n    ; t_1:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: percentile(sent_compressed_message_bytes_per_rpc_aggregated, 95)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: '95 percentile']\n    ; t_2:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: percentile(sent_compressed_message_bytes_per_rpc_aggregated, 99)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: '99 percentile']\n    ; t_3:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: mean(sent_compressed_message_bytes_per_rpc_aggregated)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: 'mean']}\n  | union\n"
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s"
-          }
-        },
-        "width": 6,
-        "xPos": 0,
-        "yPos": 16
-      },
-      {
-        "height": 4,
-        "widget": {
-          "title": "Client Sent Compressed Message Bytes per RPC",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "HEATMAP",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/client/sent_compressed_message_bytes_per_rpc\n  | align delta(1m)\n  | every 1m\n  | group_by [], [sent_compressed_message_bytes_per_rpc_aggregate: aggregate(value.sent_compressed_message_bytes_per_rpc)]\n  | map add[legend_tag: 'Client Sent Compressed Message Bytes per RPC']\n"
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s"
-          }
-        },
-        "width": 6,
-        "xPos": 6,
-        "yPos": 16
-      },
-      {
-        "height": 4,
-        "widget": {
-          "title": "Client Received Compressed Message Bytes per RPC",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "HEATMAP",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/client/received_compressed_message_bytes_per_rpc\n  | align delta(1m)\n  | every 1m\n  | group_by [], [received_compressed_message_bytes_per_rpc_aggregate: aggregate(value.received_compressed_message_bytes_per_rpc)]\n  | map add[legend_tag: 'Client Received Compressed Message Bytes per RPC']\n"
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s"
-          }
-        },
-        "width": 6,
-        "xPos": 6,
-        "yPos": 20
-      },
-      {
-        "height": 4,
-        "widget": {
-          "title": "Client Received Compressed Message Bytes per RPC",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/client/received_compressed_message_bytes_per_rpc\n  | group_by 1m, [received_compressed_message_bytes_per_rpc_aligned: aggregate(value.received_compressed_message_bytes_per_rpc)]\n  | every 1m\n  | group_by [], [received_compressed_message_bytes_per_rpc_aggregated: aggregate(received_compressed_message_bytes_per_rpc_aligned)]\n  | { t_0:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: percentile(received_compressed_message_bytes_per_rpc_aggregated, 50)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: '50 percentile']\n    ; t_1:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: percentile(received_compressed_message_bytes_per_rpc_aggregated, 95)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: '95 percentile']\n    ; t_2:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: percentile(received_compressed_message_bytes_per_rpc_aggregated, 99)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: '99 percentile']\n    ; t_3:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: mean(received_compressed_message_bytes_per_rpc_aggregated)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: 'mean']}\n  | union\n"
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s"
-          }
-        },
-        "width": 6,
-        "xPos": 0,
-        "yPos": 20
-      },
-      {
-        "height": 4,
-        "widget": {
-          "title": "Server Sent Compressed Message Bytes per RPC",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/server/sent_compressed_message_bytes_per_rpc\n  | group_by 1m, [sent_compressed_message_bytes_per_rpc_aligned: aggregate(value.sent_compressed_message_bytes_per_rpc)]\n  | every 1m\n  | group_by [], [sent_compressed_message_bytes_per_rpc_aggregated: aggregate(sent_compressed_message_bytes_per_rpc_aligned)]\n  | { t_0:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: percentile(sent_compressed_message_bytes_per_rpc_aggregated, 50)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: '50 percentile']\n    ; t_1:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: percentile(sent_compressed_message_bytes_per_rpc_aggregated, 95)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: '95 percentile']\n    ; t_2:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: percentile(sent_compressed_message_bytes_per_rpc_aggregated, 99)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: '99 percentile']\n    ; t_3:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: mean(sent_compressed_message_bytes_per_rpc_aggregated)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: 'mean']}\n  | union\n"
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s"
-          }
-        },
-        "width": 6,
-        "xPos": 0,
-        "yPos": 36
-      },
-      {
-        "height": 4,
-        "widget": {
-          "title": "Server Received Compressed Message Bytes per RPC",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "HEATMAP",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/server/received_compressed_message_bytes_per_rpc\n  | align delta(1m)\n  | every 1m\n  | group_by [], [received_compressed_message_bytes_per_rpc_aggregate: aggregate(value.received_compressed_message_bytes_per_rpc)]\n  | map add[legend_tag: 'Server Received Compressed Message Bytes per RPC']\n"
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s"
-          }
-        },
-        "width": 6,
-        "xPos": 6,
-        "yPos": 40
-      },
-      {
-        "height": 4,
-        "widget": {
-          "title": "Server Received Compressed Message Bytes per RPC",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/server/received_compressed_message_bytes_per_rpc\n  | group_by 1m, [received_compressed_message_bytes_per_rpc_aligned: aggregate(value.received_compressed_message_bytes_per_rpc)]\n  | every 1m\n  | group_by [], [received_compressed_message_bytes_per_rpc_aggregated: aggregate(received_compressed_message_bytes_per_rpc_aligned)]\n  | { t_0:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: percentile(received_compressed_message_bytes_per_rpc_aggregated, 50)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: '50 percentile']\n    ; t_1:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: percentile(received_compressed_message_bytes_per_rpc_aggregated, 95)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: '95 percentile']\n    ; t_2:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: percentile(received_compressed_message_bytes_per_rpc_aggregated, 99)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: '99 percentile']\n    ; t_3:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: mean(received_compressed_message_bytes_per_rpc_aggregated)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: 'mean']}\n  | union\n"
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s"
-          }
-        },
-        "width": 6,
-        "xPos": 0,
-        "yPos": 40
-      },
-      {
-        "height": 4,
-        "widget": {
-          "title": "Server Sent Compressed Message Bytes per RPC",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "HEATMAP",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/server/sent_compressed_message_bytes_per_rpc\n  | align delta(1m)\n  | every 1m\n  | group_by [], [sent_compressed_message_bytes_per_rpc_aggregate: aggregate(value.sent_compressed_message_bytes_per_rpc)]\n  | map add[legend_tag: 'Server Sent Compressed Message Bytes per RPC']\n"
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s"
-          }
-        },
-        "width": 6,
-        "xPos": 6,
-        "yPos": 36
-      },
-      {
-        "height": 4,
-        "widget": {
-          "title": "Server Latency",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n    | metric custom.googleapis.com/opencensus/grpc.io/server/server_latency\n    | group_by 1m, [server_latency_aligned: aggregate(value.server_latency)]\n    | every 1m\n    | group_by [], [server_latency_aggregated: aggregate(server_latency_aligned)]\n    | { t_0:\n          group_by [], [server_latency_stats_value: percentile(server_latency_aggregated, 50)]\n            | map add[server_latency_stats_tag: '50 percentile']\n      ; t_1:\n          group_by [], [server_latency_stats_value: percentile(server_latency_aggregated, 95)]\n            | map add[server_latency_stats_tag: '95 percentile']\n      ; t_2:\n          group_by [], [server_latency_stats_value: percentile(server_latency_aggregated, 99)]\n            | map add[server_latency_stats_tag: '99 percentile']\n      ; t_3:\n          group_by [], [server_latency_stats_value: mean(server_latency_aggregated)]\n            | map add[server_latency_stats_tag: 'mean']}\n    | union\n"
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s"
-          }
-        },
-        "width": 6,
-        "xPos": 0,
-        "yPos": 32
-      },
-      {
-        "height": 4,
-        "widget": {
-          "title": "Server Latency",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "HEATMAP",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/server/server_latency\n  | align delta(1m)\n  | every 1m\n  | group_by [], [server_latency_aggregate: aggregate(value.server_latency)]\n  | map add[legend_tag: 'Server Latency']\n"
-                }
-              }
-            ],
-            "thresholds": [],
-            "timeshiftDuration": "0s"
-          }
-        },
-        "width": 6,
-        "xPos": 6,
-        "yPos": 32
-      },
-      {
-        "height": 4,
+        "yPos": 48,
+        "height": 16,
+        "width": 24,
         "widget": {
           "title": "Client API Latency",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -547,19 +210,23 @@
               }
             ],
             "thresholds": [],
-            "timeshiftDuration": "0s"
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
           }
-        },
-        "width": 6,
-        "xPos": 0,
-        "yPos": 12
+        }
       },
       {
-        "height": 4,
+        "yPos": 48,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
         "widget": {
           "title": "Client API Latency",
           "xyChart": {
             "chartOptions": {
+              "displayHorizontal": false,
               "mode": "COLOR"
             },
             "dataSets": [
@@ -572,12 +239,417 @@
               }
             ],
             "thresholds": [],
-            "timeshiftDuration": "0s"
+            "yAxis": {
+              "scale": "LINEAR"
+            }
           }
-        },
-        "width": 6,
-        "xPos": 6,
-        "yPos": 12
+        }
+      },
+      {
+        "yPos": 64,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Client Sent Compressed Message Bytes per RPC",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/client/sent_compressed_message_bytes_per_rpc\n  | group_by 1m, [sent_compressed_message_bytes_per_rpc_aligned: aggregate(value.sent_compressed_message_bytes_per_rpc)]\n  | every 1m\n  | group_by [], [sent_compressed_message_bytes_per_rpc_aggregated: aggregate(sent_compressed_message_bytes_per_rpc_aligned)]\n  | { t_0:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: percentile(sent_compressed_message_bytes_per_rpc_aggregated, 50)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: '50 percentile']\n    ; t_1:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: percentile(sent_compressed_message_bytes_per_rpc_aggregated, 95)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: '95 percentile']\n    ; t_2:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: percentile(sent_compressed_message_bytes_per_rpc_aggregated, 99)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: '99 percentile']\n    ; t_3:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: mean(sent_compressed_message_bytes_per_rpc_aggregated)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: 'mean']}\n  | union\n"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 64,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Client Sent Compressed Message Bytes per RPC",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "HEATMAP",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/client/sent_compressed_message_bytes_per_rpc\n  | align delta(1m)\n  | every 1m\n  | group_by [], [sent_compressed_message_bytes_per_rpc_aggregate: aggregate(value.sent_compressed_message_bytes_per_rpc)]\n  | map add[legend_tag: 'Client Sent Compressed Message Bytes per RPC']\n"
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 80,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Client Received Compressed Message Bytes per RPC",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/client/received_compressed_message_bytes_per_rpc\n  | group_by 1m, [received_compressed_message_bytes_per_rpc_aligned: aggregate(value.received_compressed_message_bytes_per_rpc)]\n  | every 1m\n  | group_by [], [received_compressed_message_bytes_per_rpc_aggregated: aggregate(received_compressed_message_bytes_per_rpc_aligned)]\n  | { t_0:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: percentile(received_compressed_message_bytes_per_rpc_aggregated, 50)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: '50 percentile']\n    ; t_1:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: percentile(received_compressed_message_bytes_per_rpc_aggregated, 95)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: '95 percentile']\n    ; t_2:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: percentile(received_compressed_message_bytes_per_rpc_aggregated, 99)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: '99 percentile']\n    ; t_3:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: mean(received_compressed_message_bytes_per_rpc_aggregated)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: 'mean']}\n  | union\n"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 80,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Client Received Compressed Message Bytes per RPC",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "HEATMAP",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/client/received_compressed_message_bytes_per_rpc\n  | align delta(1m)\n  | every 1m\n  | group_by [], [received_compressed_message_bytes_per_rpc_aggregate: aggregate(value.received_compressed_message_bytes_per_rpc)]\n  | map add[legend_tag: 'Client Received Compressed Message Bytes per RPC']\n"
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 96,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Server Requests",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric 'custom.googleapis.com/opencensus/grpc.io/server/completed_rpcs'\n  | filter (metric.grpc_server_status == 'OK')\n  | align rate(1m)\n  | every 1m\n"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 96,
+        "height": 80,
+        "width": 48,
+        "widget": {
+          "title": "Server Side Metrics",
+          "collapsibleGroup": {
+            "collapsed": false
+          },
+          "id": ""
+        }
+      },
+      {
+        "yPos": 96,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Server Concurrency",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | { t_0:\n      metric 'custom.googleapis.com/opencensus/grpc.io/server/started_rpcs'\n        | align delta(1m)\n        | every 1m\n      ; t_1:\n      metric 'custom.googleapis.com/opencensus/grpc.io/server/completed_rpcs'\n        | align delta(1m)\n        | every 1m\n        | group_by drop [metric.grpc_server_status],\n            [completed_rpcs_aggregate: aggregate(value.completed_rpcs)] }\n  | outer_join [0]\n  | value [concurrent_rpcs: sub(t_0.started_rpcs, t_1.completed_rpcs_aggregate)]\n  | filter (val() >= 0)\n"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 112,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Server Errors",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric 'custom.googleapis.com/opencensus/grpc.io/server/completed_rpcs'\n  | filter (metric.grpc_server_status != 'OK')\n  | align rate(1m)\n  | every 1m\n"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 112,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Server Error Percentages",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/server/completed_rpcs\n| align delta(1m)\n| every 1m\n| { t_0: \n      filter (metric.grpc_server_status != 'OK')\n      | group_by drop[metric.grpc_server_status],\n          [error_rpcs_aggregate: aggregate(value.completed_rpcs)]\n  ; t_1:\n      group_by drop[metric.grpc_server_status],\n        [completed_rpcs_aggregate: aggregate(value.completed_rpcs)] }\n| ratio\n"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 128,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Server Latency",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch k8s_container\n    | metric custom.googleapis.com/opencensus/grpc.io/server/server_latency\n    | group_by 1m, [server_latency_aligned: aggregate(value.server_latency)]\n    | every 1m\n    | group_by [], [server_latency_aggregated: aggregate(server_latency_aligned)]\n    | { t_0:\n          group_by [], [server_latency_stats_value: percentile(server_latency_aggregated, 50)]\n            | map add[server_latency_stats_tag: '50 percentile']\n      ; t_1:\n          group_by [], [server_latency_stats_value: percentile(server_latency_aggregated, 95)]\n            | map add[server_latency_stats_tag: '95 percentile']\n      ; t_2:\n          group_by [], [server_latency_stats_value: percentile(server_latency_aggregated, 99)]\n            | map add[server_latency_stats_tag: '99 percentile']\n      ; t_3:\n          group_by [], [server_latency_stats_value: mean(server_latency_aggregated)]\n            | map add[server_latency_stats_tag: 'mean']}\n    | union\n"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 128,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Server Latency",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "HEATMAP",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/server/server_latency\n  | align delta(1m)\n  | every 1m\n  | group_by [], [server_latency_aggregate: aggregate(value.server_latency)]\n  | map add[legend_tag: 'Server Latency']\n"
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 144,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Server Sent Compressed Message Bytes per RPC",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/server/sent_compressed_message_bytes_per_rpc\n  | group_by 1m, [sent_compressed_message_bytes_per_rpc_aligned: aggregate(value.sent_compressed_message_bytes_per_rpc)]\n  | every 1m\n  | group_by [], [sent_compressed_message_bytes_per_rpc_aggregated: aggregate(sent_compressed_message_bytes_per_rpc_aligned)]\n  | { t_0:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: percentile(sent_compressed_message_bytes_per_rpc_aggregated, 50)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: '50 percentile']\n    ; t_1:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: percentile(sent_compressed_message_bytes_per_rpc_aggregated, 95)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: '95 percentile']\n    ; t_2:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: percentile(sent_compressed_message_bytes_per_rpc_aggregated, 99)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: '99 percentile']\n    ; t_3:\n        group_by [], [sent_compressed_message_bytes_per_rpc_stats_value: mean(sent_compressed_message_bytes_per_rpc_aggregated)]\n          | map add[sent_compressed_message_bytes_per_rpc_stats_tag: 'mean']}\n  | union\n"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 144,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Server Sent Compressed Message Bytes per RPC",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "HEATMAP",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/server/sent_compressed_message_bytes_per_rpc\n  | align delta(1m)\n  | every 1m\n  | group_by [], [sent_compressed_message_bytes_per_rpc_aggregate: aggregate(value.sent_compressed_message_bytes_per_rpc)]\n  | map add[legend_tag: 'Server Sent Compressed Message Bytes per RPC']\n"
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 160,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Server Received Compressed Message Bytes per RPC",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/server/received_compressed_message_bytes_per_rpc\n  | group_by 1m, [received_compressed_message_bytes_per_rpc_aligned: aggregate(value.received_compressed_message_bytes_per_rpc)]\n  | every 1m\n  | group_by [], [received_compressed_message_bytes_per_rpc_aggregated: aggregate(received_compressed_message_bytes_per_rpc_aligned)]\n  | { t_0:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: percentile(received_compressed_message_bytes_per_rpc_aggregated, 50)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: '50 percentile']\n    ; t_1:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: percentile(received_compressed_message_bytes_per_rpc_aggregated, 95)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: '95 percentile']\n    ; t_2:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: percentile(received_compressed_message_bytes_per_rpc_aggregated, 99)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: '99 percentile']\n    ; t_3:\n        group_by [], [received_compressed_message_bytes_per_rpc_stats_value: mean(received_compressed_message_bytes_per_rpc_aggregated)]\n          | map add[received_compressed_message_bytes_per_rpc_stats_tag: 'mean']}\n  | union\n"
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 160,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Server Received Compressed Message Bytes per RPC",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "plotType": "HEATMAP",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesQueryLanguage": "fetch k8s_container\n  | metric custom.googleapis.com/opencensus/grpc.io/server/received_compressed_message_bytes_per_rpc\n  | align delta(1m)\n  | every 1m\n  | group_by [], [received_compressed_message_bytes_per_rpc_aggregate: aggregate(value.received_compressed_message_bytes_per_rpc)]\n  | map add[legend_tag: 'Server Received Compressed Message Bytes per RPC']\n"
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "scale": "LINEAR"
+            }
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
This PR updates the Microservices (gRPC) Monitoring - GKE Dashboard to use PromQL instead of the deprecated MQL.

To prove equivalence, here are screenshots of two different versions of the dashboard over the same time period. The former is the previous version of the dashboard, the latter the updated version of the dashboard.

Ended up using a lot of ListTimeSeries for this one - histogram/distribution metrics do not really play that nicely with PromQL, and Heat Maps aren't supported with PromQL at all. Even so, the histogram dashboards (any line chart with an identically-named heat map panel next to it) look slightly different between the old and the new - I can't really account for this change, I'm assuming it's just slightly different handling of the same data.

Another thing to note: the "Client Concurrency" panel did not like my underlying data. This was because of the union on the two time series, one of which dropped a label, the other of which didn't, causing a bad union. I translated it as if they both dropped the label.

MQL:
![image](https://github.com/user-attachments/assets/cf624fd3-32e4-40cb-8b6f-c531d6ff4848)
![image](https://github.com/user-attachments/assets/fdd3dad2-61f5-4f40-ad87-c5ad606140a7)
![image](https://github.com/user-attachments/assets/994e305c-047f-4b0d-be1a-54ede480db2f)
![image](https://github.com/user-attachments/assets/d64e4248-c8fa-4b2e-badc-2eb02a793be9)

PromQL:
![image](https://github.com/user-attachments/assets/ce08f15e-1001-4d9d-9397-29a4d50c9974)
![image](https://github.com/user-attachments/assets/30f70f67-797a-4ab7-b807-ad33efda381b)
![image](https://github.com/user-attachments/assets/6cba33a5-2c9f-4c49-9d9e-d05dda18c88e)
![image](https://github.com/user-attachments/assets/11916ca0-9bc3-40a8-a650-262555a565e2)

