### PR TITLE
Update VMs Memory % panels

### DIFF
--- a/dashboards/aerospike/aerospike-gce-overview.json
+++ b/dashboards/aerospike/aerospike-gce-overview.json
@@ -245,7 +245,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "avg by (project_id, zone, instance_id) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n  and on(project_id, zone, instance_id) (\n    workload_googleapis_com:aerospike_node_memory_free{monitored_resource=\"gce_instance\"}\n  )\n)",
+                  "prometheusQuery": "sum by (project_id, zone, instance_id, metadata_system_name) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n)\nand on(project_id, zone, instance_id) (\n  workload_googleapis_com:aerospike_node_memory_free{monitored_resource=\"gce_instance\"}\n)",
                   "unitOverride": "%"
                 }
               }

--- a/dashboards/cassandra/cassandra-gce-overview.json
+++ b/dashboards/cassandra/cassandra-gce-overview.json
@@ -595,7 +595,7 @@
         "height": 16,
         "width": 16,
         "widget": {
-          "title": "CPU % Top 5 VMs",
+          "title": "VMs CPU %",
           "id": "",
           "xyChart": {
             "chartOptions": {
@@ -613,8 +613,8 @@
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
                   "outputFullDuration": false,
-                  "prometheusQuery": "topk(5, 100 *\n  avg by (project_id, zone, instance_name) (\n    avg_over_time(\n      compute_googleapis_com:instance_cpu_utilization{monitored_resource=\"gce_instance\"}[1m]\n    )\n    and\n    on(instance_id, project_id, zone)\n    (workload_googleapis_com:cassandra_client_request_count{monitored_resource=\"gce_instance\"})\n  )\n)",
-                  "unitOverride": "%"
+                  "prometheusQuery": "(avg by (project_id, zone, instance_name) (\n    avg_over_time(\n      compute_googleapis_com:instance_cpu_utilization{monitored_resource=\"gce_instance\"}[1m]\n    )\n    and\n    on(instance_id, project_id, zone)\n    (workload_googleapis_com:cassandra_client_request_count{monitored_resource=\"gce_instance\"})\n  )\n)",
+                  "unitOverride": "10^2.%"
                 }
               }
             ],
@@ -633,7 +633,7 @@
         "height": 16,
         "width": 16,
         "widget": {
-          "title": "Memory % Top 5 VMs",
+          "title": "VMs Memory %",
           "id": "",
           "xyChart": {
             "chartOptions": {
@@ -651,7 +651,7 @@
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
                   "outputFullDuration": false,
-                  "prometheusQuery": "topk(5,\n  avg by (project_id, zone, instance_id) (\n    avg_over_time(\n      agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n    )\n    and on(project_id, zone, instance_id) (\n      workload_googleapis_com:cassandra_client_request_count{monitored_resource=\"gce_instance\"}\n    )\n  )\n)",
+                  "prometheusQuery": "sum by (project_id, zone, instance_id, metadata_system_name) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n)\nand on(project_id, zone, instance_id) (\n  workload_googleapis_com:cassandra_client_request_count{monitored_resource=\"gce_instance\"}\n)",
                   "unitOverride": "%"
                 }
               }

--- a/dashboards/couchbase/gce-overview.json
+++ b/dashboards/couchbase/gce-overview.json
@@ -229,7 +229,7 @@
         "height": 16,
         "width": 24,
         "widget": {
-          "title": "CPU % Top 5 VMs",
+          "title": "VMs CPU %",
           "xyChart": {
             "chartOptions": {
               "displayHorizontal": false,
@@ -259,7 +259,7 @@
         "height": 16,
         "width": 24,
         "widget": {
-          "title": "Memory % Top 5 VMs",
+          "title": "VMs Memory %",
           "xyChart": {
             "chartOptions": {
               "displayHorizontal": false,
@@ -270,7 +270,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "avg by (project_id, zone, instance_id) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n  and on(project_id, zone, instance_id) (\n    workload_googleapis_com:couchbase_bucket_memory_usage{monitored_resource=\"gce_instance\"}\n  )\n)",
+                  "prometheusQuery": "sum by (project_id, zone, instance_id, metadata_system_name) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n)\nand on(project_id, zone, instance_id) (\n  workload_googleapis_com:couchbase_bucket_memory_usage{monitored_resource=\"gce_instance\"}\n)",
                   "unitOverride": "%"
                 }
               }

--- a/dashboards/couchdb/couchdb-gce-overview.json
+++ b/dashboards/couchdb/couchdb-gce-overview.json
@@ -453,7 +453,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "avg by (project_id, zone, instance_id) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n  and on(project_id, zone, instance_id) (\n    workload_googleapis_com:couchdb_httpd_requests{monitored_resource=\"gce_instance\"}\n  )\n)",
+                  "prometheusQuery": "sum by (project_id, zone, instance_id, metadata_system_name) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n)\nand on(project_id, zone, instance_id) (\n  workload_googleapis_com:couchdb_httpd_requests{monitored_resource=\"gce_instance\"}\n)",
                   "unitOverride": "%"
                 }
               }

--- a/dashboards/flink/flink-gce-overview.json
+++ b/dashboards/flink/flink-gce-overview.json
@@ -965,7 +965,7 @@
         "height": 16,
         "width": 16,
         "widget": {
-          "title": "CPU % Top 5 VMs",
+          "title": "VMs CPU %",
           "id": "",
           "xyChart": {
             "chartOptions": {
@@ -983,8 +983,8 @@
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
                   "outputFullDuration": false,
-                  "prometheusQuery": "topk(5, 100 *\n  avg by (project_id, zone, instance_name) (\n    avg_over_time(\n      compute_googleapis_com:instance_cpu_utilization{monitored_resource=\"gce_instance\"}[1m]\n    )\n    and\n    on(instance_id, project_id, zone)\n    (workload_googleapis_com:flink_jvm_cpu_load{monitored_resource=\"gce_instance\"})\n  )\n)",
-                  "unitOverride": "%"
+                  "prometheusQuery": "(avg by (project_id, zone, instance_name) (\n    avg_over_time(\n      compute_googleapis_com:instance_cpu_utilization{monitored_resource=\"gce_instance\"}[1m]\n    )\n    and\n    on(instance_id, project_id, zone)\n    (workload_googleapis_com:flink_jvm_cpu_load{monitored_resource=\"gce_instance\"})\n  )\n)",
+                  "unitOverride": "10^2.%"
                 }
               }
             ],
@@ -1003,7 +1003,7 @@
         "height": 16,
         "width": 16,
         "widget": {
-          "title": "Memory % Top 5 VMs",
+          "title": "VMs Memory %",
           "id": "",
           "xyChart": {
             "chartOptions": {
@@ -1021,7 +1021,7 @@
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
                   "outputFullDuration": false,
-                  "prometheusQuery": "topk(5,\n  avg by (project_id, zone, instance_id) (\n    avg_over_time(\n      agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n    )\n  )\n  and on(instance_id, project_id, zone) (\n    workload_googleapis_com:flink_jvm_cpu_load{monitored_resource=\"gce_instance\"}\n  )\n)",
+                  "prometheusQuery": "sum by (project_id, zone, instance_id, metadata_system_name) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n)\nand on(project_id, zone, instance_id) (\n  workload_googleapis_com:flink_jvm_cpu_load{monitored_resource=\"gce_instance\"}\n)",
                   "unitOverride": "%"
                 }
               }

--- a/dashboards/hadoop/hadoop-gce-overview.json
+++ b/dashboards/hadoop/hadoop-gce-overview.json
@@ -469,7 +469,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "avg by (project_id, zone, instance_id) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n  and on(project_id, zone, instance_id) (\n    workload_googleapis_com:hadoop_name_node_block_count{monitored_resource=\"gce_instance\"}\n  )\n)",
+                  "prometheusQuery": "sum by (project_id, zone, instance_id, metadata_system_name) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n)\nand on(project_id, zone, instance_id) (\n  workload_googleapis_com:hadoop_name_node_block_count{monitored_resource=\"gce_instance\"}\n)",
                   "unitOverride": "%"
                 }
               }

--- a/dashboards/iis/iis-gce-overview.json
+++ b/dashboards/iis/iis-gce-overview.json
@@ -505,7 +505,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "avg by (project_id, zone, instance_id) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n  and on(project_id, zone, instance_id) (\n    workload_googleapis_com:iis_thread_active{monitored_resource=\"gce_instance\"}\n  )\n)",
+                  "prometheusQuery": "sum by (project_id, zone, instance_id, metadata_system_name) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n)\nand on(project_id, zone, instance_id) (\n  workload_googleapis_com:iis_thread_active{monitored_resource=\"gce_instance\"}\n)",
                   "unitOverride": "%"
                 }
               }

--- a/dashboards/jetty/jetty-gce-overview.json
+++ b/dashboards/jetty/jetty-gce-overview.json
@@ -322,7 +322,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "avg by (project_id, zone, instance_id) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n  and on(project_id, zone, instance_id) (\n    workload_googleapis_com:jetty_thread_queue_count{monitored_resource=\"gce_instance\"}\n  )\n)",
+                  "prometheusQuery": "sum by (project_id, zone, instance_id, metadata_system_name) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n)\nand on(project_id, zone, instance_id) (\n  workload_googleapis_com:jetty_thread_queue_count{monitored_resource=\"gce_instance\"}\n)",
                   "unitOverride": "%"
                 }
               }

--- a/dashboards/kafka/kafka-gce-overview.json
+++ b/dashboards/kafka/kafka-gce-overview.json
@@ -455,7 +455,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "avg by (project_id, zone, instance_id) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n  and on(project_id, zone, instance_id) (\n    workload_googleapis_com:kafka_message_count{monitored_resource=\"gce_instance\"}\n  )\n)",
+                  "prometheusQuery": "sum by (project_id, zone, instance_id, metadata_system_name) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n)\nand on(project_id, zone, instance_id) (\n  workload_googleapis_com:kafka_message_count{monitored_resource=\"gce_instance\"}\n)",
                   "unitOverride": "%"
                 }
               }

--- a/dashboards/nginx/overview.json
+++ b/dashboards/nginx/overview.json
@@ -217,7 +217,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "avg by (project_id, zone, instance_id) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n  and on(project_id, zone, instance_id) (\n    workload_googleapis_com:nginx_requests{monitored_resource=\"gce_instance\"}\n  )\n)",
+                  "prometheusQuery": "sum by (project_id, zone, instance_id, metadata_system_name) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n)\nand on(project_id, zone, instance_id) (\n  workload_googleapis_com:nginx_requests{monitored_resource=\"gce_instance\"}\n)",
                   "unitOverride": "%"
                 }
               }

--- a/dashboards/tomcat/tomcat-gce-overview.json
+++ b/dashboards/tomcat/tomcat-gce-overview.json
@@ -371,7 +371,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "avg by (project_id, zone, instance_id) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n  and on(project_id, zone, instance_id) (\n    workload_googleapis_com:tomcat_errors{monitored_resource=\"gce_instance\"}\n  )\n)",
+                  "prometheusQuery": "sum by (project_id, zone, instance_id, metadata_system_name) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n)\nand on(project_id, zone, instance_id) (\n  workload_googleapis_com:tomcat_errors{monitored_resource=\"gce_instance\"}\n)",
                   "unitOverride": "%"
                 }
               }

--- a/dashboards/varnish/varnish-gce-overview.json
+++ b/dashboards/varnish/varnish-gce-overview.json
@@ -455,7 +455,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "avg by (project_id, zone, instance_id) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n  and on(project_id, zone, instance_id) (\n    workload_googleapis_com:varnish_backend_connection_count{monitored_resource=\"gce_instance\"}\n  )\n)",
+                  "prometheusQuery": "sum by (project_id, zone, instance_id, metadata_system_name) (\n  avg_over_time(\n    agent_googleapis_com:memory_percent_used{monitored_resource=\"gce_instance\", state=\"used\"}[1m]\n  )\n)\nand on(project_id, zone, instance_id) (\n  workload_googleapis_com:varnish_backend_connection_count{monitored_resource=\"gce_instance\"}\n)",
                   "unitOverride": "%"
                 }
               }


### PR DESCRIPTION
This PR corrects the VMs Memory % dashboard panels for dashboards which were previously converted and merged. The update was made based on comments left by @yqlu in [this PR.](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/pull/1077) Here is an example of an update dashboard panel:
<img width="2696" height="1574" alt="image" src="https://github.com/user-attachments/assets/797a97db-957c-4c44-8efe-16dafcf6c992" />
