### PR TITLE
PromQL Alerts: Flink

### DIFF
--- a/alerts/flink/flink-high-jvm-memory-non-heap-usage.v1.json
+++ b/alerts/flink/flink-high-jvm-memory-non-heap-usage.v1.json
@@ -3,24 +3,29 @@
   "documentation": {
     "content": "When the JVM nonheap ratio of nonheap used over max nonheap exceeds a threshold(default is 90%), then application's performance may start to degrade. This alert can trigger when for a jobmanager or a taskmanager. To specify a jobmanager, the resource_type should be jobmanager. To specify a taskmanager, the taskmanager_id filter should target the correct taskmanager instance.",
     "mimeType": "text/markdown"
-},
+  },
   "userLabels": {},
   "conditions": [
     {
       "displayName": "Flink - JVM Heap Memory Near Max",
       "conditionMonitoringQueryLanguage": {
         "duration": "0s",
-        "query": "fetch gce_instance\n| {\nt_0: metric 'workload.googleapis.com/flink.jvm.memory.nonheap.used'\n| filter (metric.resource_type == 'jobmanager');\nt_1: metric 'workload.googleapis.com/flink.jvm.memory.nonheap.max'\n| filter (metric.resource_type == 'jobmanager')\n}\n| outer_join 0\n| value t_0.value.used / t_1.value.max\n| condition val() > .9\n| every 5m\n| window 5m",
         "trigger": {
           "count": 1
-        }
+        },
+        "query": "fetch gce_instance\n| {\nt_0: metric 'workload.googleapis.com/flink.jvm.memory.nonheap.used'\n| filter (metric.resource_type == 'jobmanager');\nt_1: metric 'workload.googleapis.com/flink.jvm.memory.nonheap.max'\n| filter (metric.resource_type == 'jobmanager')\n}\n| outer_join 0\n| value t_0.value.used / t_1.value.max\n| condition val() > .9\n| every 5m\n| window 5m"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
   "enabled": true,
-  "notificationChannels": []
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/flink/flink-high-jvm-memory-non-heap-usage.v1.json
+++ b/alerts/flink/flink-high-jvm-memory-non-heap-usage.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "Flink - JVM Heap Memory Near Max",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch gce_instance\n| {\nt_0: metric 'workload.googleapis.com/flink.jvm.memory.nonheap.used'\n| filter (metric.resource_type == 'jobmanager');\nt_1: metric 'workload.googleapis.com/flink.jvm.memory.nonheap.max'\n| filter (metric.resource_type == 'jobmanager')\n}\n| outer_join 0\n| value t_0.value.used / t_1.value.max\n| condition val() > .9\n| every 5m\n| window 5m"
+      "conditionPrometheusQueryLanguage": {
+        "duration": "300s",
+        "evaluationInterval": "300s",
+        "query": "(\n    {\"workload.googleapis.com/flink.jvm.memory.nonheap.used\", monitored_resource=\"gce_instance\", resource_type=\"jobmanager\"}\n    /\n    {\"workload.googleapis.com/flink.jvm.memory.nonheap.max\", monitored_resource=\"gce_instance\", resource_type=\"jobmanager\"}\n) > 0.9"
       }
     }
   ],

--- a/alerts/flink/flink-high-jvm-memory-usage.v1.json
+++ b/alerts/flink/flink-high-jvm-memory-usage.v1.json
@@ -3,24 +3,29 @@
   "documentation": {
     "content": "When the JVM heap ratio of heap used over max heap exceeds a threshold(default is 90%), then application's performance may start to degrade. This alert can trigger when for a jobmanager or a taskmanager. To specify a jobmanager, the resource_type should be jobmanager. To specify a taskmanager, the taskmanager_id filter should target the correct taskmanager instance.",
     "mimeType": "text/markdown"
-},
+  },
   "userLabels": {},
   "conditions": [
     {
       "displayName": "Flink - JVM Heap Memory Near Max",
       "conditionMonitoringQueryLanguage": {
         "duration": "0s",
-        "query": "fetch gce_instance\n| {\nt_0: metric 'workload.googleapis.com/flink.jvm.memory.heap.used'\n| filter (metric.resource_type == 'jobmanager');\nt_1: metric 'workload.googleapis.com/flink.jvm.memory.heap.max'\n| filter (metric.resource_type == 'jobmanager')\n}\n| outer_join 0\n| value t_0.value.used / t_1.value.max\n| condition val() > .9\n| every 5m\n| window 5m",
         "trigger": {
           "count": 1
-        }
+        },
+        "query": "fetch gce_instance\n| {\nt_0: metric 'workload.googleapis.com/flink.jvm.memory.heap.used'\n| filter (metric.resource_type == 'jobmanager');\nt_1: metric 'workload.googleapis.com/flink.jvm.memory.heap.max'\n| filter (metric.resource_type == 'jobmanager')\n}\n| outer_join 0\n| value t_0.value.used / t_1.value.max\n| condition val() > .9\n| every 5m\n| window 5m"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
   "enabled": true,
-  "notificationChannels": []
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/flink/flink-high-jvm-memory-usage.v1.json
+++ b/alerts/flink/flink-high-jvm-memory-usage.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "Flink - JVM Heap Memory Near Max",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch gce_instance\n| {\nt_0: metric 'workload.googleapis.com/flink.jvm.memory.heap.used'\n| filter (metric.resource_type == 'jobmanager');\nt_1: metric 'workload.googleapis.com/flink.jvm.memory.heap.max'\n| filter (metric.resource_type == 'jobmanager')\n}\n| outer_join 0\n| value t_0.value.used / t_1.value.max\n| condition val() > .9\n| every 5m\n| window 5m"
+      "conditionPrometheusQueryLanguage": {
+        "duration": "300s",
+        "evaluationInterval": "300s",
+        "query": "(\n    {\"workload.googleapis.com/flink.jvm.memory.heap.used\", monitored_resource=\"gce_instance\", resource_type=\"jobmanager\"}\n    /\n    {\"workload.googleapis.com/flink.jvm.memory.heap.max\", monitored_resource=\"gce_instance\", resource_type=\"jobmanager\"}\n) > 0.9"
       }
     }
   ],


### PR DESCRIPTION
This PR updated the Flink alerts to use PromQL instead of the deprecated MQL.

MQL:
<img width="1856" height="804" alt="image" src="https://github.com/user-attachments/assets/56fd1e10-4607-4360-91fd-863924134f66" />
<img width="1858" height="805" alt="image" src="https://github.com/user-attachments/assets/5b10b957-849c-4a7b-a719-108575b26f5a" />

PromQL:
<img width="1858" height="805" alt="image" src="https://github.com/user-attachments/assets/a6166665-4c86-4637-89d9-6c3de909865c" />
<img width="1859" height="807" alt="image" src="https://github.com/user-attachments/assets/77179452-6c47-4f4f-9ed9-0be549c7170e" />
