### PR TITLE
PromQL Alerts: Google Cloud Alerting

### DIFF
--- a/alerts/google-cloud-alerting/entries-exceeds.v1.json
+++ b/alerts/google-cloud-alerting/entries-exceeds.v1.json
@@ -4,12 +4,10 @@
   "conditions": [
     {
       "displayName": "VM Instance - Log entries",
-      "conditionMonitoringQueryLanguage": {
+      "conditionPrometheusQueryLanguage": {
         "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch gce_instance\n| metric 'logging.googleapis.com/log_entry_count'\n| group_by 5m, [value_log_entry_count_mean: mean(value.log_entry_count)]\n| every 30s\n| condition val() > 500 '1'"
+        "evaluationInterval": "30s",
+        "query": "avg_over_time(\n  {\"logging.googleapis.com/log_entry_count\", monitored_resource=\"gce_instance\"}[5m]\n) > 500"
       }
     }
   ],


### PR DESCRIPTION
This PR updated the Google Cloud Alerting alert to use PromQL instead of the deprecated MQL.

<img width="637" height="603" alt="image" src="https://github.com/user-attachments/assets/af86d933-4c3f-41d9-99ed-d19a5bc57d6d" />
