### PR TITLE
PromQL Alerts: Hadoop

### DIFF
--- a/alerts/hadoop/hadoop-low-available-capacity.v1.json
+++ b/alerts/hadoop/hadoop-low-available-capacity.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "VM Instance - workload/hadoop.name_node.capacity.usage",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch gce_instance\n| { \n    t_0: metric workload.googleapis.com/hadoop.name_node.capacity.usage;\n    t_1: metric workload.googleapis.com/hadoop.name_node.capacity.limit\n}\n| outer_join 0\n| value val(0) / val(1)\n| condition val() > .80\n| every 5m\n| window 5m"
+      "conditionPrometheusQueryLanguage": {
+        "duration": "300s",
+        "evaluationInterval": "300s",
+        "query": "(\n  {\"workload.googleapis.com/hadoop.name_node.capacity.usage\", monitored_resource=\"gce_instance\"}\n  /\n  {\"workload.googleapis.com/hadoop.name_node.capacity.limit\", monitored_resource=\"gce_instance\"}\n) > 0.80"
       }
     }
   ],


### PR DESCRIPTION
This PR updates a Hadoop alert to use PromQL instead of the deprecated MQL.

MQL:
<img width="1858" height="802" alt="image" src="https://github.com/user-attachments/assets/df599090-1c3b-4710-ada1-6737325acb77" />

PromQL:
<img width="1860" height="803" alt="image" src="https://github.com/user-attachments/assets/6d6a049b-9dbf-49c4-bf7a-d028dab7a318" />


