### PR TITLE
PromQL Alerts: JVM

### DIFF
--- a/alerts/jvm/heap-memory-usage.v1.json
+++ b/alerts/jvm/heap-memory-usage.v1.json
@@ -1,26 +1,31 @@
 {
-    "displayName": "JVM - Heap Memory Usage Near Max",
-    "documentation": {
-        "content": "Alert for JVM heap memory usage being near maximum. When the JVM reaches its max, depending on the JVM configuration, this could lead to Out of Memory errors.",
-        "mimeType": "text/markdown"
-    },
-    "userLabels": {},
-    "conditions": [
-        {
-            "displayName": "JVM - Heap Memory Near Max",
-            "conditionMonitoringQueryLanguage": {
-                "duration": "60s",
-                "query": "{ \n    t_0: fetch gce_instance::workload.googleapis.com/jvm.memory.heap.used\n    ;\n    t_1: fetch gce_instance::workload.googleapis.com/jvm.memory.heap.max\n}\n| outer_join 0\n| value val(0) / val(1)\n| window 1m \n| condition val() > .9\n\n",
-                "trigger": {
-                    "count": 1
-                }
-            }
-        }
-    ],
-    "alertStrategy": {
-        "autoClose": "3600s"
-    },
-    "combiner": "OR",
-    "enabled": true,
-    "notificationChannels": []
+  "displayName": "JVM - Heap Memory Usage Near Max",
+  "documentation": {
+    "content": "Alert for JVM heap memory usage being near maximum. When the JVM reaches its max, depending on the JVM configuration, this could lead to Out of Memory errors.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "JVM - Heap Memory Near Max",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "60s",
+        "trigger": {
+          "count": 1
+        },
+        "query": "{ \n    t_0: fetch gce_instance::workload.googleapis.com/jvm.memory.heap.used\n    ;\n    t_1: fetch gce_instance::workload.googleapis.com/jvm.memory.heap.max\n}\n| outer_join 0\n| value val(0) / val(1)\n| window 1m \n| condition val() > .9\n\n"
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "3600s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/jvm/heap-memory-usage.v1.json
+++ b/alerts/jvm/heap-memory-usage.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "JVM - Heap Memory Near Max",
-      "conditionMonitoringQueryLanguage": {
+      "conditionPrometheusQueryLanguage": {
         "duration": "60s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "{ \n    t_0: fetch gce_instance::workload.googleapis.com/jvm.memory.heap.used\n    ;\n    t_1: fetch gce_instance::workload.googleapis.com/jvm.memory.heap.max\n}\n| outer_join 0\n| value val(0) / val(1)\n| window 1m \n| condition val() > .9\n\n"
+        "evaluationInterval": "30s",
+        "query": "(\n  {\"workload.googleapis.com/jvm.memory.heap.used\", monitored_resource=\"gce_instance\"}\n  /\n  {\"workload.googleapis.com/jvm.memory.heap.max\", monitored_resource=\"gce_instance\"}\n) > 0.9"
       }
     }
   ],


### PR DESCRIPTION
This PR updates a JVM alert to use PromQL instead of the deprecated MQL.

MQL:
<img width="1857" height="802" alt="image" src="https://github.com/user-attachments/assets/4cce63eb-b368-4078-93ff-4eb9be626ca9" />

PromQL:
<img width="1857" height="804" alt="image" src="https://github.com/user-attachments/assets/43fc127b-6c0b-4062-b179-579e55ebdacf" />
