### PR TITLE
PromQL Alerts: Nginx

### DIFF
--- a/alerts/nginx/connections-dropped.v1.json
+++ b/alerts/nginx/connections-dropped.v1.json
@@ -10,17 +10,22 @@
       "displayName": "New condition",
       "conditionMonitoringQueryLanguage": {
         "duration": "60s",
-        "query": "{ \n    t_0: fetch gce_instance::workload.googleapis.com/nginx.connections_accepted\n    ;\n    t_1: fetch gce_instance::workload.googleapis.com/nginx.connections_handled\n}\n| outer_join 0\n| value val(0) - val(1)\n| align rate(5m)\n| condition val() > 0\n",
         "trigger": {
           "count": 1
-        }
+        },
+        "query": "{ \n    t_0: fetch gce_instance::workload.googleapis.com/nginx.connections_accepted\n    ;\n    t_1: fetch gce_instance::workload.googleapis.com/nginx.connections_handled\n}\n| outer_join 0\n| value val(0) - val(1)\n| align rate(5m)\n| condition val() > 0\n"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
   "enabled": true,
-  "notificationChannels": []
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/nginx/connections-dropped.v1.json
+++ b/alerts/nginx/connections-dropped.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "New condition",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "60s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "{ \n    t_0: fetch gce_instance::workload.googleapis.com/nginx.connections_accepted\n    ;\n    t_1: fetch gce_instance::workload.googleapis.com/nginx.connections_handled\n}\n| outer_join 0\n| value val(0) - val(1)\n| align rate(5m)\n| condition val() > 0\n"
+      "conditionPrometheusQueryLanguage": {
+        "duration": "0s",
+        "evaluationInterval": "30s",
+        "query": "(\n  rate({\"workload.googleapis.com/nginx.connections_accepted\", monitored_resource=\"gce_instance\"}[5m])\n  -\n  rate({\"workload.googleapis.com/nginx.connections_handled\", monitored_resource=\"gce_instance\"}[5m])\n) > 0"
       }
     }
   ],


### PR DESCRIPTION
This PR updates an JVM alert to use PromQL instead of the deprecated MQL.

MQL:
<img width="1857" height="803" alt="image" src="https://github.com/user-attachments/assets/09f04fdf-1c22-4e18-83e8-2d02f04249ef" />

PromQL: 
<img width="1858" height="804" alt="image" src="https://github.com/user-attachments/assets/4db852ff-8634-44a4-a026-a9ef1973d078" />
