### PR TITLE
PromQL Alerts: Scylla GKE

### DIFF
--- a/alerts/scylla-gke/high-prepared-statement-eviction-rate.v1.json
+++ b/alerts/scylla-gke/high-prepared-statement-eviction-rate.v1.json
@@ -1,26 +1,31 @@
 {
-    "displayName": "ScyllaDB - Prometheus - High Prepared Statement Eviction Rate",
-    "documentation": {
-      "content": "If the prepared statement cache is being continuously evicted, it indicates an error in application prepared-statement usage logic. This can cause performance to degrade.",
-      "mimeType": "text/markdown"
-    },
-    "userLabels": {},
-    "conditions": [
-      {
-        "displayName": "Prometheus Target - prometheus/scylla_cql_prepared_cache_evictions/counter",
-        "conditionMonitoringQueryLanguage": {
-          "duration": "0s",
-          "query": "fetch prometheus_target\n| { t_0: metric 'prometheus.googleapis.com/scylla_cql_prepared_cache_evictions/counter';\n    t_1: metric 'prometheus.googleapis.com/scylla_cql_authorized_prepared_statements_cache_evictions/counter'\n}\n| outer_join 0, 0\n| add\n| align rate(5m)\n| every 5m\n| condition val() > 100\n",
-          "trigger": {
-            "count": 1
-          }
-        }
+  "displayName": "ScyllaDB - Prometheus - High Prepared Statement Eviction Rate",
+  "documentation": {
+    "content": "If the prepared statement cache is being continuously evicted, it indicates an error in application prepared-statement usage logic. This can cause performance to degrade.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Prometheus Target - prometheus/scylla_cql_prepared_cache_evictions/counter",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "0s",
+        "trigger": {
+          "count": 1
+        },
+        "query": "fetch prometheus_target\n| { t_0: metric 'prometheus.googleapis.com/scylla_cql_prepared_cache_evictions/counter';\n    t_1: metric 'prometheus.googleapis.com/scylla_cql_authorized_prepared_statements_cache_evictions/counter'\n}\n| outer_join 0, 0\n| add\n| align rate(5m)\n| every 5m\n| condition val() > 100\n"
       }
-    ],
-    "alertStrategy": {
-      "autoClose": "604800s"
-    },
-    "combiner": "OR",
-    "enabled": false,
-    "notificationChannels": []
-  }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
+}

--- a/alerts/scylla-gke/high-prepared-statement-eviction-rate.v1.json
+++ b/alerts/scylla-gke/high-prepared-statement-eviction-rate.v1.json
@@ -11,7 +11,7 @@
       "conditionPrometheusQueryLanguage": {
         "duration": "0s",
         "evaluationInterval": "300s",
-        "query": "(\n  rate(scylla_cql_prepared_cache_evictions[5m])\n  +\n  rate(scylla_cql_authorized_prepared_statements_cache_evictions[5m])\n) > 100"
+        "query": "(\n  rate({"scylla_cql_prepared_cache_evictions"}[5m])\n  +\n  rate({"scylla_cql_authorized_prepared_statements_cache_evictions"}[5m])\n) > 100"
       }
     }
   ],

--- a/alerts/scylla-gke/high-prepared-statement-eviction-rate.v1.json
+++ b/alerts/scylla-gke/high-prepared-statement-eviction-rate.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "Prometheus Target - prometheus/scylla_cql_prepared_cache_evictions/counter",
-      "conditionMonitoringQueryLanguage": {
+      "conditionPrometheusQueryLanguage": {
         "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch prometheus_target\n| { t_0: metric 'prometheus.googleapis.com/scylla_cql_prepared_cache_evictions/counter';\n    t_1: metric 'prometheus.googleapis.com/scylla_cql_authorized_prepared_statements_cache_evictions/counter'\n}\n| outer_join 0, 0\n| add\n| align rate(5m)\n| every 5m\n| condition val() > 100\n"
+        "evaluationInterval": "300s",
+        "query": "(\n  rate(scylla_cql_prepared_cache_evictions[5m])\n  +\n  rate(scylla_cql_authorized_prepared_statements_cache_evictions[5m])\n) > 100"
       }
     }
   ],

--- a/alerts/scylla-gke/high-prepared-statement-eviction-rate.v1.json
+++ b/alerts/scylla-gke/high-prepared-statement-eviction-rate.v1.json
@@ -11,7 +11,7 @@
       "conditionPrometheusQueryLanguage": {
         "duration": "0s",
         "evaluationInterval": "300s",
-        "query": "(\n  rate({"scylla_cql_prepared_cache_evictions"}[5m])\n  +\n  rate({"scylla_cql_authorized_prepared_statements_cache_evictions"}[5m])\n) > 100"
+        "query": "(\n  rate({\"scylla_cql_prepared_cache_evictions\"}[5m])\n  +\n  rate({\"scylla_cql_authorized_prepared_statements_cache_evictions\"}[5m])\n) > 100"
       }
     }
   ],


### PR DESCRIPTION
This PR updates a Scylla GKE alert to use PromQL instead of the deprecated MQL.

MQL:
<img width="1858" height="804" alt="image" src="https://github.com/user-attachments/assets/fa3d4c30-9349-4ca9-8d83-5524c53b3434" />

PromQL:
<img width="1857" height="805" alt="image" src="https://github.com/user-attachments/assets/80f167bd-c04b-4abc-913c-d854221ee6f5" />

