### PR TITLE
PromQL Alerts: Vault

### DIFF
--- a/alerts/vault/vault-audit-failure-alert.v1.json
+++ b/alerts/vault/vault-audit-failure-alert.v1.json
@@ -11,7 +11,7 @@
       "conditionPrometheusQueryLanguage": {
         "duration": "0s",
         "evaluationInterval": "30s",
-        "query": "rate{\"workload.googleapis.com/vault.audit.response.failed\", monitored_resource=\"gce_instance\"}[1m]) > 0\nor\nrate({\"workload.googleapis.com/vault.audit.request.failed\", monitored_resource=\"gce_instance\"}[1m]) > 0"
+        "query": "rate({\"workload.googleapis.com/vault.audit.response.failed\", monitored_resource=\"gce_instance\"}[1m]) > 0\nor\nrate({\"workload.googleapis.com/vault.audit.request.failed\", monitored_resource=\"gce_instance\"}[1m]) > 0"
       }
     }
   ],

--- a/alerts/vault/vault-audit-failure-alert.v1.json
+++ b/alerts/vault/vault-audit-failure-alert.v1.json
@@ -10,17 +10,22 @@
       "displayName": "New condition",
       "conditionMonitoringQueryLanguage": {
         "duration": "0s",
-        "query": "fetch gce_instance\n| { metric 'workload.googleapis.com/vault.audit.response.failed'\n; metric 'workload.googleapis.com/vault.audit.request.failed' }\n| outer_join 0\n| group_by 1m\n| condition val(0) > 0 || val(1) > 0",
         "trigger": {
           "count": 1
-        }
+        },
+        "query": "fetch gce_instance\n| { metric 'workload.googleapis.com/vault.audit.response.failed'\n; metric 'workload.googleapis.com/vault.audit.request.failed' }\n| outer_join 0\n| group_by 1m\n| condition val(0) > 0 || val(1) > 0"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
   "enabled": true,
-  "notificationChannels": []
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/vault/vault-audit-failure-alert.v1.json
+++ b/alerts/vault/vault-audit-failure-alert.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "New condition",
-      "conditionMonitoringQueryLanguage": {
+      "conditionPrometheusQueryLanguage": {
         "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch gce_instance\n| { metric 'workload.googleapis.com/vault.audit.response.failed'\n; metric 'workload.googleapis.com/vault.audit.request.failed' }\n| outer_join 0\n| group_by 1m\n| condition val(0) > 0 || val(1) > 0"
+        "evaluationInterval": "30s",
+        "query": "rate{\"workload.googleapis.com/vault.audit.response.failed\", monitored_resource=\"gce_instance\"}[1m]) > 0\nor\nrate({\"workload.googleapis.com/vault.audit.request.failed\", monitored_resource=\"gce_instance\"}[1m]) > 0"
       }
     }
   ],

--- a/alerts/vault/vault-token-renew-revoke-alert.v1.json
+++ b/alerts/vault/vault-token-renew-revoke-alert.v1.json
@@ -1,7 +1,7 @@
 {
-  "displayName": "Vault - Token Renew/Revoke Alert",
+  "displayName": "Vault - Audit Failure Alert",
   "documentation": {
-    "content": "This alert will be triggered when it is taking longer than one second to renew or revoke tokens. This alert will help notify users when there is a potential problem with backend token storage.\n\n",
+    "content": "This alert will be triggered whenever an audit request or audit response failure is greater than 0. This alert will help notify users when their audit device is potentially blocked. If it is blocked, Vault will become unresponsive.\n",
     "mimeType": "text/markdown"
   },
   "userLabels": {},
@@ -10,17 +10,22 @@
       "displayName": "New condition",
       "conditionMonitoringQueryLanguage": {
         "duration": "0s",
-        "query": "fetch gce_instance\n| { metric 'workload.googleapis.com/vault.token.renew.time'\n; metric 'workload.googleapis.com/vault.token.revoke.time' }\n| outer_join 0\n| group_by 1m\n| condition val(0) > 1000 || val(1) > 1000",
         "trigger": {
           "count": 1
-        }
+        },
+        "query": "fetch gce_instance\n| { metric 'workload.googleapis.com/vault.token.renew.time'\n; metric 'workload.googleapis.com/vault.token.revoke.time' }\n| outer_join 0\n| group_by 1m\n| condition val(0) > 1000 || val(1) > 1000"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
   "enabled": true,
-  "notificationChannels": []
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/vault/vault-token-renew-revoke-alert.v1.json
+++ b/alerts/vault/vault-token-renew-revoke-alert.v1.json
@@ -11,7 +11,7 @@
       "conditionPrometheusQueryLanguage": {
         "duration": "0s",
         "evaluationInterval": "30s",
-        "query": "rate{\"workload.googleapis.com/vault.token.renew.time\", monitored_resource=\"gce_instance\"}[1m]) > 1000\nor\nrate({\"workload.googleapis.com/vault.token.renew.time\", monitored_resource=\"gce_instance\"}[1m]) > 1000"
+        "query": "rate({\"workload.googleapis.com/vault.token.renew.time\", monitored_resource=\"gce_instance\"}[1m]) > 1000\nor\nrate({\"workload.googleapis.com/vault.token.renew.time\", monitored_resource=\"gce_instance\"}[1m]) > 1000"
       }
     }
   ],

--- a/alerts/vault/vault-token-renew-revoke-alert.v1.json
+++ b/alerts/vault/vault-token-renew-revoke-alert.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "New condition",
-      "conditionMonitoringQueryLanguage": {
+      "conditionPrometheusQueryLanguage": {
         "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch gce_instance\n| { metric 'workload.googleapis.com/vault.token.renew.time'\n; metric 'workload.googleapis.com/vault.token.revoke.time' }\n| outer_join 0\n| group_by 1m\n| condition val(0) > 1000 || val(1) > 1000"
+        "evaluationInterval": "30s",
+        "query": "rate{\"workload.googleapis.com/vault.token.renew.time\", monitored_resource=\"gce_instance\"}[1m]) > 1000\nor\nrate({\"workload.googleapis.com/vault.token.renew.time\", monitored_resource=\"gce_instance\"}[1m]) > 1000"
       }
     }
   ],


### PR DESCRIPTION
This PR updates Vault alerts to use PromQL instead of the deprecated MQL.

Note that only one of the two alerts could be verified using Metrics Explorer, but that the second alert is extremely similar to the first.

MQL: 
<img width="1856" height="804" alt="image" src="https://github.com/user-attachments/assets/88de1b8d-67e5-496e-b29d-64a98a12477a" />

PromQL:
<img width="1857" height="804" alt="image" src="https://github.com/user-attachments/assets/b927b8d6-0517-4753-8d17-54be6766cf38" />

