### PR TITLE
PromQL Alerts: Elasticsearch

### DIFF
--- a/alerts/elasticsearch/elasticsearch-high-jvm-memory-usage.v1.json
+++ b/alerts/elasticsearch/elasticsearch-high-jvm-memory-usage.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "VM Instance - workload/jvm.memory.heap.used",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch gce_instance\n| { \nt_0: metric 'workload.googleapis.com/jvm.memory.heap.used';\nt_1: metric 'workload.googleapis.com/jvm.memory.heap.max'\n}\n| outer_join 0\n| value t_0.value.used / t_1.value.max\n| condition val() > .9\n| every 5m\n| window 5m\n"
+      "conditionPrometheusQueryLanguage": {
+        "duration": "300s",
+        "evaluationInterval": "300s",
+        "query": "(\n  {\"workload.googleapis.com/jvm.memory.heap.used\", monitored_resource=\"gce_instance\"}\n  /\n  {\"workload.googleapis.com/jvm.memory.heap.max\", monitored_resource=\"gce_instance\"}\n) > 0.9"
       }
     }
   ],

--- a/alerts/elasticsearch/elasticsearch-high-jvm-memory-usage.v1.json
+++ b/alerts/elasticsearch/elasticsearch-high-jvm-memory-usage.v1.json
@@ -3,24 +3,29 @@
   "documentation": {
     "content": "When the JVM heap ratio of heap used over max heap exceeds a threshold, then application's performance may start to degrade.",
     "mimeType": "text/markdown"
-},
+  },
   "userLabels": {},
   "conditions": [
     {
       "displayName": "VM Instance - workload/jvm.memory.heap.used",
       "conditionMonitoringQueryLanguage": {
         "duration": "0s",
-        "query": "fetch gce_instance\n| { \nt_0: metric 'workload.googleapis.com/jvm.memory.heap.used';\nt_1: metric 'workload.googleapis.com/jvm.memory.heap.max'\n}\n| outer_join 0\n| value t_0.value.used / t_1.value.max\n| condition val() > .9\n| every 5m\n| window 5m\n",
         "trigger": {
           "count": 1
-        }
+        },
+        "query": "fetch gce_instance\n| { \nt_0: metric 'workload.googleapis.com/jvm.memory.heap.used';\nt_1: metric 'workload.googleapis.com/jvm.memory.heap.max'\n}\n| outer_join 0\n| value t_0.value.used / t_1.value.max\n| condition val() > .9\n| every 5m\n| window 5m\n"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
   "enabled": true,
-  "notificationChannels": []
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }


### PR DESCRIPTION
This PR updates an Elasticsearch alert to use PromQL instead of the deprecated MQL.

Note that the alerts is written using the UTF-8 naming style, which was changed after the screenshot was taken.

<img width="632" height="615" alt="image" src="https://github.com/user-attachments/assets/812dcd95-5471-4ef7-9b0d-de495b2b3a7d" />

