### PR TITLE
PromQL Alerts: Google GCE

### DIFF
--- a/alerts/google-gce/reservation-utilization-too-high.v1.json
+++ b/alerts/google-gce/reservation-utilization-too-high.v1.json
@@ -4,12 +4,10 @@
   "conditions": [
     {
       "displayName": "High Reservation Utilization",
-      "conditionMonitoringQueryLanguage": {
+      "conditionPrometheusQueryLanguage": {
         "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch compute.googleapis.com/Reservation\n|\n{ metric 'compute.googleapis.com/reservation/used'\n| align next_older(5m) | every 5m ;\nmetric 'compute.googleapis.com/reservation/reserved'\n| align next_older(5m) | every 5m\n}\n| ratio\n| condition val() >= 0.9"
+        "evaluationInterval": "300s",
+        "query": "(\n  {\"compute.googleapis.com/reservation/used\", monitored_resource=\"compute.googleapis.com/Reservation\"}\n    / on (reservation_id)\n  {\"compute.googleapis.com/reservation/reserved\", monitored_resource=\"compute.googleapis.com/Reservation\"}\n) >= 0.9"
       }
     }
   ],

--- a/alerts/google-gce/reservation-utilization-too-high.v1.json
+++ b/alerts/google-gce/reservation-utilization-too-high.v1.json
@@ -1,21 +1,27 @@
 {
-    "displayName": "Reservation - High Utilization",
-    "userLabels": {},
-    "conditions": [
-      {
-        "displayName": "High Reservation Utilization",
-        "conditionMonitoringQueryLanguage": {
-          "duration": "0s",
-          "query": "fetch compute.googleapis.com/Reservation\n|\n{ metric 'compute.googleapis.com/reservation/used'\n| align next_older(5m) | every 5m ;\nmetric 'compute.googleapis.com/reservation/reserved'\n| align next_older(5m) | every 5m\n}\n| ratio\n| condition val() >= 0.9",
-          "trigger": {
-            "count": 1
-          }
-        }
+  "displayName": "Reservation - High Utilization",
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "High Reservation Utilization",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "0s",
+        "trigger": {
+          "count": 1
+        },
+        "query": "fetch compute.googleapis.com/Reservation\n|\n{ metric 'compute.googleapis.com/reservation/used'\n| align next_older(5m) | every 5m ;\nmetric 'compute.googleapis.com/reservation/reserved'\n| align next_older(5m) | every 5m\n}\n| ratio\n| condition val() >= 0.9"
       }
-    ],
-    "alertStrategy": {
-      "autoClose": "604800s"
-    },
-    "combiner": "OR",
-    "enabled": true
-  }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
+}

--- a/alerts/google-gce/reservation-utilization-too-low.v1.json
+++ b/alerts/google-gce/reservation-utilization-too-low.v1.json
@@ -4,12 +4,10 @@
   "conditions": [
     {
       "displayName": "Low Usage for 20 hours out of 23 hours",
-      "conditionMonitoringQueryLanguage": {
+      "conditionPrometheusQueryLanguage": {
         "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch compute.googleapis.com/Reservation\n|\n{ metric 'compute.googleapis.com/reservation/used'\n| align next_older(5m) | every 5m ;\nmetric 'compute.googleapis.com/reservation/reserved'\n| align next_older(5m) | every 5m\n}\n| ratio\n| value val() <= 0.1\n| count_true_aligner(23h)\n| condition val() > 20 * 12 # 20 hours * (12 5 min intervals in hour)"
+        "evaluationInterval": "300s",
+        "query": "count_over_time(\n  (\n    ({\"compute.googleapis.com/reservation/used\", monitored_resource=\"compute.googleapis.com/Reservation\"}\n     / on (reservation_id)\n     {\"compute.googleapis.com/reservation/reserved\", monitored_resource=\"compute.googleapis.com/Reservation\"}\n    ) <= 0.1\n  )[23h:5m]\n) > (20 * 12) # 20 hours * (12 5 min intervals in hour)"
       }
     }
   ],

--- a/alerts/google-gce/reservation-utilization-too-low.v1.json
+++ b/alerts/google-gce/reservation-utilization-too-low.v1.json
@@ -1,21 +1,27 @@
 {
-    "displayName": "Reservation - Low Utilization",
-    "userLabels": {},
-    "conditions": [
-      {
-        "displayName": "Low Usage for 20 hours out of 23 hours",
-        "conditionMonitoringQueryLanguage": {
-          "duration": "0s",
-          "query": "fetch compute.googleapis.com/Reservation\n|\n{ metric 'compute.googleapis.com/reservation/used'\n| align next_older(5m) | every 5m ;\nmetric 'compute.googleapis.com/reservation/reserved'\n| align next_older(5m) | every 5m\n}\n| ratio\n| value val() <= 0.1\n| count_true_aligner(23h)\n| condition val() > 20 * 12 # 20 hours * (12 5 min intervals in hour)",
-          "trigger": {
-            "count": 1
-          }
-        }
+  "displayName": "Reservation - Low Utilization",
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Low Usage for 20 hours out of 23 hours",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "0s",
+        "trigger": {
+          "count": 1
+        },
+        "query": "fetch compute.googleapis.com/Reservation\n|\n{ metric 'compute.googleapis.com/reservation/used'\n| align next_older(5m) | every 5m ;\nmetric 'compute.googleapis.com/reservation/reserved'\n| align next_older(5m) | every 5m\n}\n| ratio\n| value val() <= 0.1\n| count_true_aligner(23h)\n| condition val() > 20 * 12 # 20 hours * (12 5 min intervals in hour)"
       }
-    ],
-    "alertStrategy": {
-      "autoClose": "604800s"
-    },
-    "combiner": "OR",
-    "enabled": true
-  }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
+}


### PR DESCRIPTION
This PR updates Google GCE alerts to use PromQL instead of the deprecated MQL.

Note that we included `on (reservation_id)` in the PromQL versions of the query, which is not a part of the original MQL. This is because without the inclusion of this expression, the PromQL data does not appear; see the screenshots for an example.

<img width="638" height="622" alt="image" src="https://github.com/user-attachments/assets/f48a602b-8b9c-4d40-9db3-613e935fc5f7" />
<img width="644" height="287" alt="image" src="https://github.com/user-attachments/assets/a7b667b5-b886-4529-88e7-ea658efe3284" />

MQL:
<img width="1856" height="806" alt="image" src="https://github.com/user-attachments/assets/56c76664-e54a-401b-9f33-affd697ce939" />
PromQL:
<img width="1858" height="807" alt="image" src="https://github.com/user-attachments/assets/5468f641-40a2-4138-b065-061ce5797792" />

