### PR TITLE
PromQL Alerts: Zookeeper

### DIFF
--- a/alerts/zookeeper/low-open-file-descriptors.v1.json
+++ b/alerts/zookeeper/low-open-file-descriptors.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "New condition",
-      "conditionMonitoringQueryLanguage": {
+      "conditionPrometheusQueryLanguage": {
         "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": " fetch gce_instance\n| { metric 'workload.googleapis.com/zookeeper.file_descriptor.limit'\n; metric 'workload.googleapis.com/zookeeper.file_descriptor.open' }\n| outer_join 0\n| group_by 1m\n| sub\n| condition val() < 1000"
+        "evaluationInterval": "30s",
+        "query": "(\n  {\"workload.googleapis.com/zookeeper.file_descriptor.limit\", monitored_resource=\"gce_instance\"}\n  -\n  {\"workload.googleapis.com/zookeeper.file_descriptor.open\", monitored_resource=\"gce_instance\"}\n) < 1000"
       }
     }
   ],

--- a/alerts/zookeeper/low-open-file-descriptors.v1.json
+++ b/alerts/zookeeper/low-open-file-descriptors.v1.json
@@ -10,17 +10,22 @@
       "displayName": "New condition",
       "conditionMonitoringQueryLanguage": {
         "duration": "0s",
-        "query": " fetch gce_instance\n| { metric 'workload.googleapis.com/zookeeper.file_descriptor.limit'\n; metric 'workload.googleapis.com/zookeeper.file_descriptor.open' }\n| outer_join 0\n| group_by 1m\n| sub\n| condition val() < 1000",
         "trigger": {
           "count": 1
-        }
+        },
+        "query": " fetch gce_instance\n| { metric 'workload.googleapis.com/zookeeper.file_descriptor.limit'\n; metric 'workload.googleapis.com/zookeeper.file_descriptor.open' }\n| outer_join 0\n| group_by 1m\n| sub\n| condition val() < 1000"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
   "enabled": true,
-  "notificationChannels": []
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }


### PR DESCRIPTION
This PR updates a Zookeeper alert to use PromQL instead of the deprecated MQL.

MQL:
<img width="1858" height="805" alt="image" src="https://github.com/user-attachments/assets/73caefcf-3af4-498d-badc-d6f459a4152f" />

PromQL:
<img width="1858" height="806" alt="image" src="https://github.com/user-attachments/assets/576daade-7527-45a1-addf-90300963416d" />

