### PR TITLE
PromQL Alerts: MongoDB

### DIFF
--- a/alerts/mongodb/high-cpu-utilization.v1.json
+++ b/alerts/mongodb/high-cpu-utilization.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "MongoDB - High CPU Utilization",
-      "conditionMonitoringQueryLanguage": {
+      "conditionPrometheusQueryLanguage": {
         "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "def top_5_cpu_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/cpu/utilization'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n@top_5_cpu_filtered_by_metric\n  'workload.googleapis.com/mongodb.memory.usage'\n| condition val() > 90'%'"
+        "evaluationInterval": "60s",
+        "query": "(avg by (project_id, zone, instance_id) (\n  avg_over_time(\n    {\"agent.googleapis.com/cpu/utilization\", monitored_resource=\"gce_instance\"}[1m]\n  )\n  and\n  on(instance_id, project_id, zone)\n    ({\"workload.googleapis.com/mongodb.memory.usage\", monitored_resource=\"gce_instance\"})  \n  )\n) > 90"
       }
     }
   ],

--- a/alerts/mongodb/high-cpu-utilization.v1.json
+++ b/alerts/mongodb/high-cpu-utilization.v1.json
@@ -1,26 +1,31 @@
 {
-    "displayName": "MongoDB - High CPU Utilization",
-    "documentation": {
-        "content": "If CPU utilization is above 90%, then the MongoDB instance is probably due to be scaled up or needs further investigation.",
-        "mimeType": "text/markdown"
-    },
-    "userLabels": {},
-    "conditions": [
-        {
-            "displayName": "MongoDB - High CPU Utilization",
-            "conditionMonitoringQueryLanguage": {
-                "duration": "0s",
-                "trigger": {
-                    "count": 1
-                },
-                "query": "def top_5_cpu_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/cpu/utilization'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n@top_5_cpu_filtered_by_metric\n  'workload.googleapis.com/mongodb.memory.usage'\n| condition val() > 90'%'"
-            }
-        }
-    ],
-    "alertStrategy": {
-        "autoClose": "3600s"
-    },
-    "combiner": "OR",
-    "enabled": true,
-    "notificationChannels": []
+  "displayName": "MongoDB - High CPU Utilization",
+  "documentation": {
+    "content": "If CPU utilization is above 90%, then the MongoDB instance is probably due to be scaled up or needs further investigation.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "MongoDB - High CPU Utilization",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "0s",
+        "trigger": {
+          "count": 1
+        },
+        "query": "def top_5_cpu_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/cpu/utilization'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n@top_5_cpu_filtered_by_metric\n  'workload.googleapis.com/mongodb.memory.usage'\n| condition val() > 90'%'"
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "3600s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/mongodb/high-disk-utilization.v1.json
+++ b/alerts/mongodb/high-disk-utilization.v1.json
@@ -8,13 +8,10 @@
   "conditions": [
     {
       "displayName": "New condition",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "60s",
-        "trigger": {
-          "count": 1
-        },
-        "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
-        "query": "def top_5_disk_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/disk/percent_used'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | every 1m;\n\n@top_5_disk_filtered_by_metric\n  'workload.googleapis.com/mongodb.memory.usage'\n| condition val() > 80'%'"
+      "conditionPrometheusQueryLanguage": {
+        "duration": "0s",
+        "evaluationInterval": "60s",
+        "query": "(avg by (project_id, zone, instance_id) (\n  avg_over_time(\n    {\"agent.googleapis.com/disk/percent_used\", monitored_resource=\"gce_instance\"}[1m]\n  )\n  and\n  on(instance_id, project_id, zone)\n    ({\"workload.googleapis.com/mongodb.memory.usage\", monitored_resource=\"gce_instance\"})\n  )\n) > 80"
       }
     }
   ],

--- a/alerts/mongodb/high-disk-utilization.v1.json
+++ b/alerts/mongodb/high-disk-utilization.v1.json
@@ -1,27 +1,32 @@
 {
-    "displayName": "MongoDB - High Disk Utilization",
-    "documentation": {
-      "content": "If Disk Utilization is above 80%, then it is time to look deeper into adding more storage or cleaning up old docs.",
-      "mimeType": "text/markdown"
-    },
-    "userLabels": {},
-    "conditions": [
-      {
-        "displayName": "New condition",
-        "conditionMonitoringQueryLanguage": {
-          "duration": "60s",
-          "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
-          "trigger": {
-            "count": 1
-          },
-          "query": "def top_5_disk_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/disk/percent_used'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | every 1m;\n\n@top_5_disk_filtered_by_metric\n  'workload.googleapis.com/mongodb.memory.usage'\n| condition val() > 80'%'"
-        }
+  "displayName": "MongoDB - High Disk Utilization",
+  "documentation": {
+    "content": "If Disk Utilization is above 80%, then it is time to look deeper into adding more storage or cleaning up old docs.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "New condition",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "60s",
+        "trigger": {
+          "count": 1
+        },
+        "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
+        "query": "def top_5_disk_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/disk/percent_used'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | every 1m;\n\n@top_5_disk_filtered_by_metric\n  'workload.googleapis.com/mongodb.memory.usage'\n| condition val() > 80'%'"
       }
-    ],
-    "alertStrategy": {
-      "autoClose": "3600s"
-    },
-    "combiner": "OR",
-    "enabled": true,
-    "notificationChannels": []
-  }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "3600s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
+}

--- a/alerts/zookeeper/low-open-file-descriptors.v1.json
+++ b/alerts/zookeeper/low-open-file-descriptors.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "New condition",
-      "conditionMonitoringQueryLanguage": {
+      "conditionPrometheusQueryLanguage": {
         "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": " fetch gce_instance\n| { metric 'workload.googleapis.com/zookeeper.file_descriptor.limit'\n; metric 'workload.googleapis.com/zookeeper.file_descriptor.open' }\n| outer_join 0\n| group_by 1m\n| sub\n| condition val() < 1000"
+        "evaluationInterval": "30s",
+        "query": "(\n  {\"workload.googleapis.com/zookeeper.file_descriptor.limit\", monitored_resource=\"gce_instance\"}\n  -\n  {\"workload.googleapis.com/zookeeper.file_descriptor.open\", monitored_resource=\"gce_instance\"}\n) < 1000"
       }
     }
   ],

--- a/alerts/zookeeper/low-open-file-descriptors.v1.json
+++ b/alerts/zookeeper/low-open-file-descriptors.v1.json
@@ -10,17 +10,22 @@
       "displayName": "New condition",
       "conditionMonitoringQueryLanguage": {
         "duration": "0s",
-        "query": " fetch gce_instance\n| { metric 'workload.googleapis.com/zookeeper.file_descriptor.limit'\n; metric 'workload.googleapis.com/zookeeper.file_descriptor.open' }\n| outer_join 0\n| group_by 1m\n| sub\n| condition val() < 1000",
         "trigger": {
           "count": 1
-        }
+        },
+        "query": " fetch gce_instance\n| { metric 'workload.googleapis.com/zookeeper.file_descriptor.limit'\n; metric 'workload.googleapis.com/zookeeper.file_descriptor.open' }\n| outer_join 0\n| group_by 1m\n| sub\n| condition val() < 1000"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
   "enabled": true,
-  "notificationChannels": []
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }


### PR DESCRIPTION
This PR updates some MongoDB alerts to use PromQL instead of the deprecated MQL.

MQL: 