### PR TITLE
PromQL Alerts: OracleDB

### DIFF
--- a/alerts/oracledb/high-process-utilization.v1.json
+++ b/alerts/oracledb/high-process-utilization.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "Processes near system max",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "{\n     t_0: fetch gce_instance::workload.googleapis.com/oracle.process.limit ;\n     t_1: fetch gce_instance::workload.googleapis.com/oracle.process.count\n}\n| group_by [resource.instance_id]\n| outer_join 0\n| window 1m\n| condition val(0) * .9 < val(1)\n"
+      "conditionPrometheusQueryLanguage": {
+        "duration": "60s",
+        "evaluationInterval": "60s",
+        "query": "sum by (instance_id) (\n  {\"workload.googleapis.com/oracle.process.count\", monitored_resource=\"gce_instance\"}\n  /\n  {\"workload.googleapis.com/oracle.process.limit\", monitored_resource=\"gce_instance\"}\n) > 0.9"
       }
     }
   ],

--- a/alerts/oracledb/high-process-utilization.v1.json
+++ b/alerts/oracledb/high-process-utilization.v1.json
@@ -1,26 +1,31 @@
 {
-    "displayName": "Oracle Database - High Process Utilization",
-    "documentation": {
-        "content": "Alert fires when the database is nearing the process limit, which could result in new processes being blocked from starting.",
-        "mimeType": "text/markdown"
-    },
-    "userLabels": {},
-    "conditions": [
-        {
-            "displayName": "Processes near system max",
-            "conditionMonitoringQueryLanguage": {
-                "duration": "0s",
-                "trigger": {
-                    "count": 1
-                },
-                "query": "{\n     t_0: fetch gce_instance::workload.googleapis.com/oracle.process.limit ;\n     t_1: fetch gce_instance::workload.googleapis.com/oracle.process.count\n}\n| group_by [resource.instance_id]\n| outer_join 0\n| window 1m\n| condition val(0) * .9 < val(1)\n"
-            }
-        }
-    ],
-    "alertStrategy": {
-        "autoClose": "604800s"
-    },
-    "combiner": "OR",
-    "enabled": true,
-    "notificationChannels": []
+  "displayName": "Oracle Database - High Process Utilization",
+  "documentation": {
+    "content": "Alert fires when the database is nearing the process limit, which could result in new processes being blocked from starting.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Processes near system max",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "0s",
+        "trigger": {
+          "count": 1
+        },
+        "query": "{\n     t_0: fetch gce_instance::workload.googleapis.com/oracle.process.limit ;\n     t_1: fetch gce_instance::workload.googleapis.com/oracle.process.count\n}\n| group_by [resource.instance_id]\n| outer_join 0\n| window 1m\n| condition val(0) * .9 < val(1)\n"
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/oracledb/high-session-utilization.v1.json
+++ b/alerts/oracledb/high-session-utilization.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "Sessions near system max",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "{\n     t_0: fetch gce_instance::workload.googleapis.com/oracle.session.limit ;\n     t_1: fetch gce_instance::workload.googleapis.com/oracle.session.count\n}\n| group_by [resource.instance_id]\n| outer_join 0\n| window 1m\n| condition val(0) * .9 < val(1)\n"
+      "conditionPrometheusQueryLanguage": {
+        "duration": "60s",
+        "evaluationInterval": "30s",
+        "query": "sum by (instance_id) (\n  {\"workload.googleapis.com/oracle.session.count\", monitored_resource=\"gce_instance\"}\n  /\n  {\"workload.googleapis.com/oracle.session.limit\", monitored_resource=\"gce_instance\"}\n) > 0.9"
       }
     }
   ],

--- a/alerts/oracledb/high-session-utilization.v1.json
+++ b/alerts/oracledb/high-session-utilization.v1.json
@@ -1,26 +1,31 @@
 {
-    "displayName": "Oracle Database - High Session Utilization",
-    "documentation": {
-        "content": "Alerts whenever the database is nearing the session limit, which could result in connections being refused.",
-        "mimeType": "text/markdown"
-    },
-    "userLabels": {},
-    "conditions": [
-        {
-            "displayName": "Sessions near system max",
-            "conditionMonitoringQueryLanguage": {
-                "duration": "0s",
-                "trigger": {
-                    "count": 1
-                },
-                "query": "{\n     t_0: fetch gce_instance::workload.googleapis.com/oracle.session.limit ;\n     t_1: fetch gce_instance::workload.googleapis.com/oracle.session.count\n}\n| group_by [resource.instance_id]\n| outer_join 0\n| window 1m\n| condition val(0) * .9 < val(1)\n"
-            }
-        }
-    ],
-    "alertStrategy": {
-        "autoClose": "604800s"
-    },
-    "combiner": "OR",
-    "enabled": true,
-    "notificationChannels": []
+  "displayName": "Oracle Database - High Session Utilization",
+  "documentation": {
+    "content": "Alerts whenever the database is nearing the session limit, which could result in connections being refused.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Sessions near system max",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "0s",
+        "trigger": {
+          "count": 1
+        },
+        "query": "{\n     t_0: fetch gce_instance::workload.googleapis.com/oracle.session.limit ;\n     t_1: fetch gce_instance::workload.googleapis.com/oracle.session.count\n}\n| group_by [resource.instance_id]\n| outer_join 0\n| window 1m\n| condition val(0) * .9 < val(1)\n"
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/oracledb/high-tablespace-utilization.v1.json
+++ b/alerts/oracledb/high-tablespace-utilization.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "Tablespace used space near total",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "{\n     t_0: fetch gce_instance::workload.googleapis.com/oracle.tablespace.size\n| filter (metric.state == 'used') ;\n     t_1: fetch gce_instance::workload.googleapis.com/oracle.tablespace.size\n| filter (metric.state == 'free')\n}\n| group_by [resource.instance_id, metric.tablespace_name]\n| outer_join 0\n| window 1m\n| condition (val(0) + val(1)) * .85 < val(0)\n"
+      "conditionPrometheusQueryLanguage": {
+        "duration": "60s",
+        "evaluationInterval": "30s",
+        "query": "(\n  sum by (instance_id, tablespace_name) (\n    {\"workload.googleapis.com/oracle.tablespace.size\", monitored_resource=\"gce_instance\", state=\"used\"})\n  /\n  (\n    sum by (instance_id, tablespace_name) (\n      {\"workload.googleapis.com/oracle.tablespace.size\", monitored_resource=\"gce_instance\", state=\"used\"})\n    + \n    sum by (instance_id, tablespace_name) (\n      {\"workload.googleapis.com/oracle.tablespace.size\", monitored_resource=\"gce_instance\", state=\"free\"})\n  )\n) > 0.85"
       }
     }
   ],

--- a/alerts/oracledb/high-tablespace-utilization.v1.json
+++ b/alerts/oracledb/high-tablespace-utilization.v1.json
@@ -1,26 +1,31 @@
 {
-    "displayName": "Oracle Database - High Tablespace Utilization",
-    "documentation": {
-        "content": "Alert fires when a tablespace should be resized as it approaches high utilization, before an interruption in service occurs.",
-        "mimeType": "text/markdown"
-    },
-    "userLabels": {},
-    "conditions": [
-        {
-            "displayName": "Tablespace used space near total",
-            "conditionMonitoringQueryLanguage": {
-                "duration": "0s",
-                "trigger": {
-                    "count": 1
-                },
-                "query": "{\n     t_0: fetch gce_instance::workload.googleapis.com/oracle.tablespace.size\n| filter (metric.state == 'used') ;\n     t_1: fetch gce_instance::workload.googleapis.com/oracle.tablespace.size\n| filter (metric.state == 'free')\n}\n| group_by [resource.instance_id, metric.tablespace_name]\n| outer_join 0\n| window 1m\n| condition (val(0) + val(1)) * .85 < val(0)\n"
-            }
-        }
-    ],
-    "alertStrategy": {
-        "autoClose": "604800s"
-    },
-    "combiner": "OR",
-    "enabled": true,
-    "notificationChannels": []
+  "displayName": "Oracle Database - High Tablespace Utilization",
+  "documentation": {
+    "content": "Alert fires when a tablespace should be resized as it approaches high utilization, before an interruption in service occurs.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Tablespace used space near total",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "0s",
+        "trigger": {
+          "count": 1
+        },
+        "query": "{\n     t_0: fetch gce_instance::workload.googleapis.com/oracle.tablespace.size\n| filter (metric.state == 'used') ;\n     t_1: fetch gce_instance::workload.googleapis.com/oracle.tablespace.size\n| filter (metric.state == 'free')\n}\n| group_by [resource.instance_id, metric.tablespace_name]\n| outer_join 0\n| window 1m\n| condition (val(0) + val(1)) * .85 < val(0)\n"
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }


### PR DESCRIPTION
This PR updates some OracleDB alerts to use PromQL instead of the deprecated MQL.

Note that while the condition for the alerts appears differently in MQL and PromQL, they are functionally identical.

MQL:
<img width="3712" height="1612" alt="image" src="https://github.com/user-attachments/assets/b02fec0d-0bfd-4901-91fe-3d7248ca085a" />

PromQL:
<img width="3714" height="1612" alt="image" src="https://github.com/user-attachments/assets/b66bee9f-bb2b-4546-aedf-5cd001844316" />
