### PR TITLE
PromQL Alerts: MongoDB

### DIFF
--- a/alerts/mongodb/high-cpu-utilization.v1.json
+++ b/alerts/mongodb/high-cpu-utilization.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "MongoDB - High CPU Utilization",
-      "conditionMonitoringQueryLanguage": {
+      "conditionPrometheusQueryLanguage": {
         "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "def top_5_cpu_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/cpu/utilization'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n@top_5_cpu_filtered_by_metric\n  'workload.googleapis.com/mongodb.memory.usage'\n| condition val() > 90'%'"
+        "evaluationInterval": "60s",
+        "query": "(avg by (project_id, zone, instance_id) (\n  avg_over_time(\n    {\"agent.googleapis.com/cpu/utilization\", monitored_resource=\"gce_instance\"}[1m]\n  )\n  and\n  on(instance_id, project_id, zone)\n    ({\"workload.googleapis.com/mongodb.memory.usage\", monitored_resource=\"gce_instance\"})  \n  )\n) > 90"
       }
     }
   ],

--- a/alerts/mongodb/high-cpu-utilization.v1.json
+++ b/alerts/mongodb/high-cpu-utilization.v1.json
@@ -1,26 +1,31 @@
 {
-    "displayName": "MongoDB - High CPU Utilization",
-    "documentation": {
-        "content": "If CPU utilization is above 90%, then the MongoDB instance is probably due to be scaled up or needs further investigation.",
-        "mimeType": "text/markdown"
-    },
-    "userLabels": {},
-    "conditions": [
-        {
-            "displayName": "MongoDB - High CPU Utilization",
-            "conditionMonitoringQueryLanguage": {
-                "duration": "0s",
-                "trigger": {
-                    "count": 1
-                },
-                "query": "def top_5_cpu_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/cpu/utilization'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n@top_5_cpu_filtered_by_metric\n  'workload.googleapis.com/mongodb.memory.usage'\n| condition val() > 90'%'"
-            }
-        }
-    ],
-    "alertStrategy": {
-        "autoClose": "3600s"
-    },
-    "combiner": "OR",
-    "enabled": true,
-    "notificationChannels": []
+  "displayName": "MongoDB - High CPU Utilization",
+  "documentation": {
+    "content": "If CPU utilization is above 90%, then the MongoDB instance is probably due to be scaled up or needs further investigation.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "MongoDB - High CPU Utilization",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "0s",
+        "trigger": {
+          "count": 1
+        },
+        "query": "def top_5_cpu_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/cpu/utilization'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | top 5\n  | every 1m;\n\n@top_5_cpu_filtered_by_metric\n  'workload.googleapis.com/mongodb.memory.usage'\n| condition val() > 90'%'"
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "3600s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/mongodb/high-disk-utilization.v1.json
+++ b/alerts/mongodb/high-disk-utilization.v1.json
@@ -8,13 +8,10 @@
   "conditions": [
     {
       "displayName": "New condition",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "60s",
-        "trigger": {
-          "count": 1
-        },
-        "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
-        "query": "def top_5_disk_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/disk/percent_used'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | every 1m;\n\n@top_5_disk_filtered_by_metric\n  'workload.googleapis.com/mongodb.memory.usage'\n| condition val() > 80'%'"
+      "conditionPrometheusQueryLanguage": {
+        "duration": "0s",
+        "evaluationInterval": "60s",
+        "query": "(avg by (project_id, zone, instance_id) (\n  avg_over_time(\n    {\"agent.googleapis.com/disk/percent_used\", monitored_resource=\"gce_instance\"}[1m]\n  )\n  and\n  on(instance_id, project_id, zone)\n    ({\"workload.googleapis.com/mongodb.memory.usage\", monitored_resource=\"gce_instance\"})\n  )\n) > 80"
       }
     }
   ],

--- a/alerts/mongodb/high-disk-utilization.v1.json
+++ b/alerts/mongodb/high-disk-utilization.v1.json
@@ -1,27 +1,32 @@
 {
-    "displayName": "MongoDB - High Disk Utilization",
-    "documentation": {
-      "content": "If Disk Utilization is above 80%, then it is time to look deeper into adding more storage or cleaning up old docs.",
-      "mimeType": "text/markdown"
-    },
-    "userLabels": {},
-    "conditions": [
-      {
-        "displayName": "New condition",
-        "conditionMonitoringQueryLanguage": {
-          "duration": "60s",
-          "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
-          "trigger": {
-            "count": 1
-          },
-          "query": "def top_5_disk_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/disk/percent_used'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | every 1m;\n\n@top_5_disk_filtered_by_metric\n  'workload.googleapis.com/mongodb.memory.usage'\n| condition val() > 80'%'"
-        }
+  "displayName": "MongoDB - High Disk Utilization",
+  "documentation": {
+    "content": "If Disk Utilization is above 80%, then it is time to look deeper into adding more storage or cleaning up old docs.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "New condition",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "60s",
+        "trigger": {
+          "count": 1
+        },
+        "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
+        "query": "def top_5_disk_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_memory:\n        metric 'agent.googleapis.com/disk/percent_used'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value val(0)\n  | group_by [metadata.system.name, resource.project_id, resource.zone], 1m,\n      .mean()\n  | every 1m;\n\n@top_5_disk_filtered_by_metric\n  'workload.googleapis.com/mongodb.memory.usage'\n| condition val() > 80'%'"
       }
-    ],
-    "alertStrategy": {
-      "autoClose": "3600s"
-    },
-    "combiner": "OR",
-    "enabled": true,
-    "notificationChannels": []
-  }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "3600s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
+}


### PR DESCRIPTION
This PR updates some MongoDB alerts to use PromQL instead of the deprecated MQL.

Note that `instance_id` is used instead of `metadata_system_name` because neither metric has a "name" attribute.

MQL:
<img width="1857" height="808" alt="image" src="https://github.com/user-attachments/assets/ec7a9ea3-454b-4d6c-b675-04ad58d26832" />

PromQL:
<img width="1856" height="806" alt="image" src="https://github.com/user-attachments/assets/83889888-44af-42ee-8f3d-598dd13e5818" />
