### PR TITLE
PromQL Alerts: Istio Proxy GKE

### DIFF
--- a/alerts/istio-proxy-gke/high-request-duration.v1.json
+++ b/alerts/istio-proxy-gke/high-request-duration.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "Prometheus Target - prometheus/istio_request_duration_milliseconds/histogram - 95th percentile",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch prometheus_target\n| metric\n    'prometheus.googleapis.com/istio_request_duration_milliseconds/histogram'\n| percentile_from(95)\n| cast_units('ms')\n| every 5m\n| window 5m\n| condition val() > 500 'ms'"
+      "conditionPrometheusQueryLanguage": {
+        "duration": "300s",
+        "evaluationInterval": "300s",
+        "query": "histogram_quantile(\n  0.95, \n  sum by (le) (\n    rate({\"istio_request_duration_milliseconds_bucket\"}[5m])\n  )\n) > 500"
       }
     }
   ],


### PR DESCRIPTION
This PR updates an Istio Proxy GKE alert to use PromQL instead of the deprecated MQL.

Note that the metric has certain attributes that should probably be included in the `sum by`, such as `job`, `instance`, and `namespace`. I left out these aggregations to mimic the MQL behavior.

MQL: 
<img width="1858" height="807" alt="image" src="https://github.com/user-attachments/assets/d826422c-974a-43b5-be9a-5002715dd43d" />

PromQL:
<img width="1858" height="805" alt="image" src="https://github.com/user-attachments/assets/b569e466-de80-4d06-ba40-73548d56e910" />

