### PR TITLE
PromQL Alerts: Google Network Intelligence Center

### DIFF
--- a/alerts/google-network-intelligence-center/interconnect-egress.v1.json
+++ b/alerts/google-network-intelligence-center/interconnect-egress.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "VLAN attachment egress usage",
-      "conditionMonitoringQueryLanguage": {
+      "conditionPrometheusQueryLanguage": {
         "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch interconnect_attachment\n| {\n   metric 'interconnect.googleapis.com/network/attachment/sent_bytes_count'\n   | align rate(30s)\n ; metric 'interconnect.googleapis.com/network/attachment/capacity'\n   | group_by 30s, [value_capacity_mean: mean(value.capacity)]\n }\n| ratio\n| condition gt(val(), 0.70 '1')"
+        "evaluationInterval": "30s",
+        "query": "(\n  rate(\n    {\"interconnect.googleapis.com/network/attachment/sent_bytes_count\", monitored_resource=\"interconnect_attachment\"}[30s]\n  )\n  /\n  avg_over_time(\n    {\"interconnect.googleapis.com/network/attachment/capacity\", monitored_resource=\"interconnect_attachment\"}[30s]\n  ) \n) > 0.7"
       }
     }
   ],

--- a/alerts/google-network-intelligence-center/interconnect-egress.v1.json
+++ b/alerts/google-network-intelligence-center/interconnect-egress.v1.json
@@ -4,20 +4,28 @@
     "content": "Alerts when the Egress bytes per second exceeds 70% of an interconnect VLAN attachment's capacity. This can help you decide whether to provision additional capacity or create additional attachments.",
     "mimeType": "text/markdown"
   },
+  "userLabels": {},
   "conditions": [
     {
       "displayName": "VLAN attachment egress usage",
       "conditionMonitoringQueryLanguage": {
-        "query": "fetch interconnect_attachment\n| {\n   metric 'interconnect.googleapis.com/network/attachment/sent_bytes_count'\n   | align rate(30s)\n ; metric 'interconnect.googleapis.com/network/attachment/capacity'\n   | group_by 30s, [value_capacity_mean: mean(value.capacity)]\n }\n| ratio\n| condition gt(val(), 0.70 '1')",
+        "duration": "0s",
         "trigger": {
           "count": 1
-        }
+        },
+        "query": "fetch interconnect_attachment\n| {\n   metric 'interconnect.googleapis.com/network/attachment/sent_bytes_count'\n   | align rate(30s)\n ; metric 'interconnect.googleapis.com/network/attachment/capacity'\n   | group_by 30s, [value_capacity_mean: mean(value.capacity)]\n }\n| ratio\n| condition gt(val(), 0.70 '1')"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
-  "enabled": true
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/google-network-intelligence-center/interconnect-ingress.v1.json
+++ b/alerts/google-network-intelligence-center/interconnect-ingress.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "VLAN attachment ingress usage",
-      "conditionMonitoringQueryLanguage": {
+      "conditionPrometheusQueryLanguage": {
         "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch interconnect_attachment\n| {\n   metric 'interconnect.googleapis.com/network/attachment/received_bytes_count'\n   | align rate(30s)\n ; metric 'interconnect.googleapis.com/network/attachment/capacity'\n   | group_by 30s, [value_capacity_mean: mean(value.capacity)]\n }\n| ratio\n| condition gt(val(), 0.70 '1')"
+        "evaluationInterval": "30s",
+        "query": "(\n  rate(\n    {\"interconnect.googleapis.com/network/attachment/received_bytes_count\", monitored_resource=\"interconnect_attachment\"}[30s]\n  )\n  /\n  avg_over_time(\n    {\"interconnect.googleapis.com/network/attachment/capacity\", monitored_resource=\"interconnect_attachment\"}[30s]\n  ) \n) > 0.7"
       }
     }
   ],

--- a/alerts/google-network-intelligence-center/interconnect-ingress.v1.json
+++ b/alerts/google-network-intelligence-center/interconnect-ingress.v1.json
@@ -4,20 +4,28 @@
     "content": "Alerts when the Ingress bytes per second exceeds 70% of an interconnect VLAN attachment's capacity. This can help you decide whether to provision additional capacity or create additional attachments.",
     "mimeType": "text/markdown"
   },
+  "userLabels": {},
   "conditions": [
     {
       "displayName": "VLAN attachment ingress usage",
       "conditionMonitoringQueryLanguage": {
-        "query": "fetch interconnect_attachment\n| {\n   metric 'interconnect.googleapis.com/network/attachment/received_bytes_count'\n   | align rate(30s)\n ; metric 'interconnect.googleapis.com/network/attachment/capacity'\n   | group_by 30s, [value_capacity_mean: mean(value.capacity)]\n }\n| ratio\n| condition gt(val(), 0.70 '1')",
+        "duration": "0s",
         "trigger": {
           "count": 1
-        }
+        },
+        "query": "fetch interconnect_attachment\n| {\n   metric 'interconnect.googleapis.com/network/attachment/received_bytes_count'\n   | align rate(30s)\n ; metric 'interconnect.googleapis.com/network/attachment/capacity'\n   | group_by 30s, [value_capacity_mean: mean(value.capacity)]\n }\n| ratio\n| condition gt(val(), 0.70 '1')"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
-  "enabled": true
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/google-network-intelligence-center/packet-loss-high.v1.json
+++ b/alerts/google-network-intelligence-center/packet-loss-high.v1.json
@@ -9,17 +9,23 @@
     {
       "displayName": "Packet Loss higher than 5%",
       "conditionMonitoringQueryLanguage": {
-        "query": "fetch gce_zone_network_health :: networking.googleapis.com/cloud_netslo/active_probing/probe_count\n | {\n   filter metric.result = 'failure'\n   | group_by [resource.region, metric.remote_region], 60s, .sum\n ;\n   group_by [\n     resource.region,\n     metric.remote_region\n   ], 60s, .sum\n   | filter val() >= 1 '1'\n }\n | ratio | condition val() > 0.05",
         "duration": "300s",
         "trigger": {
           "count": 1
-        }
+        },
+        "query": "fetch gce_zone_network_health :: networking.googleapis.com/cloud_netslo/active_probing/probe_count\n | {\n   filter metric.result = 'failure'\n   | group_by [resource.region, metric.remote_region], 60s, .sum\n ;\n   group_by [\n     resource.region,\n     metric.remote_region\n   ], 60s, .sum\n   | filter val() >= 1 '1'\n }\n | ratio | condition val() > 0.05"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
-  "enabled": true
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/google-network-intelligence-center/packet-loss-high.v1.json
+++ b/alerts/google-network-intelligence-center/packet-loss-high.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "Packet Loss higher than 5%",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "300s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch gce_zone_network_health :: networking.googleapis.com/cloud_netslo/active_probing/probe_count\n | {\n   filter metric.result = 'failure'\n   | group_by [resource.region, metric.remote_region], 60s, .sum\n ;\n   group_by [\n     resource.region,\n     metric.remote_region\n   ], 60s, .sum\n   | filter val() >= 1 '1'\n }\n | ratio | condition val() > 0.05"
+      "conditionPrometheusQueryLanguage": {
+        "duration": "0s",
+        "evaluationInterval": "30s",
+        "query": "(\n  (sum by (region, remote_region) (\n    {\"networking.googleapis.com/cloud_netslo/active_probing/probe_count\", monitored_resource=\"gce_zone_network_health\", result=\"failure\"}\n  ))\n  /\n  clamp_min(\n    sum by (region, remote_region)(\n      {\"networking.googleapis.com/cloud_netslo/active_probing/probe_count\", monitored_resource=\"gce_zone_network_health\"}\n    ), 1\n  ) \n) > 0.05"
       }
     }
   ],

--- a/alerts/google-network-intelligence-center/packet-loss-high.v1.json
+++ b/alerts/google-network-intelligence-center/packet-loss-high.v1.json
@@ -10,7 +10,7 @@
       "displayName": "Packet Loss higher than 5%",
       "conditionPrometheusQueryLanguage": {
         "duration": "0s",
-        "evaluationInterval": "30s",
+        "evaluationInterval": "60s",
         "query": "(\n  (sum by (region, remote_region) (\n    {\"networking.googleapis.com/cloud_netslo/active_probing/probe_count\", monitored_resource=\"gce_zone_network_health\", result=\"failure\"}\n  ))\n  /\n  clamp_min(\n    sum by (region, remote_region)(\n      {\"networking.googleapis.com/cloud_netslo/active_probing/probe_count\", monitored_resource=\"gce_zone_network_health\"}\n    ), 1\n  ) \n) > 0.05"
       }
     }

--- a/alerts/google-network-intelligence-center/packet-loss-high.v2.json
+++ b/alerts/google-network-intelligence-center/packet-loss-high.v2.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "Packet Loss higher than 5%",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "300s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch gce_zone_network_health :: networking.googleapis.com/cloud_netslo/active_probing/probe_count\n | {\n   filter metric.result = 'failure'\n   | group_by [resource.region, metric.remote_region], 30s, .sum\n ;\n   group_by [\n     resource.region,\n     metric.remote_region\n   ], 30s, .sum\n   | filter val() >= 1 '1'\n }\n | ratio | condition val() > 0.05"
+      "conditionPrometheusQueryLanguage": {
+        "duration": "0s",
+        "evaluationInterval": "30s",
+        "query": "(\n  (sum by (region, remote_region) (\n    {\"networking.googleapis.com/cloud_netslo/active_probing/probe_count\", monitored_resource=\"gce_zone_network_health\", result=\"failure\"}\n  ))\n  /\n  clamp_min(\n    sum by (region, remote_region)(\n      {\"networking.googleapis.com/cloud_netslo/active_probing/probe_count\", monitored_resource=\"gce_zone_network_health\"}\n    ), 1\n  ) \n) > 0.05"
       }
     }
   ],

--- a/alerts/google-network-intelligence-center/packet-loss-high.v2.json
+++ b/alerts/google-network-intelligence-center/packet-loss-high.v2.json
@@ -9,17 +9,23 @@
     {
       "displayName": "Packet Loss higher than 5%",
       "conditionMonitoringQueryLanguage": {
-        "query": "fetch gce_zone_network_health :: networking.googleapis.com/cloud_netslo/active_probing/probe_count\n | {\n   filter metric.result = 'failure'\n   | group_by [resource.region, metric.remote_region], 30s, .sum\n ;\n   group_by [\n     resource.region,\n     metric.remote_region\n   ], 30s, .sum\n   | filter val() >= 1 '1'\n }\n | ratio | condition val() > 0.05",
         "duration": "300s",
         "trigger": {
           "count": 1
-        }
+        },
+        "query": "fetch gce_zone_network_health :: networking.googleapis.com/cloud_netslo/active_probing/probe_count\n | {\n   filter metric.result = 'failure'\n   | group_by [resource.region, metric.remote_region], 30s, .sum\n ;\n   group_by [\n     resource.region,\n     metric.remote_region\n   ], 30s, .sum\n   | filter val() >= 1 '1'\n }\n | ratio | condition val() > 0.05"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
-  "enabled": true
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/google-network-intelligence-center/vpn-tunnel-bps.v1.json
+++ b/alerts/google-network-intelligence-center/vpn-tunnel-bps.v1.json
@@ -1,26 +1,31 @@
 {
-  "name": "projects/cn-fe-playground/alertPolicies/5801954640443836615",
   "displayName": "High VPN tunnel bps",
   "documentation": {
     "content": "Alerts when the sum of ingress and egress bytes exceeds 50% of the 3-Gbps (375 MBps) limit for a given VPN tunnel.",
     "mimeType": "text/markdown"
   },
+  "userLabels": {},
   "conditions": [
     {
-      "name": "projects/cn-fe-playground/alertPolicies/5801954640443836615/conditions/5801954640443837206",
       "displayName": "Tunnel traffic",
       "conditionMonitoringQueryLanguage": {
         "duration": "0s",
-        "query": "fetch vpn_gateway\n| { metric vpn.googleapis.com/network/sent_bytes_count\n; metric vpn.googleapis.com/network/received_bytes_count }\n| align rate (1m)\n| group_by [metric.tunnel_name]\n| outer_join 0,0\n| value val(0) + val(1)\n| condition val() > 187.5 \"MBy/s\"",
         "trigger": {
           "count": 1
-        }
+        },
+        "query": "fetch vpn_gateway\n| { metric vpn.googleapis.com/network/sent_bytes_count\n; metric vpn.googleapis.com/network/received_bytes_count }\n| align rate (1m)\n| group_by [metric.tunnel_name]\n| outer_join 0,0\n| value val(0) + val(1)\n| condition val() > 187.5 \"MBy/s\""
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
-  "enabled": true
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/google-network-intelligence-center/vpn-tunnel-bps.v1.json
+++ b/alerts/google-network-intelligence-center/vpn-tunnel-bps.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "Tunnel traffic",
-      "conditionMonitoringQueryLanguage": {
+      "conditionPrometheusQueryLanguage": {
         "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch vpn_gateway\n| { metric vpn.googleapis.com/network/sent_bytes_count\n; metric vpn.googleapis.com/network/received_bytes_count }\n| align rate (1m)\n| group_by [metric.tunnel_name]\n| outer_join 0,0\n| value val(0) + val(1)\n| condition val() > 187.5 \"MBy/s\""
+        "evaluationInterval": "30s",
+        "query": "sum by (tunnel_name) (\n  rate({\"vpn.googleapis.com/network/sent_bytes_count\", monitored_resource=\"vpn_gateway\"}[1m])\n  + \n  rate({\"vpn.googleapis.com/network/received_bytes_count\", monitored_resource=\"vpn_gateway\"}[1m])\n) > 1875000"
       }
     }
   ],

--- a/alerts/google-network-intelligence-center/vpn-tunnel-bps.v2.json
+++ b/alerts/google-network-intelligence-center/vpn-tunnel-bps.v2.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "Tunnel traffic",
-      "conditionMonitoringQueryLanguage": {
+      "conditionPrometheusQueryLanguage": {
         "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch vpn_gateway\n| { metric vpn.googleapis.com/network/sent_bytes_count\n; metric vpn.googleapis.com/network/received_bytes_count }\n| align rate (30s)\n| group_by [metric.tunnel_name]\n| outer_join 0,0\n| value val(0) + val(1)\n| condition val() > 187.5 \"MBy/s\""
+        "evaluationInterval": "30s",
+        "query": "sum by (tunnel_name) (\n  rate({\"vpn.googleapis.com/network/sent_bytes_count\", monitored_resource=\"vpn_gateway\"}[30s])\n  +\n  rate({\"vpn.googleapis.com/network/received_bytes_count\", monitored_resource=\"vpn_gateway\"}[30s])\n) > 1875000"
       }
     }
   ],

--- a/alerts/google-network-intelligence-center/vpn-tunnel-bps.v2.json
+++ b/alerts/google-network-intelligence-center/vpn-tunnel-bps.v2.json
@@ -4,20 +4,28 @@
     "content": "Alerts when the sum of ingress and egress bytes exceeds 50% of the 3-Gbps (375 MBps) limit for a given VPN tunnel. This can help you decide whether to provision additional VPN tunnels.",
     "mimeType": "text/markdown"
   },
+  "userLabels": {},
   "conditions": [
     {
       "displayName": "Tunnel traffic",
       "conditionMonitoringQueryLanguage": {
-        "query": "fetch vpn_gateway\n| { metric vpn.googleapis.com/network/sent_bytes_count\n; metric vpn.googleapis.com/network/received_bytes_count }\n| align rate (30s)\n| group_by [metric.tunnel_name]\n| outer_join 0,0\n| value val(0) + val(1)\n| condition val() > 187.5 \"MBy/s\"",
+        "duration": "0s",
         "trigger": {
           "count": 1
-        }
+        },
+        "query": "fetch vpn_gateway\n| { metric vpn.googleapis.com/network/sent_bytes_count\n; metric vpn.googleapis.com/network/received_bytes_count }\n| align rate (30s)\n| group_by [metric.tunnel_name]\n| outer_join 0,0\n| value val(0) + val(1)\n| condition val() > 187.5 \"MBy/s\""
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
-  "enabled": true
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/google-network-intelligence-center/vpn-tunnel-pps.v1.json
+++ b/alerts/google-network-intelligence-center/vpn-tunnel-pps.v1.json
@@ -1,26 +1,31 @@
 {
-  "name": "projects/cn-fe-playground/alertPolicies/13319234805719485687",
   "displayName": "High VPN tunnel pps",
   "documentation": {
     "content": "Alerts when the sum of ingress and egress network packets exceeds 50% of the maximum recommended packet rate of 250,000 pps for a given VPN tunnel.",
     "mimeType": "text/markdown"
   },
+  "userLabels": {},
   "conditions": [
     {
-      "name": "projects/cn-fe-playground/alertPolicies/13319234805719485687/conditions/7232902205055063304",
       "displayName": "Tunnel traffic",
       "conditionMonitoringQueryLanguage": {
         "duration": "0s",
-        "query": "fetch vpn_gateway\n| { metric vpn.googleapis.com/network/sent_packets_count\n; metric vpn.googleapis.com/network/received_packets_count }\n| align rate (1m)\n| group_by [metric.tunnel_name]\n| outer_join 0,0\n| value val(0) + val(1)\n| condition val() > 125000 \"{packets}/s\"",
         "trigger": {
           "count": 1
-        }
+        },
+        "query": "fetch vpn_gateway\n| { metric vpn.googleapis.com/network/sent_packets_count\n; metric vpn.googleapis.com/network/received_packets_count }\n| align rate (1m)\n| group_by [metric.tunnel_name]\n| outer_join 0,0\n| value val(0) + val(1)\n| condition val() > 125000 \"{packets}/s\""
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
-  "enabled": true
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/google-network-intelligence-center/vpn-tunnel-pps.v1.json
+++ b/alerts/google-network-intelligence-center/vpn-tunnel-pps.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "Tunnel traffic",
-      "conditionMonitoringQueryLanguage": {
+      "conditionPrometheusQueryLanguage": {
         "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch vpn_gateway\n| { metric vpn.googleapis.com/network/sent_packets_count\n; metric vpn.googleapis.com/network/received_packets_count }\n| align rate (1m)\n| group_by [metric.tunnel_name]\n| outer_join 0,0\n| value val(0) + val(1)\n| condition val() > 125000 \"{packets}/s\""
+        "evaluationInterval": "30s",
+        "query": "sum by (tunnel_name) (\n  rate({\"vpn.googleapis.com/network/sent_packets_count\", monitored_resource=\"vpn_gateway\"}[1m])\n  + \n  rate({\"vpn.googleapis.com/network/received_packets_count\", monitored_resource=\"vpn_gateway\"}[1m])\n) > 12500"
       }
     }
   ],

--- a/alerts/google-network-intelligence-center/vpn-tunnel-pps.v2.json
+++ b/alerts/google-network-intelligence-center/vpn-tunnel-pps.v2.json
@@ -4,20 +4,28 @@
     "content": "Alerts when the sum of ingress and egress network packets exceeds 50% of the maximum recommended packet rate of 250,000 pps for a given VPN tunnel. This can help you decide whether to provision additional VPN tunnels.",
     "mimeType": "text/markdown"
   },
+  "userLabels": {},
   "conditions": [
     {
       "displayName": "Tunnel traffic",
       "conditionMonitoringQueryLanguage": {
-        "query": "fetch vpn_gateway\n| { metric vpn.googleapis.com/network/sent_packets_count\n; metric vpn.googleapis.com/network/received_packets_count }\n| align rate (30s)\n| group_by [metric.tunnel_name]\n| outer_join 0,0\n| value val(0) + val(1)\n| condition val() > 125000 \"{packets}/s\"",
+        "duration": "0s",
         "trigger": {
           "count": 1
-        }
+        },
+        "query": "fetch vpn_gateway\n| { metric vpn.googleapis.com/network/sent_packets_count\n; metric vpn.googleapis.com/network/received_packets_count }\n| align rate (30s)\n| group_by [metric.tunnel_name]\n| outer_join 0,0\n| value val(0) + val(1)\n| condition val() > 125000 \"{packets}/s\""
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
-  "enabled": true
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/google-network-intelligence-center/vpn-tunnel-pps.v2.json
+++ b/alerts/google-network-intelligence-center/vpn-tunnel-pps.v2.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "Tunnel traffic",
-      "conditionMonitoringQueryLanguage": {
+      "conditionPrometheusQueryLanguage": {
         "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch vpn_gateway\n| { metric vpn.googleapis.com/network/sent_packets_count\n; metric vpn.googleapis.com/network/received_packets_count }\n| align rate (30s)\n| group_by [metric.tunnel_name]\n| outer_join 0,0\n| value val(0) + val(1)\n| condition val() > 125000 \"{packets}/s\""
+        "evaluationInterval": "30s",
+        "query": "sum by (tunnel_name) (\n  rate({\"vpn.googleapis.com/network/sent_packets_count\", monitored_resource=\"vpn_gateway\"}[30s])\n  +\n  rate({\"vpn.googleapis.com/network/received_packets_count\", monitored_resource=\"vpn_gateway\"}[30s])\n) > 12500"
       }
     }
   ],


### PR DESCRIPTION
This PR updates some Google Network Intelligence Center alerts to use PromQL instead of the deprecated MQL.

Note that in PromQL, packet-loss-high.v1 and packet-loss-high.v2 become identical. This is because the timing change that was made between the two versions is reflected in the alert configuration rather than in the query.

<img width="640" height="620" alt="image" src="https://github.com/user-attachments/assets/a6477a38-05a6-40e7-9317-db7e4a3d3cf7" />


