### PR TITLE
PromQL Alerts: HAProxy GKE

### DIFF
--- a/alerts/haproxy-gke/frontend-sessions-near-limit.v1.json
+++ b/alerts/haproxy-gke/frontend-sessions-near-limit.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "Prometheus Target - prometheus/haproxy_backend_limit_sessions/gauge",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch prometheus_target\n| { t_0:\n      metric prometheus.googleapis.com/haproxy_frontend_current_sessions/gauge\n  ; t_1:\n      metric prometheus.googleapis.com/haproxy_frontend_limit_sessions/gauge }\n| outer_join 0\n| value\n    t_0.value.haproxy_frontend_current_sessions\n    / t_1.value.haproxy_frontend_limit_sessions\n| condition val() > 0.9\n| every 5m\n| window 5m"
+      "conditionPrometheusQueryLanguage": {
+        "duration": "300s",
+        "evaluationInterval": "300s",
+        "query": "(\n  {\"haproxy_frontend_current_sessions\"}\n  /\n  {\"haproxy_frontend_limit_sessions\"}\n) > 0.9"
       }
     }
   ],


### PR DESCRIPTION
This PR updates a HAProxy GKE alert to use PromQL instead of the deprecated MQL.