### PR TITLE
PromQL Alerts: NGINX GKE

### DIFF
--- a/alerts/nginx-gke/connections-dropped.v1.json
+++ b/alerts/nginx-gke/connections-dropped.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "New condition",
-      "conditionMonitoringQueryLanguage": {
+      "conditionPrometheusQueryLanguage": {
         "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "{ t_0:\n    fetch\n      prometheus_target ::\n      prometheus.googleapis.com/nginx_connections_accepted/counter\n; t_1:\n    fetch\n      prometheus_target ::\n      prometheus.googleapis.com/nginx_connections_handled/counter }\n| outer_join 0\n| value val(0) - val(1)\n| align rate(5m)\n| condition val() > 0"
+        "evaluationInterval": "30s",
+        "query": "(\n  rate({\"nginx_connections_accepted\"}[5m])\n  -\n  rate({\"nginx_connections_handled\"}[5m])\n) > 0"
       }
     }
   ],


### PR DESCRIPTION
This PR updates an NGINX GKE alert to use PromQL instead of the deprecated MQL.