### PR TITLE
PromQL Alerts: Node Exporter GKE 

### DIFF
--- a/alerts/node-exporter-gke/low-available-memory.v1.json
+++ b/alerts/node-exporter-gke/low-available-memory.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "Memory Available < 10%",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch prometheus_target\n| {\n    t_0: metric prometheus.googleapis.com/node_memory_MemAvailable_bytes/gauge;\n    t_1: metric prometheus.googleapis.com/node_memory_MemTotal_bytes/gauge\n}\n| ratio\n| every 5m\n| window 5m\n| condition val() < 0.1"
+      "conditionPrometheusQueryLanguage": {
+        "duration": "300s",
+        "evaluationInterval": "300s",
+        "query": "(\n  {\"node_memory_MemAvailable_bytes\"}\n  /\n  {\"node_memory_MemTotal_bytes\"}\n) < 0.1"
       }
     }
   ],

--- a/alerts/node-exporter-gke/low-available-memory.v1.json
+++ b/alerts/node-exporter-gke/low-available-memory.v1.json
@@ -1,26 +1,31 @@
 {
-    "displayName": "Node Exporter - Prometheus - Low Available Memory",
-    "documentation": {
-      "content": "This alert triggers when the amount of memory available is low. When memory is low, GKE may be unable to assign any more pods to the node.",
-      "mimeType": "text/markdown"
-    },
-    "userLabels": {},
-    "conditions": [
-      {
-        "displayName": "Memory Available < 10%",
-        "conditionMonitoringQueryLanguage": {
-          "duration": "0s",
-          "query": "fetch prometheus_target\n| {\n    t_0: metric prometheus.googleapis.com/node_memory_MemAvailable_bytes/gauge;\n    t_1: metric prometheus.googleapis.com/node_memory_MemTotal_bytes/gauge\n}\n| ratio\n| every 5m\n| window 5m\n| condition val() < 0.1",
-          "trigger": {
-            "count": 1
-          }
-        }
+  "displayName": "Node Exporter - Prometheus - Low Available Memory",
+  "documentation": {
+    "content": "This alert triggers when the amount of memory available is low. When memory is low, GKE may be unable to assign any more pods to the node.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Memory Available < 10%",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "0s",
+        "trigger": {
+          "count": 1
+        },
+        "query": "fetch prometheus_target\n| {\n    t_0: metric prometheus.googleapis.com/node_memory_MemAvailable_bytes/gauge;\n    t_1: metric prometheus.googleapis.com/node_memory_MemTotal_bytes/gauge\n}\n| ratio\n| every 5m\n| window 5m\n| condition val() < 0.1"
       }
-    ],
-    "alertStrategy": {
-      "autoClose": "604800s"
-    },
-    "combiner": "OR",
-    "enabled": false,
-    "notificationChannels": []
-  }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
+}

--- a/alerts/node-exporter-gke/low-filesystem-space.v1.json
+++ b/alerts/node-exporter-gke/low-filesystem-space.v1.json
@@ -1,26 +1,31 @@
 {
-    "displayName": "Node Exporter - Prometheus - Low Filesystem Space",
-    "documentation": {
-        "content": "This alert triggers when the amount of space for the affected filesystem is low. When filesystem space is low, GKE may be unable to assign any more pods to the node.",
-        "mimeType": "text/markdown"
-    },
-    "userLabels": {},
-    "conditions": [
-        {
-            "displayName": "Filesystem Space Available < 10%",
-            "conditionMonitoringQueryLanguage": {
-                "duration": "0s",
-                "query": "fetch prometheus_target\n| { t_0: metric prometheus.googleapis.com/node_filesystem_avail_bytes/gauge\n  ; t_1: metric prometheus.googleapis.com/node_filesystem_size_bytes/gauge }\n| ratio\n| every 5m\n| window 5m\n| condition val() < 0.1",
-                "trigger": {
-                    "count": 1
-                }
-            }
-        }
-    ],
-    "alertStrategy": {
-        "autoClose": "604800s"
-    },
-    "combiner": "OR",
-    "enabled": true,
-    "notificationChannels": []
+  "displayName": "Node Exporter - Prometheus - Low Filesystem Space",
+  "documentation": {
+    "content": "This alert triggers when the amount of space for the affected filesystem is low. When filesystem space is low, GKE may be unable to assign any more pods to the node.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Filesystem Space Available < 10%",
+      "conditionMonitoringQueryLanguage": {
+        "duration": "0s",
+        "trigger": {
+          "count": 1
+        },
+        "query": "fetch prometheus_target\n| { t_0: metric prometheus.googleapis.com/node_filesystem_avail_bytes/gauge\n  ; t_1: metric prometheus.googleapis.com/node_filesystem_size_bytes/gauge }\n| ratio\n| every 5m\n| window 5m\n| condition val() < 0.1"
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/node-exporter-gke/low-filesystem-space.v1.json
+++ b/alerts/node-exporter-gke/low-filesystem-space.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "Filesystem Space Available < 10%",
-      "conditionMonitoringQueryLanguage": {
+      "conditionPrometheusQueryLanguage": {
         "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch prometheus_target\n| { t_0: metric prometheus.googleapis.com/node_filesystem_avail_bytes/gauge\n  ; t_1: metric prometheus.googleapis.com/node_filesystem_size_bytes/gauge }\n| ratio\n| every 5m\n| window 5m\n| condition val() < 0.1"
+        "evaluationInterval": "30s",
+        "query": "(\n  {\"node_filesystem_avail_bytes\"}\n  /\n  {\"node_filesystem_size_bytes\"}\n) < 0.1"
       }
     }
   ],


### PR DESCRIPTION
This PR updates some Node Exporter GKE alerts to use PromQL instead of the deprecated MQL.