### PR TITLE
PromQL Alerts: ZooKeeper GKE

### DIFF
--- a/alerts/zookeeper-gke/low-free-file-descriptors.v1.json
+++ b/alerts/zookeeper-gke/low-free-file-descriptors.v1.json
@@ -8,12 +8,10 @@
   "conditions": [
     {
       "displayName": "New condition",
-      "conditionMonitoringQueryLanguage": {
+      "conditionPrometheusQueryLanguage": {
         "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch prometheus_target\n| { metric 'prometheus.googleapis.com/max_file_descriptor_count/gauge'\n  ; metric 'prometheus.googleapis.com/open_file_descriptor_count/gauge' }\n| outer_join 0\n| group_by 1m\n| sub\n| condition val() < 1000"
+        "evaluationInterval": "60s",
+        "query": "(\n  {\"max_file_descriptor_count\"}\n  -\n  {\"open_file_descriptor_count\"}\n) < 1000"
       }
     }
   ],

--- a/alerts/zookeeper-gke/low-free-file-descriptors.v1.json
+++ b/alerts/zookeeper-gke/low-free-file-descriptors.v1.json
@@ -10,17 +10,22 @@
       "displayName": "New condition",
       "conditionMonitoringQueryLanguage": {
         "duration": "0s",
-        "query": "fetch prometheus_target\n| { metric 'prometheus.googleapis.com/max_file_descriptor_count/gauge'\n  ; metric 'prometheus.googleapis.com/open_file_descriptor_count/gauge' }\n| outer_join 0\n| group_by 1m\n| sub\n| condition val() < 1000",
         "trigger": {
           "count": 1
-        }
+        },
+        "query": "fetch prometheus_target\n| { metric 'prometheus.googleapis.com/max_file_descriptor_count/gauge'\n  ; metric 'prometheus.googleapis.com/open_file_descriptor_count/gauge' }\n| outer_join 0\n| group_by 1m\n| sub\n| condition val() < 1000"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
   "enabled": true,
-  "notificationChannels": []
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }


### PR DESCRIPTION
This PR updates a ZooKeeper GKE alert to use PromQL instead of the deprecated MQL.