### PR TITLE
PromQL Alerts: Google Cloud Chronicle

### DIFF
--- a/alerts/google-cloud-chronicle/ingestion-quota-limit-approaching.v1.json
+++ b/alerts/google-cloud-chronicle/ingestion-quota-limit-approaching.v1.json
@@ -4,12 +4,10 @@
   "conditions": [
     {
       "displayName": "Quota Limit Approaching",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "{ \nfetch chronicle.googleapis.com/Collector \n| metric 'chronicle.googleapis.com/ingestion/log/bytes_count' \n| group_by [], sum(val()) \n| every 1s \n| window 10m \n; \nfetch chronicle.googleapis.com/Collector \n| metric 'chronicle.googleapis.com/ingestion/quota_limit' \n| filter (metric.quota_type == 'SHORT_TERM_DATA_RATE') \n| group_by [], [value_quota_limit_min: min(value.quota_limit)] \n| every 1s \n| window 10m \n} \n| join \n| div \n| condition val() > 0.5 "
+      "conditionPrometheusQueryLanguage": {
+        "duration": "600s",
+        "evaluationInterval": "30s",
+        "query": "(\n  sum_over_time({\"chronicle.googleapis.com/ingestion/log/bytes_count\", monitored_resource=\"chronicle.googleapis.com/Collector\"}[10m])\n  /\n  min_over_time({\"chronicle.googleapis.com/ingestion/quota_limit\", monitored_resource=\"chronicle.googleapis.com/Collector\", quota_type=\"SHORT_TERM_DATA_RATE\"}[10m])\n) > 0.5"
       }
     }
   ],

--- a/alerts/google-cloud-chronicle/ingestion-quota-limit-approaching.v1.json
+++ b/alerts/google-cloud-chronicle/ingestion-quota-limit-approaching.v1.json
@@ -6,17 +6,22 @@
       "displayName": "Quota Limit Approaching",
       "conditionMonitoringQueryLanguage": {
         "duration": "0s",
-        "query": "{ \nfetch chronicle.googleapis.com/Collector \n| metric 'chronicle.googleapis.com/ingestion/log/bytes_count' \n| group_by [], sum(val()) \n| every 1s \n| window 10m \n; \nfetch chronicle.googleapis.com/Collector \n| metric 'chronicle.googleapis.com/ingestion/quota_limit' \n| filter (metric.quota_type == 'SHORT_TERM_DATA_RATE') \n| group_by [], [value_quota_limit_min: min(value.quota_limit)] \n| every 1s \n| window 10m \n} \n| join \n| div \n| condition val() > 0.5 ",
         "trigger": {
           "count": 1
-        }
+        },
+        "query": "{ \nfetch chronicle.googleapis.com/Collector \n| metric 'chronicle.googleapis.com/ingestion/log/bytes_count' \n| group_by [], sum(val()) \n| every 1s \n| window 10m \n; \nfetch chronicle.googleapis.com/Collector \n| metric 'chronicle.googleapis.com/ingestion/quota_limit' \n| filter (metric.quota_type == 'SHORT_TERM_DATA_RATE') \n| group_by [], [value_quota_limit_min: min(value.quota_limit)] \n| every 1s \n| window 10m \n} \n| join \n| div \n| condition val() > 0.5 "
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
   "enabled": true,
-  "notificationChannels": []
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/google-cloud-chronicle/ingestion-quota-rejects.v1.json
+++ b/alerts/google-cloud-chronicle/ingestion-quota-rejects.v1.json
@@ -6,17 +6,22 @@
       "displayName": "Ingestion Quota Rejection",
       "conditionMonitoringQueryLanguage": {
         "duration": "0s",
-        "query": "fetch chronicle.googleapis.com/Collector \n| metric 'chronicle.googleapis.com/ingestion/log/quota_rejected_bytes_count' \n| group_by [], sum(val()) \n| every 5m \n | window 5m \n| condition val() > 0 ",
         "trigger": {
           "count": 1
-        }
+        },
+        "query": "fetch chronicle.googleapis.com/Collector \n| metric 'chronicle.googleapis.com/ingestion/log/quota_rejected_bytes_count' \n| group_by [], sum(val()) \n| every 5m \n | window 5m \n| condition val() > 0 "
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
   "enabled": true,
-  "notificationChannels": []
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/google-cloud-chronicle/ingestion-quota-rejects.v1.json
+++ b/alerts/google-cloud-chronicle/ingestion-quota-rejects.v1.json
@@ -4,12 +4,10 @@
   "conditions": [
     {
       "displayName": "Ingestion Quota Rejection",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch chronicle.googleapis.com/Collector \n| metric 'chronicle.googleapis.com/ingestion/log/quota_rejected_bytes_count' \n| group_by [], sum(val()) \n| every 5m \n | window 5m \n| condition val() > 0 "
+      "conditionPrometheusQueryLanguage": {
+        "duration": "300s",
+        "evaluationInterval": "300s",
+        "query": "sum_over_time(\n  {\"chronicle.googleapis.com/ingestion/log/quota_rejected_bytes_count\", monitored_resource=\"chronicle.googleapis.com/Collector\"}[5m]\n) > 0"
       }
     }
   ],


### PR DESCRIPTION
This PR updates some Google Cloud Chronicle alerts to use PromQL instead of the deprecated MQL.