### PR TITLE
PromQL Alerts: Google Dataproc

### DIFF
--- a/alerts/google-dataproc/failed-job.v1.json
+++ b/alerts/google-dataproc/failed-job.v1.json
@@ -4,12 +4,10 @@
   "conditions": [
     {
       "displayName": "Dataproc Failed Job - Job in ERROR state",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "60s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch cloud_dataproc_job\n| metric 'dataproc.googleapis.com/job/state'\n| filter metric.state == 'ERROR'\n| group_by [resource.job_id, metric.state], 1m\n| condition val() == true()"
+      "conditionPrometheusQueryLanguage": {
+        "duration": "0s",
+        "evaluationInterval": "30s",
+        "query": "sum by (job_id, state) (\n  {\"dataproc.googleapis.com/job/state\", monitored_resource=\"cloud_dataproc_job\", state=\"ERROR\"}\n) == 1"
       }
     }
   ],

--- a/alerts/google-dataproc/failed-job.v1.json
+++ b/alerts/google-dataproc/failed-job.v1.json
@@ -6,17 +6,22 @@
       "displayName": "Dataproc Failed Job - Job in ERROR state",
       "conditionMonitoringQueryLanguage": {
         "duration": "60s",
-        "query": "fetch cloud_dataproc_job\n| metric 'dataproc.googleapis.com/job/state'\n| filter metric.state == 'ERROR'\n| group_by [resource.job_id, metric.state], 1m\n| condition val() == true()",
         "trigger": {
           "count": 1
-        }
+        },
+        "query": "fetch cloud_dataproc_job\n| metric 'dataproc.googleapis.com/job/state'\n| filter metric.state == 'ERROR'\n| group_by [resource.job_id, metric.state], 1m\n| condition val() == true()"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
   "enabled": true,
-  "notificationChannels": []
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/google-dataproc/long-running-job.v1.json
+++ b/alerts/google-dataproc/long-running-job.v1.json
@@ -4,12 +4,10 @@
   "conditions": [
     {
       "displayName": "Dataproc Long Running Job - Job in RUNNING state",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "3600s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch cloud_dataproc_job\n| metric 'dataproc.googleapis.com/job/state'\n| filter metric.state == 'RUNNING'\n| group_by [resource.job_id, metric.state], 1m\n| condition val() == true()"
+      "conditionPrometheusQueryLanguage": {
+        "duration": "0s",
+        "evaluationInterval": "30s",
+        "query": "sum by (job_id, state) (\n  {\"dataproc.googleapis.com/job/state\", monitored_resource=\"cloud_dataproc_job\", state=\"RUNNING\"}\n) == 1"
       }
     }
   ],

--- a/alerts/google-dataproc/long-running-job.v1.json
+++ b/alerts/google-dataproc/long-running-job.v1.json
@@ -6,17 +6,22 @@
       "displayName": "Dataproc Long Running Job - Job in RUNNING state",
       "conditionMonitoringQueryLanguage": {
         "duration": "3600s",
-        "query": "fetch cloud_dataproc_job\n| metric 'dataproc.googleapis.com/job/state'\n| filter metric.state == 'RUNNING'\n| group_by [resource.job_id, metric.state], 1m\n| condition val() == true()",
         "trigger": {
           "count": 1
-        }
+        },
+        "query": "fetch cloud_dataproc_job\n| metric 'dataproc.googleapis.com/job/state'\n| filter metric.state == 'RUNNING'\n| group_by [resource.job_id, metric.state], 1m\n| condition val() == true()"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
   "enabled": true,
-  "notificationChannels": []
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/google-dataproc/stale-job.v1.json
+++ b/alerts/google-dataproc/stale-job.v1.json
@@ -6,17 +6,22 @@
       "displayName": "Dataproc Stale Job - Job in PENDING state",
       "conditionMonitoringQueryLanguage": {
         "duration": "600s",
-        "query": "fetch cloud_dataproc_job\n| metric 'dataproc.googleapis.com/job/state'\n| filter metric.state == 'PENDING'\n| group_by [resource.job_id, metric.state], 1m\n| condition val() == true()",
         "trigger": {
           "count": 1
-        }
+        },
+        "query": "fetch cloud_dataproc_job\n| metric 'dataproc.googleapis.com/job/state'\n| filter metric.state == 'PENDING'\n| group_by [resource.job_id, metric.state], 1m\n| condition val() == true()"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
   "enabled": true,
-  "notificationChannels": []
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/google-dataproc/stale-job.v1.json
+++ b/alerts/google-dataproc/stale-job.v1.json
@@ -4,12 +4,10 @@
   "conditions": [
     {
       "displayName": "Dataproc Stale Job - Job in PENDING state",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "600s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch cloud_dataproc_job\n| metric 'dataproc.googleapis.com/job/state'\n| filter metric.state == 'PENDING'\n| group_by [resource.job_id, metric.state], 1m\n| condition val() == true()"
+      "conditionPrometheusQueryLanguage": {
+        "duration": "0s",
+        "evaluationInterval": "30s",
+        "query": "sum by (job_id, state) (\n  {\"dataproc.googleapis.com/job/state\", monitored_resource=\"cloud_dataproc_job\", state=\"PENDING\"}\n) == 1"
       }
     }
   ],


### PR DESCRIPTION
This PR updates some Google Dataproc alerts to use PromQL instead of the deprecated MQL.