### PR TITLE
PromQL Alerts: Flink

### DIFF
--- a/alerts/flink/flink-high-jvm-memory-non-heap-usage.v1.json
+++ b/alerts/flink/flink-high-jvm-memory-non-heap-usage.v1.json
@@ -3,24 +3,27 @@
   "documentation": {
     "content": "When the JVM nonheap ratio of nonheap used over max nonheap exceeds a threshold(default is 90%), then application's performance may start to degrade. This alert can trigger when for a jobmanager or a taskmanager. To specify a jobmanager, the resource_type should be jobmanager. To specify a taskmanager, the taskmanager_id filter should target the correct taskmanager instance.",
     "mimeType": "text/markdown"
-},
+  },
   "userLabels": {},
   "conditions": [
     {
       "displayName": "Flink - JVM Heap Memory Near Max",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "0s",
-        "query": "fetch gce_instance\n| {\nt_0: metric 'workload.googleapis.com/flink.jvm.memory.nonheap.used'\n| filter (metric.resource_type == 'jobmanager');\nt_1: metric 'workload.googleapis.com/flink.jvm.memory.nonheap.max'\n| filter (metric.resource_type == 'jobmanager')\n}\n| outer_join 0\n| value t_0.value.used / t_1.value.max\n| condition val() > .9\n| every 5m\n| window 5m",
-        "trigger": {
-          "count": 1
-        }
+      "conditionPrometheusQueryLanguage": {
+        "duration": "300s",
+        "evaluationInterval": "60s",
+        "query": "(\n    {\"workload.googleapis.com/flink.jvm.memory.nonheap.used\", monitored_resource=\"gce_instance\", resource_type=\"jobmanager\"}\n    /\n    {\"workload.googleapis.com/flink.jvm.memory.nonheap.max\", monitored_resource=\"gce_instance\", resource_type=\"jobmanager\"}\n) > 0.9"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
   "enabled": true,
-  "notificationChannels": []
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/flink/flink-high-jvm-memory-usage.v1.json
+++ b/alerts/flink/flink-high-jvm-memory-usage.v1.json
@@ -3,24 +3,27 @@
   "documentation": {
     "content": "When the JVM heap ratio of heap used over max heap exceeds a threshold(default is 90%), then application's performance may start to degrade. This alert can trigger when for a jobmanager or a taskmanager. To specify a jobmanager, the resource_type should be jobmanager. To specify a taskmanager, the taskmanager_id filter should target the correct taskmanager instance.",
     "mimeType": "text/markdown"
-},
+  },
   "userLabels": {},
   "conditions": [
     {
       "displayName": "Flink - JVM Heap Memory Near Max",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "0s",
-        "query": "fetch gce_instance\n| {\nt_0: metric 'workload.googleapis.com/flink.jvm.memory.heap.used'\n| filter (metric.resource_type == 'jobmanager');\nt_1: metric 'workload.googleapis.com/flink.jvm.memory.heap.max'\n| filter (metric.resource_type == 'jobmanager')\n}\n| outer_join 0\n| value t_0.value.used / t_1.value.max\n| condition val() > .9\n| every 5m\n| window 5m",
-        "trigger": {
-          "count": 1
-        }
+      "conditionPrometheusQueryLanguage": {
+        "duration": "300s",
+        "evaluationInterval": "60s",
+        "query": "(\n    {\"workload.googleapis.com/flink.jvm.memory.heap.used\", monitored_resource=\"gce_instance\", resource_type=\"jobmanager\"}\n    /\n    {\"workload.googleapis.com/flink.jvm.memory.heap.max\", monitored_resource=\"gce_instance\", resource_type=\"jobmanager\"}\n) > 0.9"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
   "enabled": true,
-  "notificationChannels": []
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }


### PR DESCRIPTION
This PR updated the Flink alerts to use PromQL instead of the deprecated MQL.

MQL:
<img width="3712" height="1608" alt="image" src="https://github.com/user-attachments/assets/b2957095-26d9-4d48-891b-37c1ce6f0ba1" />
<img width="3716" height="1610" alt="image" src="https://github.com/user-attachments/assets/8070332e-e0b5-4de6-ae68-e26871c35827" />

PromQL:
<img width="3716" height="1610" alt="image" src="https://github.com/user-attachments/assets/f7adcd9f-a754-4316-8b3a-40309d7d324e" />
<img width="3718" height="1614" alt="image" src="https://github.com/user-attachments/assets/59c71cd1-c534-498e-8700-169753d87c3f" />
