### PR TITLE
PromQL Alerts: HBase

### DIFF
--- a/alerts/hbase/authentication-errors.v1.json
+++ b/alerts/hbase/authentication-errors.v1.json
@@ -1,26 +1,29 @@
 {
-    "displayName": "HBase - Authentication Errors",
-    "documentation": {
-        "content": "Authentication errors could indicate that clients do not have correct credentials or somebody is maliciously trying to access the HBase system. The alert is configured to fire if 5 authentication errors are happening over a minute. Feel free to modify to fit use cases.",
-        "mimeType": "text/markdown"
-    },
-    "userLabels": {},
-    "conditions": [
-        {
-            "displayName": "HBase Authentication Errors",
-            "conditionMonitoringQueryLanguage": {
-                "duration": "0s",
-                "trigger": {
-                    "count": 1
-                },
-                "query": "fetch gce_instance\n| metric 'workload.googleapis.com/hbase.region_server.authentication.count'\n| filter (metric.state == \"failures\")\n| group_by 1m, [value_count_mean: mean(value.count)]\n| every 1m\n| condition val() > 5"
-            }
-        }
-    ],
-    "alertStrategy": {
-        "autoClose": "3600s"
-    },
-    "combiner": "OR",
-    "enabled": true,
-    "notificationChannels": []
+  "displayName": "HBase - Authentication Errors",
+  "documentation": {
+    "content": "Authentication errors could indicate that clients do not have correct credentials or somebody is maliciously trying to access the HBase system. The alert is configured to fire if 5 authentication errors are happening over a minute. Feel free to modify to fit use cases.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "HBase Authentication Errors",
+      "conditionPrometheusQueryLanguage": {
+        "duration": "0s",
+        "evaluationInterval": "60s",
+        "query": "avg_over_time({\"workload.googleapis.com/hbase.region_server.authentication.count\", monitored_resource=\"gce_instance\", state=\"failures\"}[1m]) > 5"
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "3600s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }


### PR DESCRIPTION
This PR updates a HBase alert to use PromQL instead of the deprecated MQL.

MQL:
<img width="3716" height="1610" alt="image" src="https://github.com/user-attachments/assets/f618772e-65d7-47e4-b821-8860473c5705" />

PromQL:
<img width="3712" height="1612" alt="image" src="https://github.com/user-attachments/assets/ac5ca198-48d2-48b8-a377-34cc36a6f522" />
