### PR TITLE
PromQL Alerts: JVM

### DIFF
--- a/alerts/jvm/heap-memory-usage.v1.json
+++ b/alerts/jvm/heap-memory-usage.v1.json
@@ -1,26 +1,29 @@
 {
-    "displayName": "JVM - Heap Memory Usage Near Max",
-    "documentation": {
-        "content": "Alert for JVM heap memory usage being near maximum. When the JVM reaches its max, depending on the JVM configuration, this could lead to Out of Memory errors.",
-        "mimeType": "text/markdown"
-    },
-    "userLabels": {},
-    "conditions": [
-        {
-            "displayName": "JVM - Heap Memory Near Max",
-            "conditionMonitoringQueryLanguage": {
-                "duration": "60s",
-                "query": "{ \n    t_0: fetch gce_instance::workload.googleapis.com/jvm.memory.heap.used\n    ;\n    t_1: fetch gce_instance::workload.googleapis.com/jvm.memory.heap.max\n}\n| outer_join 0\n| value val(0) / val(1)\n| window 1m \n| condition val() > .9\n\n",
-                "trigger": {
-                    "count": 1
-                }
-            }
-        }
-    ],
-    "alertStrategy": {
-        "autoClose": "3600s"
-    },
-    "combiner": "OR",
-    "enabled": true,
-    "notificationChannels": []
+  "displayName": "JVM - Heap Memory Usage Near Max",
+  "documentation": {
+    "content": "Alert for JVM heap memory usage being near maximum. When the JVM reaches its max, depending on the JVM configuration, this could lead to Out of Memory errors.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "JVM - Heap Memory Near Max",
+      "conditionPrometheusQueryLanguage": {
+        "duration": "60s",
+        "evaluationInterval": "30s",
+        "query": "(\n  {\"workload.googleapis.com/jvm.memory.heap.used\", monitored_resource=\"gce_instance\"}\n  /\n  {\"workload.googleapis.com/jvm.memory.heap.max\", monitored_resource=\"gce_instance\"}\n) > 0.9"
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "3600s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }


### PR DESCRIPTION
This PR updates a JVM alert to use PromQL instead of the deprecated MQL.

MQL:
<img width="3714" height="1604" alt="image" src="https://github.com/user-attachments/assets/2c0e14bd-a97e-465f-a51f-d1ea8457c39f" />

PromQL:
<img width="3714" height="1608" alt="image" src="https://github.com/user-attachments/assets/26df937e-7fba-4a09-8ca7-c7a609909437" />
