### PR TITLE
PromQL Alerts: Scylla GKE

### DIFF
--- a/alerts/scylla-gke/high-prepared-statement-eviction-rate.v1.json
+++ b/alerts/scylla-gke/high-prepared-statement-eviction-rate.v1.json
@@ -1,26 +1,29 @@
 {
-    "displayName": "ScyllaDB - Prometheus - High Prepared Statement Eviction Rate",
-    "documentation": {
-      "content": "If the prepared statement cache is being continuously evicted, it indicates an error in application prepared-statement usage logic. This can cause performance to degrade.",
-      "mimeType": "text/markdown"
-    },
-    "userLabels": {},
-    "conditions": [
-      {
-        "displayName": "Prometheus Target - prometheus/scylla_cql_prepared_cache_evictions/counter",
-        "conditionMonitoringQueryLanguage": {
-          "duration": "0s",
-          "query": "fetch prometheus_target\n| { t_0: metric 'prometheus.googleapis.com/scylla_cql_prepared_cache_evictions/counter';\n    t_1: metric 'prometheus.googleapis.com/scylla_cql_authorized_prepared_statements_cache_evictions/counter'\n}\n| outer_join 0, 0\n| add\n| align rate(5m)\n| every 5m\n| condition val() > 100\n",
-          "trigger": {
-            "count": 1
-          }
-        }
+  "displayName": "ScyllaDB - Prometheus - High Prepared Statement Eviction Rate",
+  "documentation": {
+    "content": "If the prepared statement cache is being continuously evicted, it indicates an error in application prepared-statement usage logic. This can cause performance to degrade.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Prometheus Target - prometheus/scylla_cql_prepared_cache_evictions/counter",
+      "conditionPrometheusQueryLanguage": {
+        "duration": "0s",
+        "evaluationInterval": "300s",
+        "query": "(\n  rate({\"scylla_cql_prepared_cache_evictions\"}[5m])\n  +\n  rate({\"scylla_cql_authorized_prepared_statements_cache_evictions\"}[5m])\n) > 100"
       }
-    ],
-    "alertStrategy": {
-      "autoClose": "604800s"
-    },
-    "combiner": "OR",
-    "enabled": false,
-    "notificationChannels": []
-  }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
+}


### PR DESCRIPTION
This PR updates a Scylla GKE alert to use PromQL instead of the deprecated MQL.

MQL:
<img width="3716" height="1608" alt="image" src="https://github.com/user-attachments/assets/e4b082da-39ff-475b-9188-743e1e274c94" />

PromQL:
<img width="3714" height="1610" alt="image" src="https://github.com/user-attachments/assets/ac994a93-af3c-4792-9895-90a30631757a" />
