### PR TITLE
PromQL Alerts: Google GCE

### DIFF
--- a/alerts/google-gce/reservation-utilization-too-high.v1.json
+++ b/alerts/google-gce/reservation-utilization-too-high.v1.json
@@ -1,21 +1,25 @@
 {
-    "displayName": "Reservation - High Utilization",
-    "userLabels": {},
-    "conditions": [
-      {
-        "displayName": "High Reservation Utilization",
-        "conditionMonitoringQueryLanguage": {
-          "duration": "0s",
-          "query": "fetch compute.googleapis.com/Reservation\n|\n{ metric 'compute.googleapis.com/reservation/used'\n| align next_older(5m) | every 5m ;\nmetric 'compute.googleapis.com/reservation/reserved'\n| align next_older(5m) | every 5m\n}\n| ratio\n| condition val() >= 0.9",
-          "trigger": {
-            "count": 1
-          }
-        }
+  "displayName": "Reservation - High Utilization",
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "High Reservation Utilization",
+      "conditionPrometheusQueryLanguage": {
+        "duration": "0s",
+        "evaluationInterval": "300s",
+        "query": "(\n  {\"compute.googleapis.com/reservation/used\", monitored_resource=\"compute.googleapis.com/Reservation\"}\n    / on (reservation_id)\n  {\"compute.googleapis.com/reservation/reserved\", monitored_resource=\"compute.googleapis.com/Reservation\"}\n) >= 0.9"
       }
-    ],
-    "alertStrategy": {
-      "autoClose": "604800s"
-    },
-    "combiner": "OR",
-    "enabled": true
-  }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
+}

--- a/alerts/google-gce/reservation-utilization-too-low.v1.json
+++ b/alerts/google-gce/reservation-utilization-too-low.v1.json
@@ -1,21 +1,25 @@
 {
-    "displayName": "Reservation - Low Utilization",
-    "userLabels": {},
-    "conditions": [
-      {
-        "displayName": "Low Usage for 20 hours out of 23 hours",
-        "conditionMonitoringQueryLanguage": {
-          "duration": "0s",
-          "query": "fetch compute.googleapis.com/Reservation\n|\n{ metric 'compute.googleapis.com/reservation/used'\n| align next_older(5m) | every 5m ;\nmetric 'compute.googleapis.com/reservation/reserved'\n| align next_older(5m) | every 5m\n}\n| ratio\n| value val() <= 0.1\n| count_true_aligner(23h)\n| condition val() > 20 * 12 # 20 hours * (12 5 min intervals in hour)",
-          "trigger": {
-            "count": 1
-          }
-        }
+  "displayName": "Reservation - Low Utilization",
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Low Usage for 20 hours out of 23 hours",
+      "conditionPrometheusQueryLanguage": {
+        "duration": "0s",
+        "evaluationInterval": "300s",
+        "query": "count_over_time(\n  (\n    ({\"compute.googleapis.com/reservation/used\", monitored_resource=\"compute.googleapis.com/Reservation\"}\n     / on (reservation_id)\n     {\"compute.googleapis.com/reservation/reserved\", monitored_resource=\"compute.googleapis.com/Reservation\"}\n    ) <= 0.1\n  )[23h:5m]\n) > (20 * 12) # 20 hours * (12 5 min intervals in hour)"
       }
-    ],
-    "alertStrategy": {
-      "autoClose": "604800s"
-    },
-    "combiner": "OR",
-    "enabled": true
-  }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
+}


### PR DESCRIPTION
This PR updates Google GCE alerts to use PromQL instead of the deprecated MQL.

Note that we included on (reservation_id) in the PromQL versions of the query, which is not a part of the original MQL. This is because without the inclusion of this expression, the PromQL data does not appear; see the screenshots for an example.

<img width="1276" height="1244" alt="image" src="https://github.com/user-attachments/assets/e6793024-7a90-421d-9ae9-9ff6fa2d16fa" />
<img width="1288" height="574" alt="image" src="https://github.com/user-attachments/assets/c05c488a-b55b-4bde-bc4d-6624b137caa8" />

MQL:
<img width="3712" height="1612" alt="image" src="https://github.com/user-attachments/assets/ae314ba5-4a91-476c-a6a3-30d1af882ab2" />

PromQL:
<img width="3716" height="1614" alt="image" src="https://github.com/user-attachments/assets/48db4a2d-a70b-4fab-aa0d-1c1765681c72" />
