### PR TITLE
PromQL Alerts: Zookeeper

### DIFF
--- a/alerts/zookeeper/low-open-file-descriptors.v1.json
+++ b/alerts/zookeeper/low-open-file-descriptors.v1.json
@@ -8,19 +8,22 @@
   "conditions": [
     {
       "displayName": "New condition",
-      "conditionMonitoringQueryLanguage": {
+      "conditionPrometheusQueryLanguage": {
         "duration": "0s",
-        "query": " fetch gce_instance\n| { metric 'workload.googleapis.com/zookeeper.file_descriptor.limit'\n; metric 'workload.googleapis.com/zookeeper.file_descriptor.open' }\n| outer_join 0\n| group_by 1m\n| sub\n| condition val() < 1000",
-        "trigger": {
-          "count": 1
-        }
+        "evaluationInterval": "30s",
+        "query": "(\n  {\"workload.googleapis.com/zookeeper.file_descriptor.limit\", monitored_resource=\"gce_instance\"}\n  -\n  {\"workload.googleapis.com/zookeeper.file_descriptor.open\", monitored_resource=\"gce_instance\"}\n) < 1000"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
   "enabled": true,
-  "notificationChannels": []
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }


### PR DESCRIPTION
This PR updates a Zookeeper alert to use PromQL instead of the deprecated MQL.

MQL:
<img width="3716" height="1610" alt="image" src="https://github.com/user-attachments/assets/2e083848-c317-4774-9a13-90332b8dbbdc" />

PromQL:
<img width="3716" height="1612" alt="image" src="https://github.com/user-attachments/assets/47807176-ebc5-4e99-8272-d0e0e0962d17" />
