### PR TITLE
PromQL Alerts: PostgreSQL

### DIFF
--- a/alerts/postgresql/high-connection-utilization.v1.json
+++ b/alerts/postgresql/high-connection-utilization.v1.json
@@ -1,26 +1,29 @@
 {
-    "displayName": "Postgresql - High Connection Utilization",
-    "documentation": {
-        "content": "Alert fires when active connections are near a threshold of 90. Around this point is where the instance may run into connection issues and may start refusing connections.",
-        "mimeType": "text/markdown"
-    },
-    "userLabels": {},
-    "conditions": [
-        {
-            "displayName": "Connections near system max",
-            "conditionMonitoringQueryLanguage": {
-                "duration": "0s",
-                "trigger": {
-                    "count": 1
-                },
-                "query": "{\n     t_0: fetch gce_instance::workload.googleapis.com/postgresql.connection.max ;\n     t_1: fetch gce_instance::workload.googleapis.com/postgresql.backends\n}\n| group_by [resource.instance_id]\n| outer_join 0\n| window 1m\n| condition val(0) * .9 < val(1)\n"
-            }
-        }
-    ],
-    "alertStrategy": {
-        "autoClose": "604800s"
-    },
-    "combiner": "OR",
-    "enabled": true,
-    "notificationChannels": []
+  "displayName": "Postgresql - High Connection Utilization",
+  "documentation": {
+    "content": "Alert fires when active connections are near a threshold of 90. Around this point is where the instance may run into connection issues and may start refusing connections.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Connections near system max",
+      "conditionPrometheusQueryLanguage": {
+        "duration": "60s",
+        "evaluationInterval": "30s",
+        "query": "(\n  sum by (instance_id) (\n    {\"workload.googleapis.com/postgresql.backends\", monitored_resource=\"gce_instance\"}\n  )\n  /\n  sum by (instance_id) (  \n    {\"workload.googleapis.com/postgresql.connection.max\", monitored_resource=\"gce_instance\"}\n  )\n) > 0.9"
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/postgresql/high-cpu-utilization.v1.json
+++ b/alerts/postgresql/high-cpu-utilization.v1.json
@@ -1,27 +1,29 @@
 {
-    "displayName": "Postgres - High CPU Utilization",
-    "documentation": {
-        "content": "Alerts whenever the CPU utilization goes above 80% which usually indicates the instance's performance is heavily degraded and likely is going to impact applications reliant on postgres.",
-        "mimeType": "text/markdown"
-    },
-    "userLabels": {},
-    "conditions": [
-        {
-            "displayName": "Postgres CPU > 90%",
-            "conditionMonitoringQueryLanguage": {
-                "duration": "0s",
-                "trigger": {
-                    "count": 1
-                },
-                "evaluationMissingData": "EVALUATION_MISSING_DATA_NO_OP",
-                "query": "def top_cpu_filtered_by_metric filter_metric =\n  fetch gce_instance\n  | { t_cpu: metric 'compute.googleapis.com/instance/cpu/utilization'\n    ; t_filter_metric: metric $filter_metric }\n  | join\n  | value t_cpu.value.utilization\n  | group_by [resource.project_id, resource.zone, metric.instance_name], 1m,\n      [value_utilization_mean: mean(t_cpu.value.utilization)]\n  | every 1m;\n\n@top_cpu_filtered_by_metric 'workload.googleapis.com/postgresql.operations'\n| condition val() > .9"
-            }
-        }
-    ],
-    "alertStrategy": {
-        "autoClose": "1800s"
-    },
-    "combiner": "OR",
-    "enabled": true,
-    "notificationChannels": []
+  "displayName": "Postgres - High CPU Utilization",
+  "documentation": {
+    "content": "Alerts whenever the CPU utilization goes above 80% which usually indicates the instance's performance is heavily degraded and likely is going to impact applications reliant on postgres.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Postgres CPU > 90%",
+      "conditionPrometheusQueryLanguage": {
+        "duration": "0s",
+        "evaluationInterval": "60s",
+        "query": "(avg by (project_id, zone, instance_name) (\n  avg_over_time(\n    {\"compute.googleapis.com/instance/cpu/utilization\", monitored_resource=\"gce_instance\"}[1m]\n  )\n  and\n  on(instance_id, project_id, zone)\n    ({\"workload.googleapis.com/postgresql.operations\", monitored_resource=\"gce_instance\"})\n  )\n) > 0.9"
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "1800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/postgresql/high-db-size.v1.json
+++ b/alerts/postgresql/high-db-size.v1.json
@@ -1,26 +1,29 @@
 {
-    "displayName": "Postgresql - High Database Size",
-    "documentation": {
-        "content": "Alert fires when the database size is growing greater than expected (this value will be subject to instance size and utilization); defaulted to 93 GB but will be subject to instance size as well as connected storage.",
-        "mimeType": "text/markdown"
-    },
-    "userLabels": {},
-    "conditions": [
-        {
-            "displayName": "Database Size Large for Environment",
-            "conditionMonitoringQueryLanguage": {
-                "duration": "0s",
-                "trigger": {
-                    "count": 1
-                },
-                "query": "fetch gce_instance\n| metric 'workload.googleapis.com/postgresql.db_size'\n| group_by 1m, [value_db_size_mean: mean(value.db_size)]\n| every 1m\n| cast_units \"By\"\n| condition val() > 1e+11 \"By\""
-            }
-        }
-    ],
-    "alertStrategy": {
-        "autoClose": "604800s"
-    },
-    "combiner": "OR",
-    "enabled": true,
-    "notificationChannels": []
+  "displayName": "Postgresql - High Database Size",
+  "documentation": {
+    "content": "Alert fires when the database size is growing greater than expected (this value will be subject to instance size and utilization); defaulted to 93 GB but will be subject to instance size as well as connected storage.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Database Size Large for Environment",
+      "conditionPrometheusQueryLanguage": {
+        "duration": "0s",
+        "evaluationInterval": "60s",
+        "query": "avg_over_time({\"workload.googleapis.com/postgresql.db_size\", monitored_resource=\"gce_instance\"}[1m]) > 1e+11"
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }


### PR DESCRIPTION
This PR updates some PostgreSQL alerts to use PromQL instead of the deprecated MQL.

Note that while the condition for high-connection-utilization.v1.json appear differently in MQL and PromQL, they are functionally identical.

MQL:
<img width="3714" height="1610" alt="image" src="https://github.com/user-attachments/assets/2ee13e7a-2a41-40dc-99ca-f94aaa7aefe8" />

PromQL:
<img width="3716" height="1612" alt="image" src="https://github.com/user-attachments/assets/c50b4e20-12ca-4345-b1a9-1307a2e1ddef" />
