### PR TITLE
PromQL Alerts: Kube State GKE

### DIFF
--- a/alerts/kube-state-gke/pod-disruption-budget-exceeded.v1.json
+++ b/alerts/kube-state-gke/pod-disruption-budget-exceeded.v1.json
@@ -1,26 +1,29 @@
 {
-    "displayName": "Kube State - Prometheus - Pod Disruption Budget Exceeded",
-    "documentation": {
-      "content": "When the pod disruption budget is exceeded, the configured minimum availability is not being respected, typically due to an application failure.",
-      "mimeType": "text/markdown"
-    },
-    "userLabels": {},
-    "conditions": [
-      {
-        "displayName": "Allowed Pod Disruptions Remaining",
-        "conditionMonitoringQueryLanguage": {
-          "duration": "0s",
-          "query": "fetch prometheus_target\n| { metric\n      prometheus.googleapis.com/kube_poddisruptionbudget_status_current_healthy/gauge\n  ; metric\n      prometheus.googleapis.com/kube_poddisruptionbudget_status_desired_healthy/gauge }\n| outer_join 0\n| sub\n| every 5m\n| window 5m\n| condition val() < 0",
-          "trigger": {
-            "count": 1
-          }
-        }
+  "displayName": "Kube State - Prometheus - Pod Disruption Budget Exceeded",
+  "documentation": {
+    "content": "When the pod disruption budget is exceeded, the configured minimum availability is not being respected, typically due to an application failure.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Allowed Pod Disruptions Remaining",
+      "conditionPrometheusQueryLanguage": {
+        "duration": "300s",
+        "evaluationInterval": "300s",
+        "query": "(\n  {\"kube_poddisruptionbudget_status_current_healthy\"}\n  -\n {\"kube_poddisruptionbudget_status_desired_healthy\"}\n) < 0"
       }
-    ],
-    "alertStrategy": {
-      "autoClose": "604800s"
-    },
-    "combiner": "OR",
-    "enabled": false,
-    "notificationChannels": []
-  }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
+}

--- a/alerts/kube-state-gke/volume-reaching-capacity.v1.json
+++ b/alerts/kube-state-gke/volume-reaching-capacity.v1.json
@@ -1,26 +1,29 @@
 {
-    "displayName": "Kube State - Prometheus - Volume Reaching Capacity",
-    "documentation": {
-      "content": "This alert triggers when a volume is beginning to reach its capacity. When a volume reaches capacity, it cannot store any more data, which can cause applications to stop working.",
-      "mimeType": "text/markdown"
-    },
-    "userLabels": {},
-    "conditions": [
-      {
-        "displayName": "Volume Usage Ratio",
-        "conditionMonitoringQueryLanguage": {
-          "duration": "0s",
-          "query": "fetch prometheus_target\n| {\n    t_0: metric prometheus.googleapis.com/kubelet_volume_stats_used_bytes/gauge;\n    t_1: metric prometheus.googleapis.com/kubelet_volume_stats_capacity_bytes/gauge\n}\n| ratio\n| condition val() > 0.9\n| every 5m\n| window 5m",
-          "trigger": {
-            "count": 1
-          }
-        }
+  "displayName": "Kube State - Prometheus - Volume Reaching Capacity",
+  "documentation": {
+    "content": "This alert triggers when a volume is beginning to reach its capacity. When a volume reaches capacity, it cannot store any more data, which can cause applications to stop working.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Volume Usage Ratio",
+      "conditionPrometheusQueryLanguage": {
+        "duration": "300s",
+        "evaluationInterval": "300s",
+        "query": "(\n  {\"kubelet_volume_stats_used_bytes\"}\n  /\n  {\"kubelet_volume_stats_capacity_bytes\"}\n) > 0.9"
       }
-    ],
-    "alertStrategy": {
-      "autoClose": "604800s"
-    },
-    "combiner": "OR",
-    "enabled": true,
-    "notificationChannels": []
-  }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
+  },
+  "combiner": "OR",
+  "enabled": true,
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
+}


### PR DESCRIPTION
This PR updates some Kube State GKE alerts to use PromQL instead of the deprecated MQL.

No screenshots for these ones, but the queries are very simple.