### PR TITLE
PromQL Alerts: Zookeeper GKE

### DIFF
--- a/alerts/zookeeper-gke/low-free-file-descriptors.v1.json
+++ b/alerts/zookeeper-gke/low-free-file-descriptors.v1.json
@@ -8,19 +8,22 @@
   "conditions": [
     {
       "displayName": "New condition",
-      "conditionMonitoringQueryLanguage": {
+      "conditionPrometheusQueryLanguage": {
         "duration": "0s",
-        "query": "fetch prometheus_target\n| { metric 'prometheus.googleapis.com/max_file_descriptor_count/gauge'\n  ; metric 'prometheus.googleapis.com/open_file_descriptor_count/gauge' }\n| outer_join 0\n| group_by 1m\n| sub\n| condition val() < 1000",
-        "trigger": {
-          "count": 1
-        }
+        "evaluationInterval": "60s",
+        "query": "(\n  {\"max_file_descriptor_count\"}\n  -\n  {\"open_file_descriptor_count\"}\n) < 1000"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
   "enabled": true,
-  "notificationChannels": []
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }


### PR DESCRIPTION
This PR updates a Zookeeper GKE alert to use PromQL instead of the deprecated MQL.

No screenshots for this one, but the query is very simple.