### PR TITLE
PromQL Alerts: MySQL

### DIFF
--- a/alerts/mysql/mysql-high-number-of-log-errors.v1.json
+++ b/alerts/mysql/mysql-high-number-of-log-errors.v1.json
@@ -3,24 +3,27 @@
   "documentation": {
     "content": "Log error are a count of logs collected from mysql_error logs with an error level per 5 minute window. The default condition of error per 5 minute window is 5.",
     "mimeType": "text/markdown"
-},
+  },
   "userLabels": {},
   "conditions": [
     {
       "displayName": "logging/user/mysql.error.count",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "0s",
-        "query": "fetch gce_instance\n| metric 'logging.googleapis.com/user/mysql.error.count'\n| window 5m \n| condition val() > 5\n",
-        "trigger": {
-          "count": 1
-        }
+      "conditionPrometheusQueryLanguage": {
+        "duration": "300s",
+        "evaluationInterval": "30s",
+        "query": "{\"logging.googleapis.com/user/mysql.error.count\", monitored_resource=\"gce_instance\"} > 5"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
   "enabled": true,
-  "notificationChannels": []
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/mysql/mysql-high-number-of-log-warnings.v1.json
+++ b/alerts/mysql/mysql-high-number-of-log-warnings.v1.json
@@ -3,24 +3,27 @@
   "documentation": {
     "content": "Log warnings are a count of logs collected from mysql_error logs with a warning level per 5 minute window. The default condition of warnings per 5 minute window is 20.",
     "mimeType": "text/markdown"
-},
+  },
   "userLabels": {},
   "conditions": [
     {
       "displayName": "logging/user/mysql.warning.count",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "0s",
-        "query": "fetch gce_instance\n| metric 'logging.googleapis.com/user/mysql.warning.count'\n| window 5m \n| condition val() > 20\n",
-        "trigger": {
-          "count": 1
-        }
+      "conditionPrometheusQueryLanguage": {
+        "duration": "300s",
+        "evaluationInterval": "30s",
+        "query": "{\"logging.googleapis.com/user/mysql.warning.count\", monitored_resource=\"gce_instance\"} > 20"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
   "enabled": true,
-  "notificationChannels": []
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }


### PR DESCRIPTION
This PR updates MySQL alerts to use PromQL instead of the deprecated MQL.

No screenshots for these ones, but the queries are very simple.