### PR TITLE
PromQL Alerts: Google Workload Manager

### DIFF
--- a/alerts/google-workload-manager/sap-hana-availability-low.v1.json
+++ b/alerts/google-workload-manager/sap-hana-availability-low.v1.json
@@ -8,19 +8,22 @@
   "conditions": [
     {
       "displayName": "SAPHanaAvailabilityCheck",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch gce_instance\n| { metric 'workload.googleapis.com/sap/hana/availability'\n ; metric 'workload.googleapis.com/sap/mntmode' }\n| join\n| window 1m\n| value if(t_0.value.availability < 1 && t_1.value.mntmode == false(), false(), true())\n| condition val()"
+      "conditionPrometheusQueryLanguage": {
+        "duration": "60s",
+        "evaluationInterval": "30s",
+        "query": "({\"workload.googleapis.com/sap/hana/availability\", monitored_resource=\"gce_instance\"} >= 1)\nor \n({\"workload.googleapis.com/sap/mntmode\", monitored_resource=\"gce_instance\"} != 0)"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
   "enabled": true,
-  "notificationChannels": []
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }

--- a/alerts/google-workload-manager/sap-hana-high-availability-low.v1.json
+++ b/alerts/google-workload-manager/sap-hana-high-availability-low.v1.json
@@ -8,19 +8,22 @@
   "conditions": [
     {
       "displayName": "SAPHanaHighAvailabilityCheck",
-      "conditionMonitoringQueryLanguage": {
-        "duration": "0s",
-        "trigger": {
-          "count": 1
-        },
-        "query": "fetch gce_instance\n| { metric 'workload.googleapis.com/sap/hana/ha/availability'\n  ; metric 'workload.googleapis.com/sap/mntmode' }\n| join\n| window 1m\n| value\n    if(t_0.value.availability < 4 && t_1.value.mntmode == false(), false(),\n      true())\n| condition val()"
+      "conditionPrometheusQueryLanguage": {
+        "duration": "60s",
+        "evaluationInterval": "30s",
+        "query": "({\"workload.googleapis.com/sap/hana/ha/availability\", monitored_resource=\"gce_instance\"} >= 4)\nor \n({\"workload.googleapis.com/sap/mntmode\", monitored_resource=\"gce_instance\"} != 0)"
       }
     }
   ],
   "alertStrategy": {
-    "autoClose": "604800s"
+    "autoClose": "604800s",
+    "notificationPrompts": [
+      "OPENED",
+      "CLOSED"
+    ]
   },
   "combiner": "OR",
   "enabled": true,
-  "notificationChannels": []
+  "notificationChannels": [],
+  "severity": "SEVERITY_UNSPECIFIED"
 }


### PR DESCRIPTION
This PR updates Google Workload Manager alerts to use PromQL instead of the deprecated MQL.

No screenshots for this one, but the queries are very simple, as long as you're careful about the boolean logic. Both of these have been slightly altered to be (X or Y) instead of !(X and Y).