### PR TITLE
Alert policies for Google Cloud KMS service quotas consumption monitoring

### DIFF
--- a/alerts/google-cloud-kms/README.md
+++ b/alerts/google-cloud-kms/README.md
@@ -1,0 +1,48 @@
+ # Alert policies for Cloud KMS service monitoring
+
+This contains alert policies and Terraform script to deploy them for [new generation](https://docs.cloud.google.com/kms/quotas#new-quotas) Cloud KMS quotas alert polciies.
+
+The following alert policies are included:
+- Key Read Usage quota metric `cloudkms.googleapis.com​/read_usage`
+- Key Write Usage quota metric `cloudkms.googleapis.com​/write_usage`
+- Software Key Crypto quota metric `cloudkms.googleapis.com​/software_usage`
+- Hardware Key Crypto quota metric `cloudkms.googleapis.com​/hsm`
+- External Key Crypto quota metric `cloudkms.googleapis.com​/external_kms_usage`
+
+The alert policies are created for each location specified in the `location` variable. A separate alert policy is created for each quota metric.
+
+Example of alert policy for "Write Usage" quota metric in "europe-west3" location:
+```
+{
+  "displayName": "Quota usage - Cloud KMS API - Token usage per minute per region - cloudkms.googleapis.com/write_usage (europe-west3)",
+  "documentation": {
+    "content": "To resolve this issue, click [here](https://console.cloud.google.com/iam-admin/quotas?service=${resource.label.service}&metric=${metric.label.quota_metric}&limit=${metric.label.limit_name}&dimensions=%7B%22region%22%3A%22${resource.label.location}%22%7D&project=PROJET_ID&fromNotifications=1) to review quota usage and optionally request a quota increase.",
+    "mimeType": "text/markdown"
+  },
+  "conditions": [
+    {
+      "displayName": "Quota usage reached defined threshold",
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "60s",
+            "perSeriesAligner": "ALIGN_RATE"
+          }
+        ],
+        "comparison": "COMPARISON_GT",
+        "duration": "60s",
+        "filter": "metric.type = \"serviceruntime.googleapis.com/quota_rate_net_usage\" AND metric.label.quota_metric = \"cloudkms.googleapis.com/write_usage\" AND resource.type = \"consumer_quota\" AND resource.label.location = \"europe-west3\" AND resource.label.quota_metric = \"cloudkms.googleapis.com/write_usage\" AND resource.label.limit_name = \"WriteTokensUsagePerMinutePerProjectPerRegion\" AND metric.label.limit_name = \"WriteTokensUsagePerMinutePerProjectPerRegion\" AND metric.label.project_id = \"PROJET_ID\" AND resource.label.project_id = \"PROJET_ID\"",
+        "thresholdValue": 544,
+        "trigger": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true
+}
+```

--- a/alerts/google-cloud-kms/cloud-kms-alert-policies.tf
+++ b/alerts/google-cloud-kms/cloud-kms-alert-policies.tf
@@ -1,0 +1,68 @@
+locals {
+  alert_policies = {
+    for pair in setproduct(var.location, keys(var.quota_metrics)) :
+    "${pair[0]}-${pair[1]}" => {
+      location     = pair[0]
+      quota_metric = pair[1]
+      limit_name   = var.quota_metrics[pair[1]]
+    }
+  }
+}
+
+resource "google_monitoring_alert_policy" "cloud_kms_quota_usage" {
+  for_each     = local.alert_policies
+  project      = var.project_id
+  display_name = "Quota usage - Cloud KMS API - Token usage per minute per region - ${each.value.quota_metric} (${each.value.location})"
+  combiner     = "OR"
+  enabled      = true
+
+  conditions {
+    display_name = "Quota usage reached defined threshold"
+    condition_prometheus_query_language {
+      duration            = var.alert_duration
+      evaluation_interval = var.alert_evaluation_interval
+      query               = <<-EOT
+        max_over_time(
+          sum(
+            label_replace(
+              increase(
+                serviceruntime_googleapis_com:quota_rate_net_usage{
+                  project_id='${var.project_id}',
+                  monitored_resource='consumer_quota',
+                  quota_metric='${each.value.quota_metric}',
+                  location='${each.value.location}'
+                }[1m]
+              ),
+              'limit_name', '${each.value.limit_name}', '', ''
+            )
+          ) by (service, limit_name, project_id, quota_metric, location)[4m:1m]
+        )
+        /
+        min(
+          ${each.value.quota_metric == "cloudkms.googleapis.com/external_kms_usage" ? 60 : 1} * last_over_time(
+            serviceruntime_googleapis_com:quota_limit{
+              project_id='${var.project_id}',
+              monitored_resource='consumer_quota',
+              quota_metric='${each.value.quota_metric}',
+              location='${each.value.location}',
+              limit_name='${each.value.limit_name}'
+            }[1d]
+          )
+        ) by (service, limit_name, project_id, quota_metric, location)
+        > ${var.alert_threshold}
+      EOT
+    }
+  }
+
+  documentation {
+    content   = "To resolve this issue, click [here](https://console.cloud.google.com/iam-admin/quotas?service=$${resource.label.service}&metric=$${metric.label.quota_metric}&limit=$${metric.label.limit_name}&dimensions=%7B%22region%22%3A%22$${resource.label.location}%22%7D&project=${var.project_id}&fromNotifications=1) to review quota usage and optionally request a quota increase."
+    mime_type = "text/markdown"
+  }
+
+  alert_strategy {
+    auto_close           = var.alert_auto_close
+    notification_prompts = ["OPENED"]
+  }
+
+  notification_channels = var.notification_channels
+}

--- a/alerts/google-cloud-kms/terraform.tfvars.sample
+++ b/alerts/google-cloud-kms/terraform.tfvars.sample
@@ -1,0 +1,5 @@
+project_id = "my-project-id"
+location   = ["europe-west3"]
+notification_channels = [
+  "projects/my-project-id/notificationChannels/1234567890"
+]

--- a/alerts/google-cloud-kms/variables.tf
+++ b/alerts/google-cloud-kms/variables.tf
@@ -1,0 +1,51 @@
+variable "project_id" {
+  description = "Target Project ID"
+  type        = string
+}
+
+variable "location" {
+  description = "Cloud KMS resources location"
+  type        = list(string)
+  default     = ["europe-west3"]
+}
+
+variable "notification_channels" {
+  description = "List of notification channels to attach to alert policies"
+  type        = list(string)
+}
+
+variable "quota_metrics" {
+  description = "Map of Cloud KMS quota metrics to their corresponding limit names"
+  type        = map(string)
+  default = {
+    "cloudkms.googleapis.com/write_usage"    = "WriteTokensUsagePerMinutePerProjectPerRegion"
+    "cloudkms.googleapis.com/read_usage"     = "ReadTokensUsagePerMinutePerProjectPerRegion"
+    "cloudkms.googleapis.com/software_usage" = "SoftwareTokensUsagePerMinutePerProjectPerRegion"
+    "cloudkms.googleapis.com/hsm_usage"      = "HsmTokensUsagePerMinutePerProjectPerRegion"
+    "cloudkms.googleapis.com/external_kms_usage" = "ExternalTokensUsagePerMinutePerProjectPerRegion"
+  }
+}
+
+variable "alert_duration" {
+  description = "The duration for which the condition must be met before an alert is triggered"
+  type        = string
+  default     = "60s"
+}
+
+variable "alert_evaluation_interval" {
+  description = "The interval at which the condition is evaluated"
+  type        = string
+  default     = "60s"
+}
+
+variable "alert_auto_close" {
+  description = "The duration after which an open incident is automatically closed"
+  type        = string
+  default     = "604800s"
+}
+
+variable "alert_threshold" {
+  description = "The threshold for the quota usage alert (fraction of limit)"
+  type        = number
+  default     = 0.8
+}


### PR DESCRIPTION
This PR adds a small Terraform project that generates Google Cloud alert policies for monitoring [new generation Cloud KMS quotas](https://docs.cloud.google.com/kms/quotas#new-quotas) consumption. 

The project provisions an alert policy for each Cloud KMS quota in each specified Google Cloud region.

The PromQL alert policy condition exactly follows alert policy condition generated by the alert policy template in the Google Cloud Console.