### PR TITLE
Add OTel GenAI agent sample alert policies

### DIFF
--- a/alerts/google-vertex-ai/agent-runtime-high-error-rate.v1.json
+++ b/alerts/google-vertex-ai/agent-runtime-high-error-rate.v1.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Agent Runtime - High Error Rate (${REASONING_ENGINE_ID})",
   "documentation": {
-    "content": "This alert fires when the error rate of the agent runtime instance (${REASONING_ENGINE_ID}) rises above 5% for 5 minutes or more.",
+    "content": "This alert fires when the error rate (calculated as the percentage of requests with a non-2xx status code) of the Agent Runtime instance (${REASONING_ENGINE_ID}) rises above 5% for 5 minutes or more.",
     "mimeType": "text/markdown"
   },
   "userLabels": {

--- a/alerts/google-vertex-ai/agent-runtime-high-latency.v1.json
+++ b/alerts/google-vertex-ai/agent-runtime-high-latency.v1.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Agent Runtime - High P95 Request Latency (${REASONING_ENGINE_ID})",
   "documentation": {
-    "content": "This alert fires when the P95 request latency of the agent runtime instance (${REASONING_ENGINE_ID}) rises above 120s for 5 minutes or more.",
+    "content": "This alert fires when the P95 request latency of the Agent Runtime instance (${REASONING_ENGINE_ID}) rises above 120s for 5 minutes or more.",
     "mimeType": "text/markdown"
   },
   "userLabels": {

--- a/alerts/google-vertex-ai/metadata.yaml
+++ b/alerts/google-vertex-ai/metadata.yaml
@@ -29,14 +29,14 @@ alert_policy_templates:
         platform: GCP
   - id: "agent-runtime-high-latency"
     display_name: "Agent Runtime High P95 Request Latency"
-    description: "This alert fires when the P95 request latency of the agent runtime instance rises above 120s for 5 minutes or more."
+    description: "This alert fires when the P95 request latency of the Agent Runtime instance rises above 120s for 5 minutes or more."
     version: 1
     related_integrations:
       - id: vertex_ai
         platform: GCP
   - id: "agent-runtime-high-error-rate"
     display_name: "Agent Runtime High Error Rate"
-    description: "This alert fires when the error rate of the agent runtime instance rises above 5% for 5 minutes or more."
+    description: "This alert fires when the error rate (calculated as the percentage of requests with a non-2xx status code) of the Agent Runtime instance rises above 5% for 5 minutes or more."
     version: 1
     related_integrations:
       - id: vertex_ai

--- a/alerts/otel-genai/metadata.yaml
+++ b/alerts/otel-genai/metadata.yaml
@@ -1,0 +1,13 @@
+alert_policy_templates:
+  - id: "otel-genai-agent-token-usage-high"
+    display_name: "Agent Token Usage High"
+    description: "This alert fires when token usage (over both input / output) exceeds 1 million over the past 60 mins. Edit the thresholds to meet your needs."
+    version: 1
+  - id: "otel-genai-agent-tool-error-rate"
+    display_name: "Agent to Tool Error Rate High"
+    description: "This alert will be triggered if the agent has a > 5% error rate in invoking a given tool for 5 mins or more."
+    version: 1
+  - id: "otel-genai-agent-model-error-rate"
+    display_name: "Agent to Model Error Rate High"
+    description: "This alert will be triggered if the agent has a > 5% error rate in invoking a given model for 5 mins or more."
+    version: 1

--- a/alerts/otel-genai/otel-genai-agent-model-error-rate.v1.json
+++ b/alerts/otel-genai/otel-genai-agent-model-error-rate.v1.json
@@ -1,0 +1,27 @@
+{
+  "displayName": "Agent - High Tool Call Error Rate (${AGENT_NAME})",
+  "documentation": {
+    "content": "This alert will be triggered if the agent has a > 5% error rate in invoking a given tool for 5 mins or more.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {
+    "agent_display_name": "${AGENT_NAME}",
+    "agent_id": "${AGENT_ID}",
+    "location": "${LOCATION}"
+  },
+  "conditions": [
+    {
+      "displayName": "Agent - High Model Call Error Rate (${AGENT_NAME})",
+      "conditionPrometheusQueryLanguage": {
+        "duration": "0s",
+        "evaluationInterval": "30s",
+        "query": "sum by (\"gen_ai.response.model\")(\n    increase({\n        \"__name__\"=\"gen_ai.client.operation.duration_count\",\n        \"location\"=\"${LOCATION}\",\n        \"cluster\"=\"${AGENT_ID}\",\n        \"error.type\"!= \"\"\n    }[5m])\n)\n/\nsum by (\"gen_ai.response.model\")(\n    increase({\n        \"__name__\"=\"gen_ai.client.operation.duration_count\",\n        \"location\"=\"${LOCATION}\",\n        \"cluster\"=\"${AGENT_ID}\"\n    }[5m])\n) > 0.05\n"
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true
+}

--- a/alerts/otel-genai/otel-genai-agent-token-usage-high.v1.json
+++ b/alerts/otel-genai/otel-genai-agent-token-usage-high.v1.json
@@ -1,0 +1,27 @@
+{
+  "displayName": "Agent - High Token Usage  (${AGENT_NAME})",
+  "documentation": {
+    "content": "This alert fires when token usage (over both input and output) exceeds 1 million tokens over the past hour.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {
+    "agent_display_name": "${AGENT_NAME}",
+    "agent_id": "${AGENT_ID}",
+    "location": "${LOCATION}"
+  },
+  "conditions": [
+    {
+      "displayName": "Agent - High Token Usage (${AGENT_NAME})",
+      "conditionPrometheusQueryLanguage": {
+        "duration": "300s",
+        "evaluationInterval": "60s",
+        "query": "sum (increase({\n    \"__name__\"=\"gen_ai.client.token.usage_sum\",\n    \"location\"=\"${LOCATION}\",\n    \"cluster\"=\"${AGENT_ID}\", \n    \"gen_ai.token.type\"=\"input\"\n}[1m])) + \nsum(increase({\n    \"__name__\"=\"gen_ai.client.token.usage_sum\", \n    \"location\"=\"${LOCATION}\",\n    \"cluster\"=\"${AGENT_ID}\", \n    \"gen_ai.token.type\"=\"output\"\n}[1m])) > 1000000"
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true
+}

--- a/alerts/otel-genai/otel-genai-agent-tool-error-rate.v1.json
+++ b/alerts/otel-genai/otel-genai-agent-tool-error-rate.v1.json
@@ -1,0 +1,27 @@
+{
+  "displayName": "Agent - High Tool Call Error Rate (${AGENT_NAME})",
+  "documentation": {
+    "content": "This alert will be triggered if the agent has a > 5% error rate in invoking a given tool for 5 mins or more.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {
+    "agent_display_name": "${AGENT_NAME}",
+    "agent_id": "${AGENT_ID}",
+    "location": "${LOCATION}"
+  },
+  "conditions": [
+    {
+      "displayName": "Agent - High Tool Call Error Rate (${AGENT_NAME})",
+      "conditionPrometheusQueryLanguage": {
+        "duration": "0s",
+        "evaluationInterval": "30s",
+        "query": "sum by (\"gen_ai.tool.name\")(\n    increase({\n        \"__name__\"=\"gen_ai.tool.execution.duration_count\", \n        \"location\"=\"${LOCATION}\",\n        \"cluster\"=\"${AGENT_ID}\",\n        \"error.type\"!= \"\"}[5m]\n    )\n)\n/\nsum by (\"gen_ai.tool.name\")(\n    increase({\n        \"__name__\"=\"gen_ai.tool.execution.duration_count\", \n        \"location\"=\"${LOCATION}\",\n        \"cluster\"=\"${AGENT_ID}\",\n        \"error.type\"!= \"\"}[5m]\n    )\n) > 0.05\n"
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true
+}


### PR DESCRIPTION
These are sample alert policies for metrics introduced by Otel Gen AI semconv. They are provisional (and therefore not yet associated with any integration); we expect to test them and tweak the thresholds and queries over the next week.

Some minor tweaks to the existing Agent Runtime policy descriptions.