### PR TITLE
Update display format for Agent Runtime alert policies

### DIFF
--- a/alerts/google-vertex-ai/agent-runtime-high-error-rate.v1.json
+++ b/alerts/google-vertex-ai/agent-runtime-high-error-rate.v1.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "Agent Runtime - High Error Rate (${REASONING_ENGINE_ID})",
+  "displayName": "Agent Runtime - High Error Rate (${AGENT_NAME})",
   "documentation": {
     "content": "This alert fires when the error rate of the agent runtime instance (${REASONING_ENGINE_ID}) rises above 5% for 5 minutes or more.",
     "mimeType": "text/markdown"
@@ -11,7 +11,7 @@
   },
   "conditions": [
     {
-      "displayName": "Agent Runtime - High Error Rate (${REASONING_ENGINE_ID})",
+      "displayName": "Agent Runtime - High Error Rate (${AGENT_NAME})",
       "conditionPrometheusQueryLanguage": {
         "duration": "0s",
         "evaluationInterval": "30s",

--- a/alerts/google-vertex-ai/agent-runtime-high-latency.v1.json
+++ b/alerts/google-vertex-ai/agent-runtime-high-latency.v1.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "Agent Runtime - High P95 Request Latency (${REASONING_ENGINE_ID})",
+  "displayName": "Agent Runtime - High P95 Request Latency (${AGENT_NAME})",
   "documentation": {
     "content": "This alert fires when the P95 request latency of the agent runtime instance (${REASONING_ENGINE_ID}) rises above 120s for 5 minutes or more.",
     "mimeType": "text/markdown"
@@ -11,7 +11,7 @@
   },
   "conditions": [
     {
-      "displayName": "Agent Runtime - High P95 Request Latency (${REASONING_ENGINE_ID})",
+      "displayName": "Agent Runtime - High P95 Request Latency (${AGENT_NAME})",
       "conditionThreshold": {
         "filter": "resource.type = \"aiplatform.googleapis.com/ReasoningEngine\" AND (resource.labels.location = \"${LOCATION}\" AND resource.labels.reasoning_engine_id = \"${REASONING_ENGINE_ID}\") AND metric.type = \"aiplatform.googleapis.com/reasoning_engine/request_latencies\"",
         "aggregations": [


### PR DESCRIPTION
Use display name instead of reasoning engine ID here:

<img width="1862" height="1316" alt="image" src="https://github.com/user-attachments/assets/f38f3b9c-3322-41f9-8655-cc6788a26d6c" />
