### PR TITLE
Don't include display name in alerting policy template user labels

### DIFF
--- a/alerts/google-vertex-ai/agent-runtime-high-error-rate.v1.json
+++ b/alerts/google-vertex-ai/agent-runtime-high-error-rate.v1.json
@@ -1,11 +1,10 @@
 {
   "displayName": "Agent Runtime - High Error Rate (${AGENT_NAME})",
   "documentation": {
-    "content": "This alert fires when the error rate (calculated as the percentage of requests with a non-2xx status code) of the Agent Runtime instance (${REASONING_ENGINE_ID}) rises above 5% for 5 minutes or more.",
+    "content": "This alert fires when the error rate (calculated as the percentage of requests with a non-2xx status code) of the Agent Runtime instance (${LOCATION}/${REASONING_ENGINE_ID} - ${AGENT_NAME}) rises above 5% for 5 minutes or more.",
     "mimeType": "text/markdown"
   },
   "userLabels": {
-    "agent_display_name": "${AGENT_NAME}",
     "reasoning_engine_id": "${REASONING_ENGINE_ID}",
     "location": "${LOCATION}"
   },

--- a/alerts/google-vertex-ai/agent-runtime-high-latency.v1.json
+++ b/alerts/google-vertex-ai/agent-runtime-high-latency.v1.json
@@ -1,11 +1,10 @@
 {
   "displayName": "Agent Runtime - High P95 Request Latency (${AGENT_NAME})",
   "documentation": {
-    "content": "This alert fires when the P95 request latency of the Agent Runtime instance (${REASONING_ENGINE_ID}) rises above 120s for 5 minutes or more.",
+    "content": "This alert fires when the P95 request latency of the Agent Runtime instance (${LOCATION}/${REASONING_ENGINE_ID} - ${AGENT_NAME}) rises above 120s for 5 minutes or more.",
     "mimeType": "text/markdown"
   },
   "userLabels": {
-    "agent_display_name": "${AGENT_NAME}",
     "reasoning_engine_id": "${REASONING_ENGINE_ID}",
     "location": "${LOCATION}"
   },


### PR DESCRIPTION
See b/524991671 for context. GCP user labels must conform to strict API-level regex patterns [\p{Ll}\p{Lo}\p{N}_-]{0,63} so when agent display names start with an upper case letter we get an alert policy creation error. It would be brittle to attempt to sanitize arbitrary display names dynamically (e.g. toLowercase()) because there are other cases (special characters, length limits, whitespaces...).

Instead, we should just add display name to the alert documentation field so that oncallers can see which agent this is firing for in the notification. The labels can just be resource name and location which is deterministic and will always pass validation.